### PR TITLE
Add uniform Company footer block

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -156,14 +156,17 @@ export default function RootLayout({
     },
     author: {
       "@type": "Organization",
-      name: "Intune Documentation",
-      url: "https://intunedocumentation.com",
-      sameAs: ["https://github.com/IntuneDocumentation"],
+      name: "Ugurlabs",
+      url: "https://ugurlabs.com",
+      sameAs: [
+        "https://github.com/ugurkocde",
+        "https://www.linkedin.com/company/ugurlabs",
+      ],
     },
     publisher: {
       "@type": "Organization",
-      name: "Intune Documentation",
-      url: "https://intunedocumentation.com",
+      name: "Ugurlabs",
+      url: "https://ugurlabs.com",
     },
     softwareVersion: "1.0.0",
     dateCreated: "2024-01-01",

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -159,22 +159,40 @@ export function SiteFooter() {
 
           <div>
             <h4 className="text-petrol-950 text-xs font-bold tracking-[0.16em] uppercase">
-              Related Products
+              Company
             </h4>
             <ul className="mt-4 space-y-3 text-sm">
               <li>
                 <a
-                  href="https://entradocumentation.com"
+                  href="https://ugurlabs.com/about"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="transition-colors hover:text-teal-700"
                 >
-                  EntraDocumentation
+                  About Ugurlabs
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://ugurlabs.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="transition-colors hover:text-teal-700"
+                >
+                  All products
+                </a>
+              </li>
+              <li>
+                <a
+                  href="mailto:support@ugurlabs.com"
+                  className="transition-colors hover:text-teal-700"
+                >
+                  Contact
                 </a>
               </li>
             </ul>
             <p className="text-petrol-600 mt-4 text-xs leading-5">
-              Complete Microsoft 365 documentation ecosystem
+              Practical tools for Microsoft cloud administration
             </p>
           </div>
         </div>


### PR DESCRIPTION
Replaces the Related Products footer column with a Company block that is identical across Ugurlabs product sites: About Ugurlabs (links to the new ugurlabs.com/about page), All products, and Contact. The EntraDocumentation cross-link now lives centrally on ugurlabs.com.

Also fixes the JSON-LD structured data: author and publisher now point to Ugurlabs with the correct GitHub and LinkedIn profiles instead of a non-existent GitHub org.