### PR TITLE
Fix missing Conditional Access report details

### DIFF
--- a/src/lib/__tests__/conditional-access-report.test.ts
+++ b/src/lib/__tests__/conditional-access-report.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConditionalAccessReportRows,
+  conditionalAccessStateLabel,
+} from "../conditional-access-report";
+
+function rowsByName(policy: any, groupNames?: Map<string, string>) {
+  return new Map(
+    buildConditionalAccessReportRows(policy, groupNames).map((row) => [
+      row.name,
+      row.value,
+    ]),
+  );
+}
+
+describe("Conditional Access report rows", () => {
+  it("includes target resources and the complete device filter", () => {
+    const rows = rowsByName(
+      {
+        conditions: {
+          users: {
+            includeGroups: ["pilot-group"],
+            excludeGroups: ["break-glass-group"],
+          },
+          applications: {
+            includeApplications: ["Office365"],
+          },
+          platforms: { includePlatforms: ["windows"] },
+          clientAppTypes: ["mobileAppsAndDesktopClients"],
+          devices: {
+            deviceFilter: {
+              mode: "include",
+              rule: 'device.deviceOwnership -ne "Company"',
+            },
+          },
+        },
+        grantControls: { builtInControls: ["block"] },
+      },
+      new Map([
+        ["pilot-group", "Data Protection Pilot"],
+        ["break-glass-group", "Break Glass Accounts"],
+      ]),
+    );
+
+    expect(rows.get("Include Groups")).toBe("Data Protection Pilot");
+    expect(rows.get("Exclude Groups")).toBe("Break Glass Accounts");
+    expect(rows.get("Include Applications")).toBe("Office 365");
+    expect(rows.get("Device Filter Mode")).toBe("include");
+    expect(rows.get("Device Filter Rule")).toBe(
+      'device.deviceOwnership -ne "Company"',
+    );
+    expect(rows.get("Grant Controls")).toBe("block");
+  });
+
+  it("preserves configured beta fields and explicit disabled values", () => {
+    const rows = rowsByName({
+      conditions: {
+        authenticationFlows: { transferMethods: ["deviceCodeFlow"] },
+        clientApplications: {
+          servicePrincipalFilter: {
+            mode: "exclude",
+            rule: 'CustomSecurityAttribute.foo -eq "bar"',
+          },
+        },
+      },
+      grantControls: {
+        authenticationStrength: {
+          displayName: "Phishing-resistant MFA",
+          "authenticationStrength@odata.context": "ignored",
+        },
+      },
+      sessionControls: {
+        disableResilienceDefaults: false,
+        experimentalControl: { isEnabled: true },
+      },
+    });
+
+    expect(rows.get("Authentication Flows Transfer Methods")).toBe(
+      "deviceCodeFlow",
+    );
+    expect(rows.get("Service Principal Filter Mode")).toBe("exclude");
+    expect(rows.get("Service Principal Filter Rule")).toBe(
+      'CustomSecurityAttribute.foo -eq "bar"',
+    );
+    expect(rows.get("Authentication Strength")).toBe("Phishing-resistant MFA");
+    expect(rows.get("Disable Resilience Defaults")).toBe("Disabled");
+    expect(rows.get("Session Controls Experimental Control Is Enabled")).toBe(
+      "Enabled",
+    );
+    expect([...rows.values()]).not.toContain("ignored");
+  });
+
+  it("formats policy state labels", () => {
+    expect(conditionalAccessStateLabel("enabled")).toBe("Enabled");
+    expect(
+      conditionalAccessStateLabel("enabledForReportingButNotEnforced"),
+    ).toBe("Report-only");
+    expect(conditionalAccessStateLabel(undefined)).toBe("Unknown");
+  });
+});

--- a/src/lib/conditional-access-report.ts
+++ b/src/lib/conditional-access-report.ts
@@ -1,0 +1,244 @@
+export interface ConditionalAccessReportRow {
+  name: string;
+  value: string;
+}
+
+const APPLICATION_NAMES: Record<string, string> = {
+  All: "All resources",
+  Office365: "Office 365",
+  MicrosoftAdminPortals: "Microsoft Admin Portals",
+  "00000003-0000-0ff1-ce00-000000000000": "Office 365",
+};
+
+const USER_TARGET_NAMES: Record<string, string> = {
+  All: "All users",
+  GuestsOrExternalUsers: "Guests or external users",
+};
+
+const LOCATION_NAMES: Record<string, string> = {
+  All: "All locations",
+  AllTrusted: "All trusted locations",
+};
+
+const LABELS: Record<string, string> = {
+  "conditions.userRiskLevels": "User Risk Levels",
+  "conditions.signInRiskLevels": "Sign-in Risk Levels",
+  "conditions.servicePrincipalRiskLevels": "Service Principal Risk Levels",
+  "conditions.agentIdRiskLevels": "Agent ID Risk Levels",
+  "conditions.insiderRiskLevels": "Insider Risk Levels",
+  "conditions.clientAppTypes": "Client Apps",
+  "conditions.users.includeUsers": "Include Users",
+  "conditions.users.excludeUsers": "Exclude Users",
+  "conditions.users.includeGroups": "Include Groups",
+  "conditions.users.excludeGroups": "Exclude Groups",
+  "conditions.users.includeRoles": "Include Roles",
+  "conditions.users.excludeRoles": "Exclude Roles",
+  "conditions.users.includeGuestsOrExternalUsers.guestOrExternalUserTypes":
+    "Include Guest or External User Types",
+  "conditions.users.includeGuestsOrExternalUsers.externalTenants.members":
+    "Include External Tenants",
+  "conditions.users.includeGuestsOrExternalUsers.externalTenants.membershipKind":
+    "Included External Tenant Scope",
+  "conditions.users.excludeGuestsOrExternalUsers.guestOrExternalUserTypes":
+    "Exclude Guest or External User Types",
+  "conditions.users.excludeGuestsOrExternalUsers.externalTenants.members":
+    "Exclude External Tenants",
+  "conditions.users.excludeGuestsOrExternalUsers.externalTenants.membershipKind":
+    "Excluded External Tenant Scope",
+  "conditions.applications.includeApplications": "Include Applications",
+  "conditions.applications.excludeApplications": "Exclude Applications",
+  "conditions.applications.includeUserActions": "Include User Actions",
+  "conditions.applications.includeAuthenticationContextClassReferences":
+    "Include Authentication Contexts",
+  "conditions.applications.applicationFilter.mode": "Application Filter Mode",
+  "conditions.applications.applicationFilter.rule": "Application Filter Rule",
+  "conditions.platforms.includePlatforms": "Include Platforms",
+  "conditions.platforms.excludePlatforms": "Exclude Platforms",
+  "conditions.locations.includeLocations": "Include Locations",
+  "conditions.locations.excludeLocations": "Exclude Locations",
+  "conditions.deviceStates.includeStates": "Include Device States",
+  "conditions.deviceStates.excludeStates": "Exclude Device States",
+  "conditions.devices.includeDevices": "Include Devices",
+  "conditions.devices.excludeDevices": "Exclude Devices",
+  "conditions.devices.includeDeviceStates": "Include Device States (Legacy)",
+  "conditions.devices.excludeDeviceStates": "Exclude Device States (Legacy)",
+  "conditions.devices.deviceFilter.mode": "Device Filter Mode",
+  "conditions.devices.deviceFilter.rule": "Device Filter Rule",
+  "conditions.clientApplications.includeServicePrincipals":
+    "Include Service Principals",
+  "conditions.clientApplications.excludeServicePrincipals":
+    "Exclude Service Principals",
+  "conditions.clientApplications.servicePrincipalFilter.mode":
+    "Service Principal Filter Mode",
+  "conditions.clientApplications.servicePrincipalFilter.rule":
+    "Service Principal Filter Rule",
+  "conditions.clientApplications.includeAgentIdServicePrincipals":
+    "Include Agent ID Service Principals",
+  "conditions.clientApplications.excludeAgentIdServicePrincipals":
+    "Exclude Agent ID Service Principals",
+  "conditions.clientApplications.agentIdServicePrincipalFilter.mode":
+    "Agent ID Service Principal Filter Mode",
+  "conditions.clientApplications.agentIdServicePrincipalFilter.rule":
+    "Agent ID Service Principal Filter Rule",
+  "grantControls.operator": "Grant Operator",
+  "grantControls.builtInControls": "Grant Controls",
+  "grantControls.customAuthenticationFactors": "Custom Auth Factors",
+  "grantControls.termsOfUse": "Terms of Use",
+  "grantControls.authenticationStrength.id": "Authentication Strength ID",
+  "grantControls.authenticationStrength.displayName": "Authentication Strength",
+  "grantControls.authenticationStrength.description":
+    "Authentication Strength Description",
+  "grantControls.authenticationStrength.policyType":
+    "Authentication Strength Policy Type",
+  "grantControls.authenticationStrength.requirementsSatisfied":
+    "Authentication Strength Requirements",
+  "grantControls.authenticationStrength.allowedCombinations":
+    "Authentication Strength Combinations",
+  "sessionControls.applicationEnforcedRestrictions.isEnabled":
+    "App Enforced Restrictions",
+  "sessionControls.cloudAppSecurity.isEnabled": "Cloud App Security",
+  "sessionControls.cloudAppSecurity.cloudAppSecurityType":
+    "Cloud App Security Type",
+  "sessionControls.continuousAccessEvaluation.mode":
+    "Continuous Access Evaluation",
+  "sessionControls.disableResilienceDefaults": "Disable Resilience Defaults",
+  "sessionControls.persistentBrowser.isEnabled": "Persistent Browser",
+  "sessionControls.persistentBrowser.mode": "Persistent Browser Mode",
+  "sessionControls.secureSignInSession.isEnabled": "Secure Sign-in Session",
+  "sessionControls.signInFrequency.isEnabled": "Sign-in Frequency",
+  "sessionControls.signInFrequency.value": "Sign-in Frequency Value",
+  "sessionControls.signInFrequency.type": "Sign-in Frequency Type",
+  "sessionControls.signInFrequency.authenticationType":
+    "Sign-in Frequency Authentication Type",
+  "sessionControls.signInFrequency.frequencyInterval":
+    "Sign-in Frequency Interval",
+  "sessionControls.globalSecureAccessFilteringProfile.isEnabled":
+    "Global Secure Access Filtering Profile",
+  "sessionControls.globalSecureAccessFilteringProfile.profileId":
+    "Global Secure Access Filtering Profile ID",
+};
+
+function humanize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1 $2")
+    .replace(/Id\b/g, "ID")
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
+function labelFor(path: string[]): string {
+  const key = path.join(".");
+  if (LABELS[key]) return LABELS[key];
+
+  return path
+    .filter((segment) => segment !== "conditions")
+    .map(humanize)
+    .join(" ");
+}
+
+function mapListValue(path: string, value: unknown): string {
+  if (typeof value === "boolean") return value ? "Enabled" : "Disabled";
+  if (typeof value !== "string") return String(value);
+
+  if (
+    path === "conditions.users.includeGroups" ||
+    path === "conditions.users.excludeGroups"
+  ) {
+    return value;
+  }
+  if (
+    path === "conditions.applications.includeApplications" ||
+    path === "conditions.applications.excludeApplications"
+  ) {
+    return APPLICATION_NAMES[value] || value;
+  }
+  if (
+    path === "conditions.users.includeUsers" ||
+    path === "conditions.users.excludeUsers"
+  ) {
+    return USER_TARGET_NAMES[value] || value;
+  }
+  if (
+    path === "conditions.locations.includeLocations" ||
+    path === "conditions.locations.excludeLocations"
+  ) {
+    return LOCATION_NAMES[value] || value;
+  }
+
+  return value;
+}
+
+function isOdataAnnotation(key: string): boolean {
+  return key.startsWith("@odata.") || key.includes("@odata.");
+}
+
+/**
+ * Flatten every configured Conditional Access condition and control into
+ * report-ready rows. Known Graph fields receive concise labels, while unknown
+ * beta fields are still emitted with a generated path label so new settings do
+ * not silently disappear from exports.
+ */
+export function buildConditionalAccessReportRows(
+  policy: any,
+  groupNames?: Map<string, string>,
+): ConditionalAccessReportRow[] {
+  const rows: ConditionalAccessReportRow[] = [];
+
+  const visit = (value: unknown, path: string[]) => {
+    if (value == null) return;
+
+    const pathKey = path.join(".");
+    if (Array.isArray(value)) {
+      if (value.length === 0) return;
+
+      const rendered = value.map((item) => {
+        if (
+          typeof item === "string" &&
+          (pathKey === "conditions.users.includeGroups" ||
+            pathKey === "conditions.users.excludeGroups")
+        ) {
+          return groupNames?.get(item) || item;
+        }
+        if (item !== null && typeof item === "object") {
+          return JSON.stringify(item);
+        }
+        return mapListValue(pathKey, item);
+      });
+
+      rows.push({ name: labelFor(path), value: rendered.join(", ") });
+      return;
+    }
+
+    if (typeof value === "object") {
+      for (const [key, child] of Object.entries(value)) {
+        if (!isOdataAnnotation(key)) visit(child, [...path, key]);
+      }
+      return;
+    }
+
+    if (typeof value === "string" && value.length === 0) return;
+    rows.push({
+      name: labelFor(path),
+      value: mapListValue(pathKey, value),
+    });
+  };
+
+  visit(policy?.conditions, ["conditions"]);
+  visit(policy?.grantControls, ["grantControls"]);
+  visit(policy?.sessionControls, ["sessionControls"]);
+
+  return rows;
+}
+
+export function conditionalAccessStateLabel(state: unknown): string {
+  switch (state) {
+    case "enabled":
+      return "Enabled";
+    case "disabled":
+      return "Disabled";
+    case "enabledForReportingButNotEnforced":
+      return "Report-only";
+    default:
+      return typeof state === "string" && state ? state : "Unknown";
+  }
+}

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -40,6 +40,10 @@ import {
 } from "./configuration-parser";
 import type { BrandingOptions } from "~/types/branding";
 import { REDACTED_VALUE } from "./intune-policy-registry";
+import {
+  buildConditionalAccessReportRows,
+  conditionalAccessStateLabel,
+} from "./conditional-access-report";
 
 // ---------------------------------------------------------------------------
 // Helper utilities
@@ -2001,14 +2005,7 @@ export async function generateDetailedDOCX(
         );
 
         // State
-        const stateLabel =
-          policy.state === "enabled"
-            ? "Enabled"
-            : policy.state === "disabled"
-              ? "Disabled"
-              : policy.state === "enabledForReportingButNotEnforced"
-                ? "Report-only"
-                : (policy.state ?? "Unknown");
+        const stateLabel = conditionalAccessStateLabel(policy.state);
 
         sectionChildren.push(
           new Paragraph({
@@ -2048,177 +2045,15 @@ export async function generateDetailedDOCX(
           );
         }
 
+        if (policy.description) {
+          sectionChildren.push(bodyText(policy.description));
+        }
+
         // Conditions table
-        const conditions: string[][] = [];
-
-        // Users
-        const userConditions = policy.conditions?.users;
-        if (userConditions) {
-          if (userConditions.includeUsers?.length) {
-            conditions.push([
-              "Include Users",
-              userConditions.includeUsers.join(", "),
-            ]);
-          }
-          if (userConditions.excludeUsers?.length) {
-            conditions.push([
-              "Exclude Users",
-              userConditions.excludeUsers.join(", "),
-            ]);
-          }
-          if (userConditions.includeGroups?.length) {
-            const resolved = userConditions.includeGroups.map(
-              (id: string) => data.groupNames?.get(id) ?? id,
-            );
-            conditions.push(["Include Groups", resolved.join(", ")]);
-          }
-          if (userConditions.excludeGroups?.length) {
-            const resolved = userConditions.excludeGroups.map(
-              (id: string) => data.groupNames?.get(id) ?? id,
-            );
-            conditions.push(["Exclude Groups", resolved.join(", ")]);
-          }
-          if (userConditions.includeRoles?.length) {
-            conditions.push([
-              "Include Roles",
-              userConditions.includeRoles.join(", "),
-            ]);
-          }
-          if (userConditions.excludeRoles?.length) {
-            conditions.push([
-              "Exclude Roles",
-              userConditions.excludeRoles.join(", "),
-            ]);
-          }
-        }
-
-        // Applications
-        const appConditions = policy.conditions?.applications;
-        if (appConditions) {
-          if (appConditions.includeApplications?.length) {
-            conditions.push([
-              "Include Applications",
-              appConditions.includeApplications.join(", "),
-            ]);
-          }
-          if (appConditions.excludeApplications?.length) {
-            conditions.push([
-              "Exclude Applications",
-              appConditions.excludeApplications.join(", "),
-            ]);
-          }
-        }
-
-        // Platforms
-        const platformConditions = policy.conditions?.platforms;
-        if (platformConditions) {
-          if (platformConditions.includePlatforms?.length) {
-            conditions.push([
-              "Include Platforms",
-              platformConditions.includePlatforms.join(", "),
-            ]);
-          }
-          if (platformConditions.excludePlatforms?.length) {
-            conditions.push([
-              "Exclude Platforms",
-              platformConditions.excludePlatforms.join(", "),
-            ]);
-          }
-        }
-
-        // Locations
-        const locationConditions = policy.conditions?.locations;
-        if (locationConditions) {
-          if (locationConditions.includeLocations?.length) {
-            conditions.push([
-              "Include Locations",
-              locationConditions.includeLocations.join(", "),
-            ]);
-          }
-          if (locationConditions.excludeLocations?.length) {
-            conditions.push([
-              "Exclude Locations",
-              locationConditions.excludeLocations.join(", "),
-            ]);
-          }
-        }
-
-        // Client app types
-        if (policy.conditions?.clientAppTypes?.length) {
-          conditions.push([
-            "Client App Types",
-            policy.conditions.clientAppTypes.join(", "),
-          ]);
-        }
-
-        // Sign-in risk levels
-        if (policy.conditions?.signInRiskLevels?.length) {
-          conditions.push([
-            "Sign-in Risk Levels",
-            policy.conditions.signInRiskLevels.join(", "),
-          ]);
-        }
-
-        // User risk levels
-        if (policy.conditions?.userRiskLevels?.length) {
-          conditions.push([
-            "User Risk Levels",
-            policy.conditions.userRiskLevels.join(", "),
-          ]);
-        }
-
-        // Grant controls
-        const grantControls = policy.grantControls;
-        if (grantControls) {
-          if (grantControls.operator) {
-            conditions.push(["Grant Operator", grantControls.operator]);
-          }
-          if (grantControls.builtInControls?.length) {
-            conditions.push([
-              "Grant Controls",
-              grantControls.builtInControls.join(", "),
-            ]);
-          }
-          if (grantControls.customAuthenticationFactors?.length) {
-            conditions.push([
-              "Custom Auth Factors",
-              grantControls.customAuthenticationFactors.join(", "),
-            ]);
-          }
-          if (grantControls.termsOfUse?.length) {
-            conditions.push([
-              "Terms of Use",
-              grantControls.termsOfUse.join(", "),
-            ]);
-          }
-        }
-
-        // Session controls
-        const sessionControls = policy.sessionControls;
-        if (sessionControls) {
-          if (sessionControls.applicationEnforcedRestrictions?.isEnabled) {
-            conditions.push(["App Enforced Restrictions", "Enabled"]);
-          }
-          if (sessionControls.cloudAppSecurity?.isEnabled) {
-            conditions.push([
-              "Cloud App Security",
-              sessionControls.cloudAppSecurity.cloudAppSecurityType ||
-                "Enabled",
-            ]);
-          }
-          if (sessionControls.signInFrequency?.isEnabled) {
-            conditions.push([
-              "Sign-in Frequency",
-              `${sessionControls.signInFrequency.value} ${sessionControls.signInFrequency.type}`,
-            ]);
-          }
-          if (sessionControls.persistentBrowser?.isEnabled) {
-            conditions.push([
-              "Persistent Browser",
-              sessionControls.persistentBrowser.mode || "Enabled",
-            ]);
-          }
-        }
+        const conditions = buildConditionalAccessReportRows(
+          policy,
+          data.groupNames,
+        ).map((row) => [row.name, row.value]);
 
         if (conditions.length > 0) {
           sectionChildren.push(

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -17,6 +17,10 @@ import {
   type ExportGenerationResult,
 } from "./configuration-analyzer";
 import { REDACTED_VALUE } from "./intune-policy-registry";
+import {
+  buildConditionalAccessReportRows,
+  conditionalAccessStateLabel,
+} from "./conditional-access-report";
 
 export type { PolicyExportError };
 export type PdfGenerationResult = ExportGenerationResult;
@@ -2642,77 +2646,31 @@ export async function generateDetailedPDF(
 
     totalPolicies += data.conditionalAccessPolicies.length;
 
-    const groupName = (id: string) => data.groupNames?.get(id) || id;
-
     data.conditionalAccessPolicies.forEach((policy: any) => {
       try {
         addConfigHeader(
           policy.displayName,
-          "Not assigned",
+          "Defined by policy conditions",
           policy.createdDateTime,
           policy.modifiedDateTime,
         );
 
         if (policy.state) {
-          addText(`State: ${policy.state}`, 9, "normal", [100, 100, 100]);
+          addText(
+            `State: ${conditionalAccessStateLabel(policy.state)}`,
+            9,
+            "normal",
+            [100, 100, 100],
+          );
           yPosition += 2;
         }
 
-        const users = policy?.conditions?.users || {};
-        const includeGroups: string[] = (users.includeGroups || []).map(
-          groupName,
-        );
-        const excludeGroups: string[] = (users.excludeGroups || []).map(
-          groupName,
-        );
-        const includeUsers: string[] = users.includeUsers || [];
-        const excludeUsers: string[] = users.excludeUsers || [];
-        const platforms: string[] =
-          policy?.conditions?.platforms?.includePlatforms || [];
-        const clientApps: string[] = policy?.conditions?.clientAppTypes || [];
-        const locations = policy?.conditions?.locations || {};
-        const includeLocations: string[] = locations.includeLocations || [];
-        const excludeLocations: string[] = locations.excludeLocations || [];
-        const grants: string[] = policy?.grantControls?.builtInControls || [];
-        const session = policy?.sessionControls || {};
-        const sessionEnabled = Object.keys(session).filter((k) => session[k]);
+        if (policy.description) {
+          addText(policy.description, 9, "normal", [100, 100, 100]);
+          yPosition += 2;
+        }
 
-        const info: { name: string; value: string }[] = [];
-        if (includeGroups.length)
-          info.push({
-            name: "Include Groups",
-            value: includeGroups.join(", "),
-          });
-        if (excludeGroups.length)
-          info.push({
-            name: "Exclude Groups",
-            value: excludeGroups.join(", "),
-          });
-        if (includeUsers.length)
-          info.push({ name: "Include Users", value: includeUsers.join(", ") });
-        if (excludeUsers.length)
-          info.push({ name: "Exclude Users", value: excludeUsers.join(", ") });
-        if (platforms.length)
-          info.push({ name: "Platforms", value: platforms.join(", ") });
-        if (clientApps.length)
-          info.push({ name: "Client Apps", value: clientApps.join(", ") });
-        if (includeLocations.length)
-          info.push({
-            name: "Include Locations",
-            value: includeLocations.join(", "),
-          });
-        if (excludeLocations.length)
-          info.push({
-            name: "Exclude Locations",
-            value: excludeLocations.join(", "),
-          });
-        if (grants.length)
-          info.push({ name: "Grant Controls", value: grants.join(", ") });
-        if (sessionEnabled.length)
-          info.push({
-            name: "Session Controls",
-            value: sessionEnabled.join(", "),
-          });
+        const info = buildConditionalAccessReportRows(policy, data.groupNames);
 
         if (info.length > 0) {
           addSettingsTable(info);


### PR DESCRIPTION
## What changed

- include target resources and device filter mode/rule in Conditional Access PDF and DOCX exports
- render all configured condition, grant, and session-control fields through one shared formatter
- keep unknown Microsoft Graph beta fields visible so newly added settings are not silently omitted
- show readable policy state and application labels, policy descriptions, and accurate assignment context

## Root cause

The export generators manually selected a small subset of Conditional Access fields. The PDF path did not render application targets or device filters at all, while PDF and DOCX had diverged coverage.

## Impact

Reports now include the settings highlighted in issue #11, including Office 365 target resources and device filter rules, with consistent coverage across PDF and DOCX.

## Validation

- `npm test` (42 tests passed)
- `npm run typecheck`
- `npm run build`

Fixes #11