### PR TITLE
Fix Graph resource loading and add category export controls

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -28,6 +28,7 @@ import { DashboardSidebar } from "~/components/dashboard/dashboard-sidebar";
 import { DashboardContent } from "~/components/dashboard/dashboard-content";
 import {
   buildDashboardTypeStats,
+  type ConfigurationTypeKey,
   type DashboardView,
   type IntuneConfigurations,
 } from "~/components/dashboard/types";
@@ -579,7 +580,11 @@ export default function DashboardPage() {
       newSelected.add(id);
     }
     setSelectedConfigs(newSelected);
-    setSelectAll(newSelected.size === getAllConfigIds().length);
+    const allConfigIds = getAllConfigIds();
+    setSelectAll(
+      allConfigIds.length > 0 &&
+        allConfigIds.every((configId) => newSelected.has(configId)),
+    );
   };
 
   const handleBulkSelect = (idsToAdd: string[], idsToRemove: string[]) => {
@@ -587,7 +592,33 @@ export default function DashboardPage() {
     idsToRemove.forEach((id) => newSelected.delete(id));
     idsToAdd.forEach((id) => newSelected.add(id));
     setSelectedConfigs(newSelected);
-    setSelectAll(newSelected.size === getAllConfigIds().length);
+    const allConfigIds = getAllConfigIds();
+    setSelectAll(
+      allConfigIds.length > 0 &&
+        allConfigIds.every((configId) => newSelected.has(configId)),
+    );
+  };
+
+  const handleToggleFamily = (key: ConfigurationTypeKey) => {
+    if (!configurations) return;
+
+    const familyIds = configurations.sections
+      .filter(
+        (section) =>
+          section.familyKey === key &&
+          (section.familyKey !== "conditionalAccessPolicies" ||
+            (includeCA && caConsentStatus === "included")),
+      )
+      .flatMap((section) =>
+        section.items.map((item) => `${section.selectionPrefix}-${item.id}`),
+      );
+    const allFamilyItemsSelected =
+      familyIds.length > 0 && familyIds.every((id) => selectedConfigs.has(id));
+
+    handleBulkSelect(
+      allFamilyItemsSelected ? [] : familyIds,
+      allFamilyItemsSelected ? familyIds : [],
+    );
   };
 
   // Filter configurations based on search query
@@ -807,6 +838,7 @@ export default function DashboardPage() {
           onSelectFiltered={handleSelectFiltered}
           onSelectConfig={handleSelectConfig}
           onBulkSelect={handleBulkSelect}
+          onToggleFamily={handleToggleFamily}
           onIncludeCAChange={async (next) => {
             setIncludeCA(next);
             localStorage.setItem("include-ca", String(next));

--- a/src/components/dashboard/__tests__/selection-progress.test.tsx
+++ b/src/components/dashboard/__tests__/selection-progress.test.tsx
@@ -1,0 +1,112 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SelectionProgress } from "../selection-progress";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+interface CheckboxProps {
+  checked: boolean;
+  className: string;
+  "aria-label": string;
+  onChange: () => void;
+  ref?: (input: HTMLInputElement | null) => void;
+}
+
+function findCheckboxes(node: ReactNode): ReactElement<CheckboxProps>[] {
+  const checkboxes: ReactElement<CheckboxProps>[] = [];
+
+  Children.forEach(node, (child) => {
+    if (!isValidElement(child)) return;
+    if (child.type === "input") {
+      checkboxes.push(child as ReactElement<CheckboxProps>);
+    }
+    checkboxes.push(
+      ...findCheckboxes((child.props as { children?: ReactNode }).children),
+    );
+  });
+
+  return checkboxes;
+}
+
+describe("SelectionProgress", () => {
+  it("renders round category controls that toggle the export family", () => {
+    const onToggleFamily = vi.fn();
+    const tree = SelectionProgress({
+      stats: [
+        {
+          key: "settingsCatalog",
+          label: "Settings Catalog",
+          compactLabel: "Settings Catalog",
+          total: 143,
+          selected: 0,
+        },
+      ],
+      selectedCount: 0,
+      totalCount: 143,
+      onToggleFamily,
+    });
+    const [checkbox] = findCheckboxes(tree);
+
+    expect(checkbox).toBeDefined();
+    expect(checkbox?.props.checked).toBe(false);
+    expect(checkbox?.props.className).toContain("checkbox-enhanced--round");
+    expect(checkbox?.props["aria-label"]).toBe(
+      "Add all Settings Catalog to the export",
+    );
+
+    checkbox?.props.onChange();
+    expect(onToggleFamily).toHaveBeenCalledWith("settingsCatalog");
+  });
+
+  it("describes a fully selected family as removable from the export", () => {
+    const tree = SelectionProgress({
+      stats: [
+        {
+          key: "settingsCatalog",
+          label: "Settings Catalog",
+          compactLabel: "Settings Catalog",
+          total: 143,
+          selected: 143,
+        },
+      ],
+      selectedCount: 143,
+      totalCount: 143,
+      onToggleFamily: vi.fn(),
+    });
+    const [checkbox] = findCheckboxes(tree);
+
+    expect(checkbox?.props.checked).toBe(true);
+    expect(checkbox?.props["aria-label"]).toBe(
+      "Remove all Settings Catalog from the export",
+    );
+  });
+
+  it("marks a partially selected family as indeterminate", () => {
+    const tree = SelectionProgress({
+      stats: [
+        {
+          key: "settingsCatalog",
+          label: "Settings Catalog",
+          compactLabel: "Settings Catalog",
+          total: 143,
+          selected: 1,
+        },
+      ],
+      selectedCount: 1,
+      totalCount: 143,
+      onToggleFamily: vi.fn(),
+    });
+    const [checkbox] = findCheckboxes(tree);
+    const input = { indeterminate: false } as HTMLInputElement;
+
+    checkbox?.props.ref?.(input);
+    expect(checkbox?.props.checked).toBe(false);
+    expect(input.indeterminate).toBe(true);
+  });
+});

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -8,6 +8,7 @@ import { KpiCards } from "~/components/dashboard/kpi-cards";
 import { SelectionProgress } from "~/components/dashboard/selection-progress";
 import { TypeDonut } from "~/components/dashboard/type-donut";
 import type {
+  ConfigurationTypeKey,
   DashboardConfigurationItem,
   DashboardTypeStat,
   DashboardView,
@@ -35,6 +36,7 @@ interface DashboardContentProps {
   onSelectFiltered: () => void;
   onSelectConfig: (id: string) => void;
   onBulkSelect: (idsToAdd: string[], idsToRemove: string[]) => void;
+  onToggleFamily: (key: ConfigurationTypeKey) => void;
   onIncludeCAChange: (next: boolean) => void | Promise<void>;
 }
 
@@ -207,6 +209,7 @@ export function DashboardContent({
   onSelectFiltered,
   onSelectConfig,
   onBulkSelect,
+  onToggleFamily,
   onIncludeCAChange,
 }: DashboardContentProps) {
   const showConditionalAccess = includeCA && caConsentStatus === "included";
@@ -229,7 +232,20 @@ export function DashboardContent({
   const warningCount =
     (configurations.permissionErrors?.length ?? 0) +
     (configurations.fetchErrors?.length ?? 0);
-  const populatedTypeCount = typeStats.filter((stat) => stat.total > 0).length;
+  const overviewTypeStats = typeStats.filter(
+    (stat) => showConditionalAccess || stat.key !== "conditionalAccessPolicies",
+  );
+  const overviewSelectedCount = overviewTypeStats.reduce(
+    (count, stat) => count + stat.selected,
+    0,
+  );
+  const overviewTotalCount = overviewTypeStats.reduce(
+    (count, stat) => count + stat.total,
+    0,
+  );
+  const populatedTypeCount = overviewTypeStats.filter(
+    (stat) => stat.total > 0,
+  ).length;
   const filter = (items: DashboardConfigurationItem[]) =>
     filterConfigurations(items, searchQuery);
 
@@ -265,14 +281,12 @@ export function DashboardContent({
         {activeView === "overview" && (
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,0.75fr)]">
             <SelectionProgress
-              stats={typeStats}
-              selectedCount={selectedConfigs.size}
-              totalCount={configurations.summary.totalConfigurations}
+              stats={overviewTypeStats}
+              selectedCount={overviewSelectedCount}
+              totalCount={overviewTotalCount}
+              onToggleFamily={onToggleFamily}
             />
-            <TypeDonut
-              stats={typeStats}
-              total={configurations.summary.totalConfigurations}
-            />
+            <TypeDonut stats={overviewTypeStats} total={overviewTotalCount} />
           </div>
         )}
 

--- a/src/components/dashboard/selection-progress.tsx
+++ b/src/components/dashboard/selection-progress.tsx
@@ -1,16 +1,21 @@
 import { ListChecks } from "lucide-react";
-import type { DashboardTypeStat } from "~/components/dashboard/types";
+import type {
+  ConfigurationTypeKey,
+  DashboardTypeStat,
+} from "~/components/dashboard/types";
 
 interface SelectionProgressProps {
   stats: DashboardTypeStat[];
   selectedCount: number;
   totalCount: number;
+  onToggleFamily: (key: ConfigurationTypeKey) => void;
 }
 
 export function SelectionProgress({
   stats,
   selectedCount,
   totalCount,
+  onToggleFamily,
 }: SelectionProgressProps) {
   const visibleStats = stats.filter((stat) => stat.total > 0);
   const overallPercent =
@@ -21,13 +26,17 @@ export function SelectionProgress({
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
-            <ListChecks className="h-[18px] w-[18px] text-teal-700" />
+            <ListChecks
+              className="h-[18px] w-[18px] text-teal-700"
+              aria-hidden="true"
+            />
             <h2 className="text-petrol-950 text-sm font-semibold">
               Selection progress
             </h2>
           </div>
           <p className="text-petrol-600 mt-1.5 text-xs">
-            Track export coverage across your tenant.
+            Select entire categories or track export coverage across your
+            tenant.
           </p>
         </div>
         <div className="rounded-xl bg-teal-50 px-3 py-2 text-right">
@@ -40,35 +49,53 @@ export function SelectionProgress({
         </div>
       </div>
 
-      <div className="mt-5 grid gap-x-6 gap-y-4 sm:grid-cols-2">
+      <div className="mt-5 grid gap-x-6 gap-y-2 sm:grid-cols-2">
         {visibleStats.map((stat) => {
           const percent =
             stat.total > 0 ? Math.round((stat.selected / stat.total) * 100) : 0;
+          const allSelected = stat.selected === stat.total;
+          const partiallySelected = stat.selected > 0 && !allSelected;
 
           return (
-            <div key={stat.key}>
-              <div className="mb-1.5 flex items-center justify-between gap-3">
-                <span className="text-petrol-700 truncate text-xs font-medium">
-                  {stat.compactLabel}
+            <label
+              key={stat.key}
+              className="group hover:bg-mint-50 focus-within:bg-mint-50 flex min-h-14 cursor-pointer touch-manipulation items-center gap-3 rounded-xl p-2 transition-colors"
+            >
+              <input
+                type="checkbox"
+                name={`export-family-${stat.key}`}
+                checked={allSelected}
+                ref={(input) => {
+                  if (input) input.indeterminate = partiallySelected;
+                }}
+                onChange={() => onToggleFamily(stat.key)}
+                className="checkbox-enhanced checkbox-enhanced--round shrink-0"
+                aria-label={`${allSelected ? "Remove" : "Add"} all ${stat.compactLabel} ${allSelected ? "from" : "to"} the export`}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="mb-1.5 flex items-center justify-between gap-3">
+                  <span className="text-petrol-700 truncate text-xs font-medium transition-colors group-hover:text-teal-700">
+                    {stat.compactLabel}
+                  </span>
+                  <span className="text-petrol-600 shrink-0 text-[10px] font-semibold tabular-nums">
+                    {stat.selected}/{stat.total}
+                  </span>
                 </span>
-                <span className="text-petrol-600 shrink-0 text-[10px] font-semibold tabular-nums">
-                  {stat.selected}/{stat.total}
+                <span
+                  className="bg-mint-100 block h-1.5 overflow-hidden rounded-full"
+                  role="progressbar"
+                  aria-label={`${stat.label}: ${stat.selected} of ${stat.total} selected`}
+                  aria-valuemin={0}
+                  aria-valuemax={stat.total}
+                  aria-valuenow={stat.selected}
+                >
+                  <span
+                    className="block h-full w-full origin-left rounded-full bg-teal-600 transition-transform duration-300 motion-reduce:transition-none"
+                    style={{ transform: `scaleX(${percent / 100})` }}
+                  />
                 </span>
-              </div>
-              <div
-                className="bg-mint-100 h-1.5 overflow-hidden rounded-full"
-                role="progressbar"
-                aria-label={`${stat.label}: ${stat.selected} of ${stat.total} selected`}
-                aria-valuemin={0}
-                aria-valuemax={stat.total}
-                aria-valuenow={stat.selected}
-              >
-                <div
-                  className="h-full rounded-full bg-teal-600 transition-[width] duration-300"
-                  style={{ width: `${percent}%` }}
-                />
-              </div>
-            </div>
+              </span>
+            </label>
           );
         })}
       </div>

--- a/src/lib/__tests__/intune-policy-registry.test.ts
+++ b/src/lib/__tests__/intune-policy-registry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_REGISTRY_PAGE_SIZE,
   INTUNE_POLICY_REGISTRY,
   REDACTED_VALUE,
+  getRegistryPageSize,
+  isExpectedRegistryUnavailableError,
   sanitizeGraphData,
 } from "../intune-policy-registry";
 
@@ -14,6 +17,60 @@ describe("Intune policy registry", () => {
         (entry) => entry.path.startsWith("/") && !entry.path.includes("v1.0"),
       ),
     ).toBe(true);
+  });
+
+  it("uses endpoint-compatible update page sizes and valid mobile app selects", () => {
+    const updateKeys = [
+      "windowsFeatureUpdateProfiles",
+      "windowsQualityUpdateProfiles",
+      "windowsQualityUpdatePolicies",
+      "windowsDriverUpdateProfiles",
+    ];
+    const updateEntries = INTUNE_POLICY_REGISTRY.filter((entry) =>
+      updateKeys.includes(entry.key),
+    );
+    const mobileApps = INTUNE_POLICY_REGISTRY.find(
+      (entry) => entry.key === "mobileApps",
+    );
+
+    expect(updateEntries).toHaveLength(updateKeys.length);
+    expect(updateEntries.every((entry) => entry.pageSize === 200)).toBe(true);
+    expect(
+      INTUNE_POLICY_REGISTRY.filter(
+        (entry) => entry.shape !== "singleton",
+      ).every((entry) => getRegistryPageSize(entry) > 0),
+    ).toBe(true);
+    expect(
+      getRegistryPageSize(
+        INTUNE_POLICY_REGISTRY.find((entry) => entry.key === "mobileApps")!,
+      ),
+    ).toBe(DEFAULT_REGISTRY_PAGE_SIZE);
+    expect(mobileApps?.select).not.toContain("@odata.type");
+    expect(
+      sanitizeGraphData({
+        "@odata.type": "#microsoft.graph.win32LobApp",
+      }),
+    ).toEqual({ "@odata.type": "#microsoft.graph.win32LobApp" });
+  });
+
+  it("only treats the known Remote Assist service 403 as unavailable", () => {
+    const remoteAssistance = INTUNE_POLICY_REGISTRY.find(
+      (entry) => entry.key === "remoteAssistanceSettings",
+    );
+
+    expect(remoteAssistance).toBeDefined();
+    expect(
+      isExpectedRegistryUnavailableError(remoteAssistance!, {
+        response: { status: 403 },
+        message: "Request failed in RemoteAssistService",
+      }),
+    ).toBe(true);
+    expect(
+      isExpectedRegistryUnavailableError(remoteAssistance!, {
+        statusCode: 403,
+        message: "Insufficient privileges to complete the operation",
+      }),
+    ).toBe(false);
   });
 
   it("redacts enrollment tokens, script bodies, payloads, and icons recursively", () => {

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -9,6 +9,8 @@ import type { ConfigurationSectionData } from "./configuration-sections";
 import { getItemLabel, getStableItemId } from "./configuration-sections";
 import {
   INTUNE_POLICY_REGISTRY,
+  getRegistryPageSize,
+  isExpectedRegistryUnavailableError,
   mapWithConcurrency,
   sanitizeGraphData,
 } from "./intune-policy-registry";
@@ -273,7 +275,8 @@ export class DetailedIntuneService {
       let request = this.client.api(entry.path).version("beta");
       if (entry.select?.length)
         request = request.select(entry.select.join(","));
-      if (entry.shape !== "singleton") request = request.top(999);
+      if (entry.shape !== "singleton")
+        request = request.top(getRegistryPageSize(entry));
       const response = await this.retryWithBackoff(() => request.get(), 3, 500);
 
       let rawItems: any[];
@@ -302,7 +305,7 @@ export class DetailedIntuneService {
               if (child.expand)
                 childRequest = childRequest.expand(child.expand);
               if (child.shape !== "singleton")
-                childRequest = childRequest.top(999);
+                childRequest = childRequest.top(getRegistryPageSize(child));
               const childResponse = await this.retryWithBackoff(
                 () => childRequest.get(),
                 2,
@@ -369,7 +372,10 @@ export class DetailedIntuneService {
       }
     } catch (error: any) {
       const details = this.graphError(error);
-      if (!(details.statusCode === 404 && entry.notConfiguredOn404)) {
+      if (
+        !(details.statusCode === 404 && entry.notConfiguredOn404) &&
+        !isExpectedRegistryUnavailableError(entry, error)
+      ) {
         base.error = {
           ...details,
           permissionHint: entry.permissionHint,

--- a/src/lib/intune-policy-registry.ts
+++ b/src/lib/intune-policy-registry.ts
@@ -15,16 +15,30 @@ export interface IntuneRegistryEntry {
   path: string;
   permissionHint: string;
   shape?: "collection" | "singleton";
+  pageSize?: number;
   select?: string[];
   notConfiguredOn404?: boolean;
+  unavailableWhen?: {
+    statusCode: number;
+    messageIncludes: string;
+  };
   legacy?: boolean;
   sensitiveFields?: string[];
   childCollections?: Array<{
     property: string;
     path: string;
     shape?: "collection" | "singleton";
+    pageSize?: number;
     expand?: string;
   }>;
+}
+
+export const DEFAULT_REGISTRY_PAGE_SIZE = 999;
+
+export function getRegistryPageSize(
+  entry: Pick<IntuneRegistryEntry, "pageSize">,
+): number {
+  return entry.pageSize ?? DEFAULT_REGISTRY_PAGE_SIZE;
 }
 
 export const ADDITIONAL_FAMILY_LABELS: Record<
@@ -48,6 +62,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsFeatureUpdateProfiles",
     permissionHint: "DeviceManagementConfiguration.Read.All",
+    pageSize: 200,
   },
   {
     key: "windowsQualityUpdateProfiles",
@@ -55,6 +70,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsQualityUpdateProfiles",
     permissionHint: "DeviceManagementConfiguration.Read.All",
+    pageSize: 200,
   },
   {
     key: "windowsQualityUpdatePolicies",
@@ -62,6 +78,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsQualityUpdatePolicies",
     permissionHint: "DeviceManagementConfiguration.Read.All",
+    pageSize: 200,
   },
   {
     key: "windowsDriverUpdateProfiles",
@@ -69,6 +86,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsDriverUpdateProfiles",
     permissionHint: "DeviceManagementConfiguration.Read.All",
+    pageSize: 200,
   },
   {
     key: "deviceHealthScripts",
@@ -129,7 +147,6 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     permissionHint: "DeviceManagementApps.Read.All",
     select: [
       "id",
-      "@odata.type",
       "displayName",
       "description",
       "publisher",
@@ -334,8 +351,40 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     permissionHint: "DeviceManagementServiceConfig.Read.All",
     shape: "singleton",
     notConfiguredOn404: true,
+    unavailableWhen: {
+      statusCode: 403,
+      messageIncludes: "RemoteAssistService",
+    },
   },
 ];
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+export function isExpectedRegistryUnavailableError(
+  entry: IntuneRegistryEntry,
+  error: any,
+): boolean {
+  if (!entry.unavailableWhen) return false;
+
+  const statusCode = error?.statusCode || error?.response?.status;
+  const message = [error?.message, error?.error?.message]
+    .map(errorText)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    statusCode === entry.unavailableWhen.statusCode &&
+    message.includes(entry.unavailableWhen.messageIncludes.toLowerCase())
+  );
+}
 
 const REDACTED_FIELDS = new Set([
   "apptoken",

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -205,6 +205,10 @@ button:focus-visible {
     cursor: pointer;
   }
 
+  .checkbox-enhanced--round {
+    border-radius: 9999px;
+  }
+
   .checkbox-enhanced:checked {
     background: var(--color-teal-600);
     border-color: var(--color-teal-600);


### PR DESCRIPTION
## Summary

- use the live-verified `$top=200` limit for all four Windows update collections while preserving existing page sizes elsewhere
- remove the invalid `@odata.type` term from the Mobile Apps `$select`; Graph still returns the derived-type annotation in each item
- treat only the known Remote Assist service-proxy 403 as unavailable, while preserving ordinary permission failures
- add accessible round category checkboxes to Selection progress so a whole family can be added to or removed from the export
- keep totals, progress bars, Conditional Access visibility, and Select all state synchronized

## Verification

- Microsoft Graph beta requests verified live through Lokka for all six affected resources
- Mobile Apps verified to return both `@odata.type` and `@odata.nextLink` with the corrected select
- Claude Code Opus review completed; paging, selection-state, and indeterminate-state findings addressed
- `npm test` — 17 tests passed
- `npm run typecheck` — passed
- `SKIP_ENV_VALIDATION=1 npm run check` — passed with existing warnings only
- `SKIP_ENV_VALIDATION=1 npm run build` — passed
- desktop browser interaction verified: selecting Settings Catalog updated 0/313 to 143/313 and changed the accessible action to removal

## Notes

The untracked LinkedIn draft is intentionally excluded from this pull request.