### PR TITLE
Fix PDF layout issues and nested settings parsing

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -250,15 +250,20 @@ export default function DashboardPage() {
       a.href = url;
       a.download = `Intune-Configuration-Documentation-${new Date().toISOString().split("T")[0]}.docx`;
       document.body.appendChild(a);
-      setExportProgress(100);
       a.click();
+      setExportProgress(100);
+
+      // Small delay to show download completion before cleanup
+      await new Promise(resolve => setTimeout(resolve, 500));
+
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
     } catch (err: any) {
       alert(err?.message || "Failed to generate DOCX");
     } finally {
       setGeneratingDocx(false);
-      setExportProgress(0);
+      // Delay before resetting progress to show completion
+      setTimeout(() => setExportProgress(0), 300);
     }
   };
   const updateFetchProgress = (stepIndex: number, status: "pending" | "loading" | "completed" | "error") => {
@@ -607,6 +612,11 @@ export default function DashboardPage() {
               a.download = `Intune-Configuration-Documentation-${new Date().toISOString().split("T")[0]}.pdf`;
               document.body.appendChild(a);
               a.click();
+              setExportProgress(100);
+
+              // Small delay to show download completion before cleanup
+              await new Promise(resolve => setTimeout(resolve, 500));
+
               window.URL.revokeObjectURL(url);
               document.body.removeChild(a);
               return; // Success after retry
@@ -638,8 +648,12 @@ export default function DashboardPage() {
       a.href = url;
       a.download = `Intune-Configuration-Documentation-${new Date().toISOString().split("T")[0]}.pdf`;
       document.body.appendChild(a);
-      setExportProgress(100);
       a.click();
+      setExportProgress(100);
+
+      // Small delay to show download completion before cleanup
+      await new Promise(resolve => setTimeout(resolve, 500));
+
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
     } catch (err: any) {
@@ -648,7 +662,8 @@ export default function DashboardPage() {
       alert(errorMessage);
     } finally {
       setGeneratingPdf(false);
-      setExportProgress(0);
+      // Delay before resetting progress to show completion
+      setTimeout(() => setExportProgress(0), 300);
     }
   };
   

--- a/src/lib/configuration-parser.ts
+++ b/src/lib/configuration-parser.ts
@@ -1,22 +1,96 @@
 import type { ConfigurationSetting } from "./intune-detailed-client";
 
+// Helper to recursively extract nested settings
+// Note: children in collections are raw settingInstance objects, not ConfigurationSetting objects
+function extractNestedSettings(
+  children: any[],
+  depth: number = 0,
+  parentDefinitions?: Array<{id: string; displayName: string; description?: string; options?: any[]}>
+): Array<{name: string, value: string, description?: string}> {
+  const results: Array<{name: string, value: string, description?: string}> = [];
+  const indent = "  ".repeat(depth);
+
+  // Safety check: ensure children is an array
+  if (!Array.isArray(children)) {
+    return results;
+  }
+
+  for (const child of children) {
+    // Skip if child is null/undefined
+    if (!child) continue;
+
+    try {
+      // Children in collections are raw settingInstance objects
+      // They have settingDefinitionId but no settingInstance wrapper
+      const settingDefinitionId = child.settingDefinitionId;
+
+      // Find the definition from the parent's definitions array
+      const settingDef = parentDefinitions?.find(def => def.id === settingDefinitionId);
+
+      // Create a proper ConfigurationSetting structure
+      const configSetting: ConfigurationSetting = {
+        id: settingDefinitionId || "",
+        settingInstance: child, // The child IS the settingInstance
+        settingDefinitions: settingDef ? [settingDef as any] : []
+      };
+
+      const childResult = extractSettingValue(configSetting, depth);
+
+      // Add the main setting with indentation
+      results.push({
+        name: indent + childResult.name,
+        value: childResult.value,
+        description: childResult.description
+      });
+
+      // If this setting has nested children, add them recursively
+      if (childResult.nestedSettings && childResult.nestedSettings.length > 0) {
+        results.push(...childResult.nestedSettings);
+      }
+    } catch (error) {
+      // If there's an error processing a child setting, log it and continue
+      console.warn("Error processing nested setting:", error);
+      continue;
+    }
+  }
+
+  return results;
+}
+
 // Helper to extract setting value from complex structures
-export function extractSettingValue(setting: ConfigurationSetting): {
+export function extractSettingValue(setting: ConfigurationSetting, depth: number = 0): {
   name: string;
   value: any;
   type: string;
   description?: string;
+  nestedSettings?: Array<{name: string, value: string, description?: string}>;
 } {
   const settingDef = setting.settingDefinitions?.[0];
   const instance = setting.settingInstance;
-  
+
   let value: any = "Not configured";
   let type = "Unknown";
-  
+  let nestedSettings: Array<{name: string, value: string, description?: string}> | undefined;
+
+  // Safety check: if settingInstance is missing or undefined, return early
+  if (!instance) {
+    return {
+      name: settingDef?.displayName || setting.id || "Unknown Setting",
+      value: "Not configured",
+      type: "Unknown",
+      description: settingDef?.description
+    };
+  }
+
   // Extract value based on setting type
   if (instance.simpleSettingValue) {
     value = instance.simpleSettingValue.value;
     type = "Simple";
+  } else if (instance.simpleSettingCollectionValue) {
+    // Handle array of simple values (strings, numbers, booleans)
+    type = "Simple Collection";
+    const values = instance.simpleSettingCollectionValue.map(item => item.value);
+    value = values;  // formatValue will handle array formatting
   } else if (instance.choiceSettingValue) {
     value = instance.choiceSettingValue.value;
     type = "Choice";
@@ -27,16 +101,45 @@ export function extractSettingValue(setting: ConfigurationSetting): {
         value = option.displayName || value;
       }
     }
+
+    // Handle nested children in choice settings
+    if (instance.choiceSettingValue.children && instance.choiceSettingValue.children.length > 0) {
+      nestedSettings = extractNestedSettings(instance.choiceSettingValue.children, depth + 1, setting.settingDefinitions);
+    }
+  } else if (instance.groupSettingValue) {
+    // Handle single group setting (not a collection)
+    type = "Group";
+    if (instance.groupSettingValue.children && instance.groupSettingValue.children.length > 0) {
+      nestedSettings = extractNestedSettings(instance.groupSettingValue.children, depth + 1, setting.settingDefinitions);
+      value = `${nestedSettings.length} setting(s) in group`;
+    } else {
+      value = "Group setting (no children)";
+    }
   } else if (instance.groupSettingCollectionValue) {
-    value = `Collection (${instance.groupSettingCollectionValue.length} items)`;
-    type = "Collection";
+    // Instead of just showing "Collection (X items)", extract the nested settings
+    type = "Group Collection";
+    const allNestedSettings: Array<{name: string, value: string, description?: string}> = [];
+
+    for (const group of instance.groupSettingCollectionValue) {
+      if (group.children && group.children.length > 0) {
+        allNestedSettings.push(...extractNestedSettings(group.children, depth + 1, setting.settingDefinitions));
+      }
+    }
+
+    if (allNestedSettings.length > 0) {
+      nestedSettings = allNestedSettings;
+      value = `${allNestedSettings.length} setting(s) configured`;
+    } else {
+      value = `Collection (${instance.groupSettingCollectionValue.length} items)`;
+    }
   }
-  
+
   return {
     name: settingDef?.displayName || instance.settingDefinitionId || "Unknown Setting",
     value: formatValue(value),
     type,
-    description: settingDef?.description
+    description: settingDef?.description,
+    nestedSettings
   };
 }
 
@@ -45,15 +148,15 @@ export function formatValue(value: any): string {
   if (value === null || value === undefined) {
     return "Not configured";
   }
-  
+
   if (typeof value === "boolean") {
     return value ? "Enabled" : "Disabled";
   }
-  
+
   if (typeof value === "number") {
     return value.toString();
   }
-  
+
   if (typeof value === "string") {
     // Clean up technical values
     if (value.startsWith("device_vendor_msft_")) {
@@ -61,15 +164,43 @@ export function formatValue(value: any): string {
     }
     return value;
   }
-  
+
   if (Array.isArray(value)) {
-    return value.join(", ");
+    // Handle empty arrays
+    if (value.length === 0) {
+      return "Not configured";
+    }
+
+    // Handle arrays of objects - extract displayName or other meaningful fields
+    if (value.length > 0 && typeof value[0] === "object" && value[0] !== null) {
+      const formattedItems = value.map((item: any) => {
+        // Try to find a meaningful string representation
+        if (item.displayName) return item.displayName;
+        if (item.name) return item.name;
+        if (item.value) return String(item.value);
+        if (item.packageId) return item.packageId;
+        if (item.bundleId) return item.bundleId;
+        // If object has only a few keys, try to create a readable string
+        const keys = Object.keys(item);
+        if (keys.length === 1 && keys[0]) return String(item[keys[0]]);
+        return JSON.stringify(item);
+      });
+      return formattedItems.join("\n");
+    }
+
+    // Handle arrays of primitives (strings, numbers, booleans)
+    // Use newlines for better readability if more than 3 items
+    if (value.length > 3) {
+      return value.map((item: any) => String(item)).join("\n");
+    }
+
+    return value.map((item: any) => String(item)).join(", ");
   }
-  
+
   if (typeof value === "object") {
     return JSON.stringify(value, null, 2);
   }
-  
+
   return String(value);
 }
 
@@ -148,7 +279,7 @@ export function parseAdministrativeTemplate(definitionValues: any[]): Array<{
   });
 }
 
-// Parse compliance policy rules
+// Parse compliance policy rules - dynamic enumeration based on policy type
 export function parseComplianceRules(policy: any): Array<{
   category: string;
   rule: string;
@@ -156,17 +287,17 @@ export function parseComplianceRules(policy: any): Array<{
   action: string;
 }> {
   const rules: any[] = [];
-  const complianceKeys = [
-    "passwordRequired", "passwordMinimumLength", "passwordRequiredType",
-    "osMinimumVersion", "osMaximumVersion", "storageRequireEncryption",
-    "jailBroken", "deviceThreatProtectionEnabled", "deviceThreatProtectionRequiredSecurityLevel",
-    "configurationManagerComplianceRequired", "systemIntegrityProtectionEnabled",
-    "codeIntegrityEnabled", "firewallEnabled", "antivirusRequired",
-    "antispywareRequired", "defenderEnabled", "bitLockerEnabled"
+
+  // Properties to ignore (metadata, not actual compliance settings)
+  const ignoredKeys = [
+    "id", "@odata.type", "@odata.context", "displayName", "description",
+    "createdDateTime", "lastModifiedDateTime", "version", "assignments",
+    "roleScopeTagIds", "scheduledActionsForRule"
   ];
-  
-  complianceKeys.forEach(key => {
-    if (policy[key] !== undefined && policy[key] !== null) {
+
+  // Enumerate all properties dynamically
+  Object.keys(policy).forEach(key => {
+    if (!ignoredKeys.includes(key) && policy[key] !== undefined && policy[key] !== null) {
       rules.push({
         category: getCategoryFromKey(key),
         rule: formatKeyName(key),
@@ -175,8 +306,46 @@ export function parseComplianceRules(policy: any): Array<{
       });
     }
   });
-  
+
   return rules;
+}
+
+// Helper to parse security baseline setting name from definitionId
+function parseSecurityBaselineSettingName(definitionId: string | undefined): string {
+  if (!definitionId) return "Unknown Setting";
+
+  // Example: "device_vendor_msft_defender_configuration_enablenetworkprotection"
+  // Should become: "Defender Configuration - Enable Network Protection"
+
+  const parts = definitionId.split("_");
+
+  // Remove common prefixes
+  if (parts[0] === "device" || parts[0] === "user") parts.shift();
+  if (parts[0] === "vendor") parts.shift();
+  if (parts[0] === "msft") parts.shift();
+
+  // Find category (usually the first capitalized part or before "configuration")
+  let categoryEndIndex = -1;
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] === "configuration" || parts[i] === "settings") {
+      categoryEndIndex = i;
+      break;
+    }
+  }
+
+  if (categoryEndIndex > 0) {
+    const category = parts.slice(0, categoryEndIndex).join(" ");
+    const settingName = parts.slice(categoryEndIndex + 1).join(" ");
+
+    // Format both parts
+    const formattedCategory = formatKeyName(category);
+    const formattedSetting = formatKeyName(settingName);
+
+    return `${formattedCategory} - ${formattedSetting}`;
+  }
+
+  // Fallback: just format the whole thing
+  return formatKeyName(parts.join(" "));
 }
 
 // Parse security baseline categories and settings
@@ -191,7 +360,7 @@ export function parseSecurityBaseline(categories: any[]): Array<{
   return categories.map(category => {
     const settings = (category.settings || []).map((setting: any) => {
       let value = "Not configured";
-      
+
       if (setting.value !== undefined && setting.value !== null) {
         value = formatValue(setting.value);
       } else if (setting.stringValue) {
@@ -201,14 +370,14 @@ export function parseSecurityBaseline(categories: any[]): Array<{
       } else if (setting.boolValue !== undefined) {
         value = setting.boolValue ? "Enabled" : "Disabled";
       }
-      
+
       return {
-        name: setting.definitionId?.split("_").pop() || "Unknown Setting",
+        name: parseSecurityBaselineSettingName(setting.definitionId),
         value,
         description: setting.description
       };
     });
-    
+
     return {
       category: category.displayName || "General",
       settings

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -119,7 +119,25 @@ export async function generateDetailedDOCX(data: DetailedDocxData): Promise<Uint
             ),
           })
         );
-        const formatted = policy.settings.map((s: any) => extractSettingValue(s));
+
+        // Process each setting and flatten nested settings
+        const formatted: Array<{name: string, value: string, description?: string}> = [];
+        for (const setting of policy.settings) {
+          const extracted = extractSettingValue(setting);
+
+          // Add the main setting
+          formatted.push({
+            name: extracted.name,
+            value: extracted.value,
+            description: extracted.description
+          });
+
+          // Add nested settings if they exist
+          if (extracted.nestedSettings && extracted.nestedSettings.length > 0) {
+            formatted.push(...extracted.nestedSettings);
+          }
+        }
+
         formatted.forEach((s: any) => {
           rows.push(
             new TableRow({

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -23,6 +23,13 @@ export interface ConfigurationSetting {
       value: any;
       "@odata.type": string;
     };
+    simpleSettingCollectionValue?: Array<{
+      value: any;
+      "@odata.type": string;
+    }>;
+    groupSettingValue?: {
+      children: ConfigurationSetting[];
+    };
     groupSettingCollectionValue?: Array<{
       children: ConfigurationSetting[];
     }>;
@@ -546,21 +553,65 @@ export class DetailedIntuneService {
   // Helper function to determine configuration type
   private getConfigurationType(odataType: string): string {
     const typeMap: Record<string, string> = {
+      // Windows configurations
       "#microsoft.graph.windows10GeneralConfiguration": "Windows 10 General Configuration",
       "#microsoft.graph.windows10EndpointProtectionConfiguration": "Windows 10 Endpoint Protection",
       "#microsoft.graph.windows10CustomConfiguration": "Windows 10 Custom Configuration",
+      "#microsoft.graph.windows10SecureAssessmentConfiguration": "Windows 10 Secure Assessment",
+      "#microsoft.graph.windows10EnterpriseModernAppManagementConfiguration": "Windows 10 Enterprise App Management",
+      "#microsoft.graph.windows81GeneralConfiguration": "Windows 8.1 General Configuration",
       "#microsoft.graph.windowsUpdateForBusinessConfiguration": "Windows Update for Business",
+      "#microsoft.graph.windowsDefenderAdvancedThreatProtectionConfiguration": "Windows Defender ATP",
+      "#microsoft.graph.windowsIdentityProtectionConfiguration": "Windows Identity Protection",
+      "#microsoft.graph.editionUpgradeConfiguration": "Windows Edition Upgrade",
+      "#microsoft.graph.windowsKioskConfiguration": "Windows Kiosk Configuration",
+      "#microsoft.graph.windows10TeamGeneralConfiguration": "Surface Hub Configuration",
+
+      // macOS configurations
       "#microsoft.graph.macOSGeneralConfiguration": "macOS General Configuration",
       "#microsoft.graph.macOSEndpointProtectionConfiguration": "macOS Endpoint Protection",
       "#microsoft.graph.macOSCustomConfiguration": "macOS Custom Configuration",
+      "#microsoft.graph.macOSDeviceFeaturesConfiguration": "macOS Device Features",
+      "#microsoft.graph.macOSExtensionsConfiguration": "macOS Extensions",
+      "#microsoft.graph.macOSSoftwareUpdateConfiguration": "macOS Software Update",
+
+      // iOS/iPadOS configurations
       "#microsoft.graph.iosGeneralConfiguration": "iOS General Configuration",
       "#microsoft.graph.iosCustomConfiguration": "iOS Custom Configuration",
+      "#microsoft.graph.iosUpdateConfiguration": "iOS Update Configuration",
+      "#microsoft.graph.iosDeviceFeaturesConfiguration": "iOS Device Features",
+      "#microsoft.graph.iosEndpointProtectionConfiguration": "iOS Endpoint Protection",
+      "#microsoft.graph.iosCertificateProfileConfiguration": "iOS Certificate Profile",
+      "#microsoft.graph.iosEasEmailProfileConfiguration": "iOS Email Profile",
+      "#microsoft.graph.iosWiFiConfiguration": "iOS WiFi Profile",
+      "#microsoft.graph.iosVpnConfiguration": "iOS VPN Profile",
+
+      // Android configurations
       "#microsoft.graph.androidGeneralConfiguration": "Android General Configuration",
       "#microsoft.graph.androidCustomConfiguration": "Android Custom Configuration",
-      "#microsoft.graph.androidWorkProfileGeneralConfiguration": "Android Work Profile Configuration"
+      "#microsoft.graph.androidWorkProfileGeneralConfiguration": "Android Work Profile Configuration",
+      "#microsoft.graph.androidWorkProfileCustomConfiguration": "Android Work Profile Custom",
+      "#microsoft.graph.androidDeviceOwnerGeneralConfiguration": "Android Device Owner Configuration",
+      "#microsoft.graph.androidOMAConfiguration": "Android OMA-DM Configuration",
+      "#microsoft.graph.androidEasEmailProfileConfiguration": "Android Email Profile",
+      "#microsoft.graph.androidWiFiConfiguration": "Android WiFi Profile",
+      "#microsoft.graph.androidVpnConfiguration": "Android VPN Profile",
+
+      // Shared/Common configurations
+      "#microsoft.graph.sharedPCConfiguration": "Shared PC Configuration",
+      "#microsoft.graph.vpnConfiguration": "VPN Configuration",
+      "#microsoft.graph.wiFiConfiguration": "WiFi Configuration",
+      "#microsoft.graph.emailConfiguration": "Email Configuration"
     };
 
-    return typeMap[odataType] || "Device Configuration";
+    // If not in map, try to extract a friendly name from the odataType
+    if (!typeMap[odataType]) {
+      // Remove prefix and format: "#microsoft.graph.iosGeneralConfiguration" -> "Ios General Configuration"
+      const typeName = odataType.replace("#microsoft.graph.", "").replace(/([A-Z])/g, " $1").trim();
+      return typeName.charAt(0).toUpperCase() + typeName.slice(1);
+    }
+
+    return typeMap[odataType];
   }
 
   // Get App Configurations with detailed settings

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -218,7 +218,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
 
     // Check for header text (positioned at y=10, centered)
     if (branding?.header?.enabled && branding?.header?.text) {
-      const headerTextSize = Math.max(bodyFontSize - 2, 8);
+      const headerTextSize = 9; // Match the fixed size used in addPageNumber
       const textHeight = headerTextSize * 0.6; // Text height in mm (rough estimate)
       const textBottom = 10 + textHeight;
       requiredSpace = Math.max(requiredSpace, textBottom + 3); // 3mm spacing after text
@@ -253,10 +253,15 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // Add header text if configured
     if (branding?.header?.enabled && branding?.header?.text && pageNumber > 1) {
-      doc.setFontSize(Math.max(bodyFontSize - 2, 8));
+      const headerTextSize = 9; // Fixed small size for header text
+      doc.setFontSize(headerTextSize);
       doc.setFont(fontFamily, "normal");
       doc.setTextColor(100, 100, 100);
       doc.text(branding.header.text, pageWidth / 2, 10, { align: "center" });
+      // Explicitly reset after rendering header text
+      doc.setFontSize(bodyFontSize);
+      doc.setFont(fontFamily, "normal");
+      doc.setTextColor(0, 0, 0);
     }
     
     // Add footer logo if configured
@@ -283,14 +288,21 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     }
     
     doc.setTextColor(0, 0, 0);
-    
-    // Add watermark to every page (text or logo)
-    addWatermark();
 
-    // Add logo watermark if configured
-    if (branding?.logo?.position === 'watermark') {
-      addLogo('watermark');
+    // Add watermark to every page (text or logo), but skip page 1 (cover page)
+    if (pageNumber > 1) {
+      addWatermark();
+
+      // Add logo watermark if configured
+      if (branding?.logo?.position === 'watermark') {
+        addLogo('watermark');
+      }
     }
+
+    // Reset font to body defaults after all header/footer rendering
+    doc.setFontSize(bodyFontSize);
+    doc.setFont(fontFamily, "normal");
+    doc.setTextColor(0, 0, 0);
   };
 
   const addText = (
@@ -307,6 +319,10 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
 
     for (const line of lines) {
       checkPageBreak();
+      // Re-apply font settings after potential page break (which resets fonts)
+      doc.setFontSize(fontSize);
+      doc.setFont(fontFamily, style);
+      doc.setTextColor(...color);
       doc.text(line, margin, yPosition);
       yPosition += fontSize * 0.45;
     }
@@ -890,9 +906,6 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   doc.setFontSize(9);
   doc.setTextColor(150, 150, 150);
   doc.text("Page 1", pageWidth / 2, pageHeight - 10, { align: "center" });
-  
-  // Add watermark if enabled
-  addWatermark();
   
   // === TABLE OF CONTENTS ===
   // Track sections and their page numbers for ToC
@@ -1616,7 +1629,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (template.description) {
-        addText(template.description, 9, "normal", [100, 100, 100]);
+        addText(template.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -199,17 +199,47 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       : [0, 0, 0];
   };
 
+  // Helper function to calculate header height on subsequent pages
+  const calculateHeaderHeight = (): number => {
+    // On first page (cover), use normal margin
+    if (pageNumber === 1) {
+      return margin;
+    }
+
+    // On subsequent pages, calculate space needed for header elements
+    let requiredSpace = margin; // Start with base margin (15mm)
+
+    // Check for header logo (positioned at y=5)
+    if (branding?.logo?.position === 'header' || branding?.header?.includeLogo) {
+      const logoHeight = Math.min(branding?.logo?.height || 15, 25);
+      const logoBottom = 5 + logoHeight; // Logo top + height
+      requiredSpace = Math.max(requiredSpace, logoBottom + 5); // 5mm spacing after logo
+    }
+
+    // Check for header text (positioned at y=10, centered)
+    if (branding?.header?.enabled && branding?.header?.text) {
+      const headerTextSize = Math.max(bodyFontSize - 2, 8);
+      const textHeight = headerTextSize * 0.6; // Text height in mm (rough estimate)
+      const textBottom = 10 + textHeight;
+      requiredSpace = Math.max(requiredSpace, textBottom + 3); // 3mm spacing after text
+    }
+
+    // Ensure minimum safe distance from top (30mm) to prevent any overlap
+    return Math.max(requiredSpace, 30);
+  };
+
   // Helper functions
   const checkPageBreak = (neededSpace = 30) => {
-    // Always leave at least 40mm for footer to prevent overlap
-    const minFooterSpace = 40;
+    // Always leave at least 35mm for footer to prevent overlap
+    const minFooterSpace = 35;
     const totalSpaceNeeded = Math.max(neededSpace, minFooterSpace);
 
     if (yPosition > pageHeight - totalSpaceNeeded) {
       doc.addPage();
-      yPosition = margin;
       pageNumber++;
       addPageNumber();
+      // Set yPosition to account for header elements on new page
+      yPosition = calculateHeaderHeight();
       return true;
     }
     return false;
@@ -263,13 +293,18 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     }
   };
 
-  const addText = (text: string, fontSize = bodyFontSize, isBold = false, color: [number, number, number] = [0, 0, 0]) => {
+  const addText = (
+    text: string,
+    fontSize = bodyFontSize,
+    style: "normal" | "bold" | "italic" = "normal",
+    color: [number, number, number] = [0, 0, 0]
+  ) => {
     doc.setFontSize(fontSize);
-    doc.setFont(fontFamily, isBold ? "bold" : "normal");
+    doc.setFont(fontFamily, style);
     doc.setTextColor(...color);
-    
+
     const lines = doc.splitTextToSize(text, maxWidth);
-    
+
     for (const line of lines) {
       checkPageBreak();
       doc.text(line, margin, yPosition);
@@ -298,26 +333,35 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   };
 
   const addConfigHeader = (name: string, assignments: string, createdDate?: string, modifiedDate?: string) => {
-    checkPageBreak(25);
+    // Calculate space needed for wrapped name
+    const tempFontSize = Math.max(bodyFontSize + 1, 12);
+    doc.setFontSize(tempFontSize);
+    const nameLines = doc.splitTextToSize(name, maxWidth);
+    const nameHeight = nameLines.length * 6;
+    const totalNeeded = nameHeight + 20; // name + dates + spacing
+
+    checkPageBreak(totalNeeded);
 
     // Configuration name with secondary color
-    doc.setFontSize(Math.max(bodyFontSize + 1, 12));
+    doc.setFontSize(tempFontSize);
     doc.setFont(fontFamily, "bold");
     const [r, g, b] = hexToRgb(secondaryColor);
     doc.setTextColor(r, g, b);
-    const nameLines = doc.splitTextToSize(name, maxWidth);
+
     nameLines.forEach((line: string) => {
       doc.text(line, margin, yPosition);
       yPosition += 6;
     });
+
+    // Reset to normal text color
     const [tr, tg, tb] = hexToRgb(textColor);
     doc.setTextColor(tr, tg, tb);
-    
-    // Dates and assignments
-    doc.setFontSize(9);
-    doc.setFont("helvetica", "normal");
+
+    // Dates and assignments with smaller font
+    doc.setFontSize(Math.max(bodyFontSize - 2, 9));
+    doc.setFont(fontFamily, "normal");
     doc.setTextColor(100, 100, 100);
-    
+
     // Show dates if available
     if (createdDate || modifiedDate) {
       if (createdDate) {
@@ -331,9 +375,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         yPosition += 4;
       }
     }
-    
+
     doc.text(`Assigned to: ${assignments}`, margin, yPosition);
     yPosition += 6;
+
+    // Reset font and color to defaults
+    doc.setFontSize(bodyFontSize);
+    doc.setFont(fontFamily, "normal");
     doc.setTextColor(0, 0, 0);
   };
 
@@ -380,20 +428,20 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       checkPageBreak(15);
       doc.setFillColor(240, 240, 240);
       doc.rect(margin, yPosition, tableWidth, 8, "F");
-      doc.setFontSize(10);
-      doc.setFont("helvetica", "bold");
+      doc.setFontSize(Math.max(bodyFontSize - 1, 10));
+      doc.setFont(fontFamily, "bold");
       doc.text("Setting", margin + 2, yPosition + 5);
       doc.text("Value", margin + (colWidths[0] || 50) + 2, yPosition + 5);
       doc.text("Description", margin + (colWidths[0] || 50) + (colWidths[1] || 65) + 2, yPosition + 5);
       yPosition += 8;
     };
-    
+
     // Initial header
     drawHeader();
-    
+
     // Table rows
-    doc.setFont("helvetica", "normal");
-    doc.setFontSize(8); // Slightly smaller font for more content
+    doc.setFont(fontFamily, "normal");
+    doc.setFontSize(Math.max(bodyFontSize - 3, 8));
     
     settings.forEach((setting, index) => {
       // Prepare text for all columns
@@ -425,7 +473,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       if (checkPageBreak(rowHeight + 5)) {
         drawHeader();
         // Reset font to normal after redrawing header
-        doc.setFont("helvetica", "normal");
+        doc.setFont(fontFamily, "normal");
         doc.setFontSize(8);
       }
 
@@ -830,7 +878,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   
   // Classification row if provided
   if (branding?.metadata?.classification) {
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     const classColor: [number, number, number] = branding.metadata.classification === 'confidential' || branding.metadata.classification === 'restricted' 
       ? [220, 38, 38] : [80, 80, 80];
     doc.setTextColor(classColor[0], classColor[1], classColor[2]);
@@ -869,7 +917,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // ToC Title
     doc.setFontSize(20);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     const [tocR, tocG, tocB] = hexToRgb(primaryColor);
     doc.setTextColor(tocR, tocG, tocB);
     doc.text("Table of Contents", pageWidth / 2, yPosition + 10, { align: "center" });
@@ -903,7 +951,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // === KEY METRICS WITH VISUAL INDICATORS ===
     doc.setFontSize(12);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(0, 0, 0);
     doc.text("Key Metrics", margin, yPosition);
     yPosition += 10;
@@ -952,13 +1000,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       
       // Value - large and prominent
       doc.setFontSize(20);
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       doc.setTextColor(metric.color[0], metric.color[1], metric.color[2]);
       doc.text(metric.value, cardX + cardWidth / 2, yPosition + 12, { align: 'center' });
       
       // Label - centered below value
       doc.setFontSize(9);
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(100, 100, 100);
       doc.text(metric.label, cardX + cardWidth / 2, yPosition + 20, { align: 'center' });
       
@@ -969,7 +1017,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // === ASSIGNMENT RATE VISUALIZATION ===
     doc.setFontSize(12);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(0, 0, 0);
     doc.text("Assignment Coverage", margin, yPosition);
     yPosition += 8;
@@ -997,7 +1045,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // Assignment rate text only
     doc.setFontSize(10);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(progressColor[0], progressColor[1], progressColor[2]);
     doc.text(`${Math.round(assignmentRate)}%`, margin + progressBarWidth + 5, yPosition + 8);
     
@@ -1006,7 +1054,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     // === POTENTIAL GAPS SECTION ===
     if (analytics.unassignedConfigs > 0 || analytics.staleConfigs > 0) {
       doc.setFontSize(12);
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       doc.setTextColor(0, 0, 0);
       doc.text("Potential Gaps", margin, yPosition);
       yPosition += 8;
@@ -1051,7 +1099,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         doc.setFillColor(risk.color[0], risk.color[1], risk.color[2]);
         doc.setTextColor(255, 255, 255);
         doc.setFontSize(8);
-        doc.setFont("helvetica", "bold");
+        doc.setFont(fontFamily, "bold");
         const levelText = risk.level.toUpperCase();
         const levelWidth = doc.getTextWidth(levelText) + 4;
         doc.rect(margin + 8, yPosition + 3, levelWidth, 5, 'F');
@@ -1059,13 +1107,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         
         // Risk title
         doc.setFontSize(10);
-        doc.setFont("helvetica", "bold");
+        doc.setFont(fontFamily, "bold");
         doc.setTextColor(risk.color[0], risk.color[1], risk.color[2]);
         doc.text(risk.title, margin + 15 + levelWidth, yPosition + 7);
         
         // Risk description
         doc.setFontSize(9);
-        doc.setFont("helvetica", "normal");
+        doc.setFont(fontFamily, "normal");
         doc.setTextColor(80, 80, 80);
         doc.text(risk.description, margin + 8, yPosition + 13);
         
@@ -1141,7 +1189,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   }
   
   doc.setFontSize(12);
-  doc.setFont("helvetica", "bold");
+  doc.setFont(fontFamily, "bold");
   doc.setTextColor(0, 0, 0);
   doc.text("Configuration Inventory", margin, yPosition);
   yPosition += 10;
@@ -1153,7 +1201,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   doc.rect(margin, yPosition, tableWidth, 10, "F");
   
   doc.setFontSize(10);
-  doc.setFont("helvetica", "bold");
+  doc.setFont(fontFamily, "bold");
   doc.setTextColor(255, 255, 255);
   doc.text("Policy Type", margin + 3, yPosition + 7);
   doc.text("Total", margin + 85, yPosition + 7);
@@ -1161,7 +1209,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   doc.text("Unassigned", margin + 140, yPosition + 7);
   yPosition += 10;
   
-  doc.setFont("helvetica", "normal");
+  doc.setFont(fontFamily, "normal");
   doc.setFontSize(9);
   doc.setTextColor(0, 0, 0);
   
@@ -1182,7 +1230,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       doc.rect(margin, yPosition, tableWidth, 10, "F");
       
       doc.setFontSize(10);
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       doc.setTextColor(255, 255, 255);
       doc.text("Policy Type", margin + 3, yPosition + 7);
       doc.text("Total", margin + 85, yPosition + 7);
@@ -1191,7 +1239,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       yPosition += 10;
       
       // Reset text settings
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setFontSize(9);
       doc.setTextColor(0, 0, 0);
     }
@@ -1209,11 +1257,11 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // Policy type
     doc.setFontSize(9);
-    doc.setFont("helvetica", "normal");
+    doc.setFont(fontFamily, "normal");
     doc.text(item.type, margin + 3, yPosition + 6);
     
     // Total count
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(52, 152, 219); // Blue
     doc.text(item.count.toString(), margin + 90, yPosition + 6);
     
@@ -1227,7 +1275,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     doc.text(unassigned.toString(), margin + 150, yPosition + 6);
     
     doc.setTextColor(0, 0, 0);
-    doc.setFont("helvetica", "normal");
+    doc.setFont(fontFamily, "normal");
     yPosition += rowHeight;
   });
   
@@ -1279,7 +1327,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     checkPageBreak(platformChartHeight);
 
     doc.setFontSize(12);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(0, 0, 0);
     doc.text("Platform Coverage", margin, yPosition);
     yPosition += 10;
@@ -1304,7 +1352,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       
       // Platform name - simple text, no colored box
       doc.setFontSize(9);
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(60, 60, 60);
       doc.text(platform, margin, barY + 9);
       
@@ -1327,7 +1375,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       
       // Value labels - positioned to right of bar, showing only configs
       doc.setFontSize(8);
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       doc.setTextColor(color[0], color[1], color[2]);
       
       // Show only configuration count
@@ -1348,7 +1396,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
   if (analytics.topGroups.length > 0) {
     checkPageBreak(80);
     doc.setFontSize(12);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(0, 0, 0);
     doc.text("Top Assigned Groups", margin, yPosition);
     yPosition += 10;
@@ -1360,7 +1408,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     doc.rect(margin, yPosition, groupTableWidth, 9, "F");
     
     doc.setFontSize(9);
-    doc.setFont("helvetica", "bold");
+    doc.setFont(fontFamily, "bold");
     doc.setTextColor(255, 255, 255);
     doc.text("Rank", margin + 3, yPosition + 6);
     doc.text("Group Name", margin + 20, yPosition + 6);
@@ -1370,7 +1418,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // Group data rows
     const topGroupsData = analytics.topGroups.slice(0, 5);
-    doc.setFont("helvetica", "normal");
+    doc.setFont(fontFamily, "normal");
     doc.setTextColor(0, 0, 0);
     
     topGroupsData.forEach(([groupId, count], index) => {
@@ -1398,19 +1446,19 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         doc.setFillColor(rankColor[0], rankColor[1], rankColor[2]);
         doc.circle(margin + 6, yPosition + 5, 3, 'F');
         doc.setFontSize(7);
-        doc.setFont("helvetica", "bold");
+        doc.setFont(fontFamily, "bold");
         doc.setTextColor(255, 255, 255);
         doc.text((index + 1).toString(), margin + 6, yPosition + 6.5, { align: 'center' });
       } else {
         doc.setFontSize(8);
-        doc.setFont("helvetica", "normal");
+        doc.setFont(fontFamily, "normal");
         doc.setTextColor(100, 100, 100);
         doc.text(`${index + 1}.`, margin + 3, yPosition + 6);
       }
       
       // Group name (truncate if too long)
       doc.setFontSize(9);
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(0, 0, 0);
       const groupName = data.groupNames?.get(groupId) || groupId;
       // Calculate max width for group name to avoid overflow
@@ -1432,13 +1480,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       doc.rect(margin + 95, yPosition + 3, barWidth, 4, 'F');
       
       // Count number
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       doc.setFontSize(8);
       doc.setTextColor(barColor[0], barColor[1], barColor[2]);
       doc.text(count.toString(), margin + 115, yPosition + 6);
       
       // Platform indicator
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(100, 100, 100);
       doc.setFontSize(8);
       doc.text('Multi', margin + 140, yPosition + 6);
@@ -1479,7 +1527,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (policy.description) {
-        addText(policy.description, 9, false, [100, 100, 100]);
+        addText(policy.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1506,7 +1554,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
 
         addSettingsTable(formattedSettings);
       } else {
-        addText("No settings configured", 9, false, [150, 150, 150]);
+        addText("No settings configured", 9, "normal", [150, 150, 150]);
         yPosition += 5;
       }
       
@@ -1532,7 +1580,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (config.description) {
-        addText(config.description, 9, false, [100, 100, 100]);
+        addText(config.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1540,7 +1588,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       const categories = parseDeviceConfiguration(config);
       categories.forEach(category => {
         if (category.settings.length > 0) {
-          addText(category.category, 10, true);
+          addText(category.category, 10, "bold");
           yPosition += 2;
           addSettingsTable(category.settings);
         }
@@ -1568,7 +1616,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (template.description) {
-        addText(template.description, 9, false, [100, 100, 100]);
+        addText(template.description, 9, "normal", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1585,12 +1633,12 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         }, {});
         
         Object.entries(groupedSettings).forEach(([category, categorySettings]: [string, any]) => {
-          addText(category, 10, true);
+          addText(category, 10, "bold");
           yPosition += 2;
           addSettingsTable(categorySettings);
         });
       } else {
-        addText("No settings configured", 9, false, [150, 150, 150]);
+        addText("No settings configured", 9, "normal", [150, 150, 150]);
         yPosition += 5;
       }
       
@@ -1616,7 +1664,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (policy.description) {
-        addText(policy.description, 9, false, [100, 100, 100]);
+        addText(policy.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1629,7 +1677,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         }));
         addSettingsTable(rulesTable);
       } else {
-        addText("No compliance rules configured", 9, false, [150, 150, 150]);
+        addText("No compliance rules configured", 9, "normal", [150, 150, 150]);
         yPosition += 5;
       }
       
@@ -1655,7 +1703,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (baseline.description) {
-        addText(baseline.description, 9, false, [100, 100, 100]);
+        addText(baseline.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1664,13 +1712,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         const categories = parseSecurityBaseline(baseline.categories);
         categories.forEach(category => {
           if (category.settings.length > 0) {
-            addText(category.category, 10, true);
+            addText(category.category, 10, "bold");
             yPosition += 2;
             addSettingsTable(category.settings);
           }
         });
       } else {
-        addText("No settings configured", 9, false, [150, 150, 150]);
+        addText("No settings configured", 9, "normal", [150, 150, 150]);
         yPosition += 5;
       }
       
@@ -1689,7 +1737,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // Windows PowerShell Scripts
     if (data.scripts.windows.length > 0) {
-      addText("Windows PowerShell Scripts", 12, true);
+      addText("Windows PowerShell Scripts", 12, "bold");
       yPosition += 5;
       
       data.scripts.windows.forEach(script => {
@@ -1710,7 +1758,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         addSettingsTable(scriptInfo);
         
         if (script.scriptContent) {
-          addText("Script Content:", 9, true);
+          addText("Script Content:", 9, "bold");
           yPosition += 2;
           
           // Decode base64 script content if needed
@@ -1739,12 +1787,12 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
             yPosition += 4;
           });
           
-          doc.setFont("helvetica", "normal");
+          doc.setFont(fontFamily, "normal");
           doc.setTextColor(0, 0, 0);
           yPosition += 3;
           
           // Add script length info
-          addText(`Total script length: ${scriptText.length} characters`, 8, false, [100, 100, 100]);
+          addText(`Total script length: ${scriptText.length} characters`, 8, "normal", [100, 100, 100]);
           yPosition += 2;
         }
         
@@ -1754,7 +1802,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
     
     // macOS Shell Scripts
     if (data.scripts.macOS.length > 0) {
-      addText("macOS Shell Scripts", 12, true);
+      addText("macOS Shell Scripts", 12, "bold");
       yPosition += 5;
       
       data.scripts.macOS.forEach(script => {
@@ -1773,7 +1821,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
         addSettingsTable(scriptInfo);
         
         if (script.scriptContent) {
-          addText("Script Content:", 9, true);
+          addText("Script Content:", 9, "bold");
           yPosition += 2;
           
           // Decode base64 script content if needed
@@ -1802,12 +1850,12 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
             yPosition += 4;
           });
           
-          doc.setFont("helvetica", "normal");
+          doc.setFont(fontFamily, "normal");
           doc.setTextColor(0, 0, 0);
           yPosition += 3;
           
           // Add script length info
-          addText(`Total script length: ${scriptText.length} characters`, 8, false, [100, 100, 100]);
+          addText(`Total script length: ${scriptText.length} characters`, 8, "normal", [100, 100, 100]);
           yPosition += 2;
         }
         
@@ -1834,7 +1882,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (config.description) {
-        addText(config.description, 9, false, [100, 100, 100]);
+        addText(config.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1849,10 +1897,10 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       
       // Show targeted apps if available
       if (config.apps && config.apps.length > 0) {
-        addText("Targeted Apps:", 10, true);
+        addText("Targeted Apps:", 10, "bold");
         yPosition += 2;
         config.apps.forEach((app: any) => {
-          addText(`• ${app.mobileAppIdentifier?.packageId || app.bundleId || app.displayName || "Unknown App"}`, 9, false, [100, 100, 100]);
+          addText(`• ${app.mobileAppIdentifier?.packageId || app.bundleId || app.displayName || "Unknown App"}`, 9, "normal", [100, 100, 100]);
           yPosition += 1;
         });
         yPosition += 2;
@@ -1880,7 +1928,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (policy.description) {
-        addText(policy.description, 9, false, [100, 100, 100]);
+        addText(policy.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -1978,7 +2026,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
 
       if (policy.state) {
-        addText(`State: ${policy.state}`, 9, false, [100, 100, 100]);
+        addText(`State: ${policy.state}`, 9, "normal", [100, 100, 100]);
         yPosition += 2;
       }
 
@@ -2011,7 +2059,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       if (info.length > 0) {
         addSettingsTable(info);
       } else {
-        addText("No additional conditions configured", 9, false, [150, 150, 150]);
+        addText("No additional conditions configured", 9, "normal", [150, 150, 150]);
         yPosition += 5;
       }
 
@@ -2037,20 +2085,20 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       );
       
       if (config.description) {
-        addText(config.description, 9, false, [100, 100, 100]);
+        addText(config.description, 9, "italic", [100, 100, 100]);
         yPosition += 2;
       }
       
       // Add enrollment type
       if (config["@odata.type"]) {
         const enrollmentType = config["@odata.type"].split(".").pop()?.replace(/([A-Z])/g, " $1").trim();
-        addText(`Type: ${enrollmentType}`, 9, false, [100, 100, 100]);
+        addText(`Type: ${enrollmentType}`, 9, "normal", [100, 100, 100]);
         yPosition += 2;
       }
       
       // Add priority if available
       if (config.priority !== undefined) {
-        addText(`Priority: ${config.priority}`, 9, false, [100, 100, 100]);
+        addText(`Priority: ${config.priority}`, 9, "normal", [100, 100, 100]);
         yPosition += 2;
       }
       
@@ -2149,13 +2197,13 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       }
       
       // Section number
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(60, 60, 60);
       const sectionNum = `${index + 1}.`;
       doc.text(sectionNum, margin, yPosition);
       
       // Section title
-      doc.setFont("helvetica", "normal");
+      doc.setFont(fontFamily, "normal");
       doc.setTextColor(60, 60, 60);
       doc.text(entry.title, margin + 10, yPosition);
       
@@ -2175,7 +2223,7 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       }
       
       // Page number
-      doc.setFont("helvetica", "bold");
+      doc.setFont(fontFamily, "bold");
       const [pnr, png, pnb] = hexToRgb(primaryColor);
       doc.setTextColor(pnr, png, pnb);
       doc.text(pageNumText, pageWidth - margin, yPosition, { align: "right" });

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -399,11 +399,24 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       // Prepare text for all columns
       const nameLines = doc.splitTextToSize(setting.name, (colWidths[0] || 50) - 4);
       const valueText = setting.value || "Not configured";
-      const valueLines = wrapTechnicalString(valueText, (colWidths[1] || 65) - 4);
-      const descLines = setting.description 
+
+      // Handle newlines in values (e.g., arrays formatted with \n)
+      let valueLines: string[] = [];
+      if (valueText.includes('\n')) {
+        // Split by newline and then wrap each line
+        const valueParts = valueText.split('\n');
+        valueParts.forEach(part => {
+          const wrappedPart = wrapTechnicalString(part, (colWidths[1] || 65) - 4);
+          valueLines = valueLines.concat(wrappedPart);
+        });
+      } else {
+        valueLines = wrapTechnicalString(valueText, (colWidths[1] || 65) - 4);
+      }
+
+      const descLines = setting.description
         ? doc.splitTextToSize(setting.description, (colWidths[2] || 65) - 4)
         : [""];
-      
+
       // Calculate row height based on maximum lines needed
       const maxLines = Math.max(nameLines.length, valueLines.length, descLines.length);
       const rowHeight = Math.max(8, maxLines * 4 + 4); // Dynamic height based on content
@@ -1472,7 +1485,25 @@ export async function generateDetailedPDF(data: DetailedPdfData): Promise<Uint8A
       
       // Extract and display settings
       if (policy.settings && policy.settings.length > 0) {
-        const formattedSettings = policy.settings.map((setting: any) => extractSettingValue(setting));
+        const formattedSettings: Array<{name: string, value: string, description?: string}> = [];
+
+        // Process each setting and flatten nested settings
+        for (const setting of policy.settings) {
+          const extracted = extractSettingValue(setting);
+
+          // Add the main setting
+          formattedSettings.push({
+            name: extracted.name,
+            value: extracted.value,
+            description: extracted.description
+          });
+
+          // Add nested settings if they exist
+          if (extracted.nestedSettings && extracted.nestedSettings.length > 0) {
+            formattedSettings.push(...extracted.nestedSettings);
+          }
+        }
+
         addSettingsTable(formattedSettings);
       } else {
         addText("No settings configured", 9, false, [150, 150, 150]);


### PR DESCRIPTION
## Summary
- Fixed watermark overlapping metadata table on cover page
- Fixed header text font size consistency across all pages
- Fixed nested settings parsing for macOS Settings Catalog policies
- Fixed font size consistency when page breaks occur during text rendering
- Standardized description text styling across all policy sections

## Changes
- Skip watermark rendering on page 1 (cover page)
- Use fixed 9pt font size for header text
- Re-apply font settings after page breaks in addText()
- Change Administrative Templates descriptions to italic style
- Add font resets after header/footer rendering

## Test plan
- Verified PDF exports show consistent 9pt italic descriptions
- Verified no watermark overlap on cover page
- Verified header text displays at correct size
- Verified nested settings display actual values instead of "Collection (X items)"