### PR TITLE
Compliance framework picker and dashboard navigation improvements

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -143,6 +143,14 @@ function mergeConfigurationSection(
   return next;
 }
 
+// Module-scope cache so browser back/forward navigation does not refetch the
+// whole tenant. Only the explicit refresh action bypasses it.
+const dashboardCache: {
+  accountId: string | null;
+  configurations: IntuneConfigurations | null;
+  lastFetched: Date | null;
+} = { accountId: null, configurations: null, lastFetched: null };
+
 export default function DashboardPage() {
   const { instance, accounts, inProgress } = useMsal();
   const router = useRouter();
@@ -242,9 +250,27 @@ export default function DashboardPage() {
       router.push("/");
     } else if (!hasFetchedRef.current && !isFetchingRef.current) {
       hasFetchedRef.current = true;
+      if (
+        dashboardCache.configurations &&
+        dashboardCache.accountId === (accounts[0]?.homeAccountId ?? null)
+      ) {
+        setConfigurations(dashboardCache.configurations);
+        setLastFetched(dashboardCache.lastFetched);
+        setHasCompletedInitialLoad(true);
+        setLoading(false);
+        return;
+      }
       void fetchConfigurations();
     }
   }, [accounts, router]);
+
+  useEffect(() => {
+    if (!loading && configurations && lastFetched) {
+      dashboardCache.accountId = accounts[0]?.homeAccountId ?? null;
+      dashboardCache.configurations = configurations;
+      dashboardCache.lastFetched = lastFetched;
+    }
+  }, [loading, configurations, lastFetched, accounts]);
 
   useEffect(() => {
     if (window.innerWidth < 768) {

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ComplianceView } from "../compliance-view";
 import type { IntuneConfigurations } from "../types";
 
@@ -63,14 +63,22 @@ const configurations: IntuneConfigurations = {
 };
 
 describe("ComplianceView", () => {
-  afterEach(cleanup);
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
 
-  it("switches frameworks and expands control evidence", async () => {
-    const user = userEvent.setup();
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("shows only the framework picker when no selection is stored", () => {
     render(<ComplianceView configurations={configurations} />);
 
     expect(
-      screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
+      screen.getByRole("heading", {
+        name: "Choose a compliance framework",
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "NIST SP 800-53" }),
@@ -79,12 +87,88 @@ describe("ComplianceView", () => {
       screen.getByRole("button", { name: "NIST CSF 2.0" }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByText("Partial configuration evidence").length,
-    ).toBeGreaterThan(0);
+      screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Download report/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /SC-28/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reveals the selected framework content and dropdown trigger", async () => {
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
 
     await user.click(screen.getByRole("button", { name: "NIST SP 800-53" }));
 
-    const sc28Control = screen.getByRole("button", { name: /SC-28/ });
+    const trigger = await screen.findByRole("button", {
+      name: "Selected framework: NIST SP 800-53",
+    });
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveFocus();
+    expect(
+      screen.getByRole("button", { name: "Download report (PDF)" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Partial configuration evidence").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("persists and restores a framework selection", async () => {
+    const user = userEvent.setup();
+    const firstRender = render(
+      <ComplianceView configurations={configurations} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "NIST SP 800-53" }));
+    expect(window.localStorage.getItem("compliance-framework")).toBe(
+      "nist-800-53-r5",
+    );
+
+    firstRender.unmount();
+    render(<ComplianceView configurations={configurations} />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Selected framework: NIST SP 800-53",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download report (PDF)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("returns to the picker and clears the stored selection", async () => {
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+
+    await user.click(screen.getByRole("button", { name: "NIST SP 800-53" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Selected framework: NIST SP 800-53",
+      }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: "Show all frameworks" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Choose a compliance framework",
+      }),
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem("compliance-framework")).toBeNull();
+  });
+
+  it("expands control evidence inside the selected framework", async () => {
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+
+    await user.click(screen.getByRole("button", { name: "NIST SP 800-53" }));
+
+    const sc28Control = await screen.findByRole("button", { name: /SC-28/ });
     expect(sc28Control).toHaveAttribute("aria-expanded", "false");
 
     await user.click(sc28Control);
@@ -132,6 +216,9 @@ describe("ComplianceView", () => {
     };
 
     render(<ComplianceView configurations={counterConfigurations} />);
+    await user.click(
+      screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
+    );
     await user.click(screen.getByRole("button", { name: /NET.3.2/ }));
 
     expect(
@@ -174,6 +261,9 @@ describe("ComplianceView", () => {
     };
 
     render(<ComplianceView configurations={minimumVersionConfigurations} />);
+    await user.click(
+      screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
+    );
     await user.click(screen.getByRole("button", { name: /OPS.1.1.3/ }));
 
     expect(

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -1,8 +1,25 @@
 "use client";
 
 import { useMsal } from "@azure/msal-react";
-import { ChevronDown, Download, LoaderCircle, ShieldCheck } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+  AnimatePresence,
+  LayoutGroup,
+  motion,
+  useReducedMotion,
+} from "framer-motion";
+import {
+  Check,
+  ChevronDown,
+  Download,
+  LoaderCircle,
+  ShieldCheck,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  FrameworkBadge,
+  type FrameworkId,
+} from "~/components/dashboard/framework-badge";
 import type { IntuneConfigurations } from "~/components/dashboard/types";
 import type { DetailedExportData } from "~/lib/configuration-analyzer";
 import { assessCompliance, compareControlIds } from "~/lib/compliance";
@@ -13,20 +30,60 @@ import type {
   ControlStatus,
 } from "~/lib/compliance/types";
 
-type FrameworkId = "bsi-it-grundschutz" | "nist-800-53-r5" | "nist-csf-2";
-
 interface ComplianceViewProps {
   configurations: IntuneConfigurations;
 }
 
-const FRAMEWORK_TABS: ReadonlyArray<{
+const FRAMEWORK_STORAGE_KEY = "compliance-framework";
+
+const FRAMEWORK_OPTIONS: ReadonlyArray<{
   id: FrameworkId;
   label: string;
+  shortLabel: string;
+  description: string;
 }> = [
-  { id: "bsi-it-grundschutz", label: "BSI IT-Grundschutz" },
-  { id: "nist-800-53-r5", label: "NIST SP 800-53" },
-  { id: "nist-csf-2", label: "NIST CSF 2.0" },
+  {
+    id: "nist-800-53-r5",
+    label: "NIST SP 800-53",
+    shortLabel: "NIST 800-53",
+    description:
+      "Security and privacy controls for information systems and organizations.",
+  },
+  {
+    id: "nist-csf-2",
+    label: "NIST CSF 2.0",
+    shortLabel: "NIST CSF",
+    description:
+      "Outcome-based guidance for managing and reducing cybersecurity risk.",
+  },
+  {
+    id: "bsi-it-grundschutz",
+    label: "BSI IT-Grundschutz",
+    shortLabel: "BSI",
+    description:
+      "Baseline safeguards for systematic information security management.",
+  },
 ];
+
+function isFrameworkId(value: string | null): value is FrameworkId {
+  return FRAMEWORK_OPTIONS.some((framework) => framework.id === value);
+}
+
+function storeFrameworkSelection(frameworkId: FrameworkId) {
+  try {
+    window.localStorage.setItem(FRAMEWORK_STORAGE_KEY, frameworkId);
+  } catch {
+    // The picker remains usable when browser storage is unavailable.
+  }
+}
+
+function clearFrameworkSelection() {
+  try {
+    window.localStorage.removeItem(FRAMEWORK_STORAGE_KEY);
+  } catch {
+    // The picker remains usable when browser storage is unavailable.
+  }
+}
 
 const CONTROL_STATUS_ORDER: Record<ControlStatus, number> = {
   evidenceFound: 0,
@@ -332,28 +389,37 @@ function SummaryCard({
   );
 }
 
-function ComplianceHeader({ disclaimer }: { disclaimer: string }) {
+function ComplianceHeader({
+  disclaimer,
+  frameworkSelector,
+}: {
+  disclaimer: string;
+  frameworkSelector?: ReactNode;
+}) {
   return (
     <div className="border-petrol-950/6 shadow-card rounded-2xl border bg-white p-5 sm:p-6">
-      <div className="flex items-start gap-4">
-        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-teal-50 text-teal-700">
-          <ShieldCheck className="h-5 w-5" />
-        </span>
-        <div className="min-w-0">
-          <h2
-            id="compliance-evidence-title"
-            className="text-petrol-950 text-lg font-semibold"
-          >
-            Compliance Evidence
-          </h2>
-          <p className="text-petrol-600 mt-1 max-w-3xl text-sm leading-6">
-            Review the technical evidence found in your loaded Intune policies
-            and assignments for each supported framework.
-          </p>
-          <p className="text-petrol-600/80 mt-3 max-w-4xl text-[11px] leading-5">
-            {disclaimer}
-          </p>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-4">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-teal-50 text-teal-700">
+            <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h2
+              id="compliance-evidence-title"
+              className="text-petrol-950 text-lg font-semibold"
+            >
+              Compliance Evidence
+            </h2>
+            <p className="text-petrol-600 mt-1 max-w-3xl text-sm leading-6">
+              Review the technical evidence found in your loaded Intune policies
+              and assignments for each supported framework.
+            </p>
+            <p className="text-petrol-600/80 mt-3 max-w-4xl text-[11px] leading-5">
+              {disclaimer}
+            </p>
+          </div>
         </div>
+        {frameworkSelector}
       </div>
     </div>
   );
@@ -361,23 +427,89 @@ function ComplianceHeader({ disclaimer }: { disclaimer: string }) {
 
 export function ComplianceView({ configurations }: ComplianceViewProps) {
   const { accounts } = useMsal();
+  const prefersReducedMotion = useReducedMotion();
   const assessment = useMemo(
     () => assessCompliance(configurations as unknown as DetailedExportData),
     [configurations],
   );
   const [selectedFrameworkId, setSelectedFrameworkId] =
-    useState<FrameworkId>("bsi-it-grundschutz");
+    useState<FrameworkId | null>(null);
   const [expandedControls, setExpandedControls] = useState<Set<string>>(
     new Set(),
   );
   const [isGenerating, setIsGenerating] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [isFrameworkMenuOpen, setIsFrameworkMenuOpen] = useState(false);
+  const frameworkMenuRef = useRef<HTMLDivElement>(null);
+  const frameworkTriggerRef = useRef<HTMLButtonElement>(null);
+  const shouldFocusFrameworkTriggerRef = useRef(false);
   const tenantLabel = accounts[0]?.tenantId
     ? `${accounts[0].tenantId.slice(0, 8)}...`
     : undefined;
 
+  useEffect(() => {
+    try {
+      const storedFrameworkId = window.localStorage.getItem(
+        FRAMEWORK_STORAGE_KEY,
+      );
+      if (isFrameworkId(storedFrameworkId)) {
+        setSelectedFrameworkId(storedFrameworkId);
+      }
+    } catch {
+      // An unavailable storage implementation should not block the picker.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (
+      selectedFrameworkId &&
+      shouldFocusFrameworkTriggerRef.current &&
+      frameworkTriggerRef.current
+    ) {
+      shouldFocusFrameworkTriggerRef.current = false;
+      frameworkTriggerRef.current.focus();
+    }
+  }, [selectedFrameworkId]);
+
+  useEffect(() => {
+    if (!isFrameworkMenuOpen) return;
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (
+        event.target instanceof Node &&
+        !frameworkMenuRef.current?.contains(event.target)
+      ) {
+        setIsFrameworkMenuOpen(false);
+        frameworkTriggerRef.current?.focus();
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setIsFrameworkMenuOpen(false);
+        frameworkTriggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("click", handleDocumentClick);
+    document.addEventListener("keydown", handleEscape);
+    frameworkMenuRef.current
+      ?.querySelector<HTMLButtonElement>(
+        '[role="menuitem"][data-selected="true"]',
+      )
+      ?.focus();
+
+    return () => {
+      document.removeEventListener("click", handleDocumentClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isFrameworkMenuOpen]);
+
   const selectedFramework = assessment.frameworks.find(
     (framework) => framework.framework.id === selectedFrameworkId,
+  );
+  const selectedFrameworkOption = FRAMEWORK_OPTIONS.find(
+    (framework) => framework.id === selectedFrameworkId,
   );
   const capabilitiesById = useMemo(
     () =>
@@ -404,12 +536,34 @@ export function ComplianceView({ configurations }: ComplianceViewProps) {
     configurations.sections.length === 0 &&
     !hasLegacyConfigurations(configurations);
 
-  const handleFrameworkChange = (frameworkId: FrameworkId) => {
+  const handleFrameworkChange = (
+    frameworkId: FrameworkId,
+    source: "picker" | "menu",
+  ) => {
+    if (source === "picker") {
+      shouldFocusFrameworkTriggerRef.current = true;
+    }
+    storeFrameworkSelection(frameworkId);
     setSelectedFrameworkId(frameworkId);
     setDownloadError(null);
   };
 
+  const handleMenuFrameworkChange = (frameworkId: FrameworkId) => {
+    handleFrameworkChange(frameworkId, "menu");
+    setIsFrameworkMenuOpen(false);
+    frameworkTriggerRef.current?.focus();
+  };
+
+  const handleShowAllFrameworks = () => {
+    clearFrameworkSelection();
+    setIsFrameworkMenuOpen(false);
+    setSelectedFrameworkId(null);
+    setDownloadError(null);
+  };
+
   const handleDownload = async () => {
+    if (!selectedFrameworkId) return;
+
     setIsGenerating(true);
     setDownloadError(null);
 
@@ -449,143 +603,468 @@ export function ComplianceView({ configurations }: ComplianceViewProps) {
     }
   };
 
-  if (isEmpty) {
-    return (
-      <section
-        className="space-y-5"
-        aria-labelledby="compliance-evidence-title"
-      >
-        <ComplianceHeader disclaimer={assessment.disclaimer} />
-        <div className="border-petrol-950/6 shadow-card rounded-2xl border bg-white px-6 py-12 text-center">
-          <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-teal-50 text-teal-700">
-            <ShieldCheck className="h-5 w-5" />
-          </span>
-          <h3 className="text-petrol-950 mt-4 text-sm font-semibold">
-            Load tenant data to assess compliance evidence
-          </h3>
-          <p className="text-petrol-600 mx-auto mt-1 max-w-lg text-xs leading-5">
-            Compliance evidence appears after your Intune configurations and
-            assignments finish loading. Refresh the dashboard to load tenant
-            data first.
-          </p>
-        </div>
-      </section>
-    );
-  }
-
-  if (!selectedFramework) return null;
-
   return (
-    <section className="space-y-5" aria-labelledby="compliance-evidence-title">
-      <ComplianceHeader disclaimer={assessment.disclaimer} />
-
-      <div
-        className="border-petrol-950/6 shadow-card flex flex-col gap-2 rounded-2xl border bg-white p-2 sm:flex-row"
-        aria-label="Compliance frameworks"
-      >
-        {FRAMEWORK_TABS.map((framework) => {
-          const selected = framework.id === selectedFrameworkId;
-          return (
-            <button
-              key={framework.id}
-              type="button"
-              aria-pressed={selected}
-              onClick={() => handleFrameworkChange(framework.id)}
-              className={`min-h-11 flex-1 cursor-pointer rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:outline-none ${
-                selected
-                  ? "bg-petrol-950 text-white"
-                  : "text-petrol-700 hover:bg-mint-50 hover:text-petrol-950"
-              }`}
-            >
-              {framework.label}
-            </button>
-          );
-        })}
-      </div>
-
-      <div
-        className="grid gap-3 sm:grid-cols-3"
-        aria-label={`${selectedFramework.framework.name} summary`}
-      >
-        <SummaryCard
-          label="Evidence"
-          count={selectedFramework.summary.withEvidence}
-          total={selectedFramework.summary.totalControls}
-          tone="green"
-        />
-        <SummaryCard
-          label="Partial"
-          count={selectedFramework.summary.partial}
-          total={selectedFramework.summary.totalControls}
-          tone="amber"
-        />
-        <SummaryCard
-          label="No evidence"
-          count={selectedFramework.summary.withoutEvidence}
-          total={selectedFramework.summary.totalControls}
-          tone="slate"
-        />
-      </div>
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 className="text-petrol-950 text-lg font-semibold">
-            {selectedFramework.framework.name}
-          </h2>
-          <p className="text-petrol-600 mt-1 text-xs">
-            {selectedFramework.framework.version}
-          </p>
-        </div>
-        <div className="sm:text-right">
-          <button
-            type="button"
-            onClick={() => void handleDownload()}
-            disabled={isGenerating}
-            aria-busy={isGenerating}
-            className="bg-petrol-950 hover:bg-petrol-800 inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isGenerating ? (
-              <LoaderCircle className="h-4 w-4 animate-spin motion-reduce:animate-none" />
-            ) : (
-              <Download className="h-4 w-4" />
+    <section
+      aria-labelledby={
+        selectedFrameworkId
+          ? "compliance-evidence-title"
+          : "framework-picker-title"
+      }
+    >
+      <LayoutGroup id="compliance-framework-picker">
+        <motion.div
+          layout={!prefersReducedMotion}
+          className={
+            selectedFrameworkId
+              ? ""
+              : "mx-auto flex min-h-[28rem] max-w-6xl flex-col justify-center py-8 sm:py-12"
+          }
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 360, damping: 34 }
+          }
+        >
+          <AnimatePresence initial={false}>
+            {!selectedFrameworkId && (
+              <motion.div
+                key="framework-picker-intro"
+                initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: prefersReducedMotion ? 0 : 0.16 }}
+                className="text-center"
+              >
+                <h2
+                  id="framework-picker-title"
+                  className="text-petrol-950 text-xl font-semibold tracking-[-0.02em] sm:text-2xl"
+                >
+                  Choose a compliance framework
+                </h2>
+                <p className="text-petrol-600 mx-auto mt-2 max-w-2xl text-sm leading-6">
+                  Select a framework to review the configuration evidence found
+                  in your Intune policies and assignments.
+                </p>
+              </motion.div>
             )}
-            {isGenerating ? "Generating report…" : "Download report (PDF)"}
-          </button>
-          {downloadError && (
-            <p className="mt-2 text-xs text-red-700" role="alert">
-              {downloadError}
-            </p>
-          )}
-        </div>
-      </div>
+          </AnimatePresence>
 
-      {selectedFramework.framework.note && (
-        <p className="text-petrol-600 text-xs leading-5">
-          {selectedFramework.framework.note}
-        </p>
-      )}
+          <motion.div
+            layout={!prefersReducedMotion}
+            className={
+              selectedFrameworkId ? "grid" : "mt-8 grid gap-4 md:grid-cols-3"
+            }
+          >
+            <AnimatePresence
+              initial={false}
+              custom={selectedFrameworkId}
+              mode="popLayout"
+            >
+              {!selectedFrameworkId &&
+                FRAMEWORK_OPTIONS.map((framework) => {
+                  const assessmentFramework = assessment.frameworks.find(
+                    (item) => item.framework.id === framework.id,
+                  );
 
-      <div className="space-y-3">
-        {sortedControls.map((control) => {
-          const expansionKey = `${selectedFrameworkId}:${control.control.id}`;
-          return (
-            <ControlRow
-              key={control.control.id}
-              control={control}
-              capabilitiesById={capabilitiesById}
-              expanded={expandedControls.has(expansionKey)}
-              onToggle={() =>
-                setExpandedControls((current) => {
-                  const next = new Set(current);
-                  if (next.has(expansionKey)) next.delete(expansionKey);
-                  else next.add(expansionKey);
-                  return next;
-                })
+                  return (
+                    <motion.button
+                      key={framework.id}
+                      type="button"
+                      layoutId={
+                        prefersReducedMotion
+                          ? undefined
+                          : `framework-card-${framework.id}`
+                      }
+                      aria-label={framework.label}
+                      onClick={() =>
+                        handleFrameworkChange(framework.id, "picker")
+                      }
+                      initial={
+                        prefersReducedMotion
+                          ? { opacity: 1 }
+                          : { opacity: 0, scale: 0.98 }
+                      }
+                      animate={
+                        prefersReducedMotion
+                          ? { opacity: 1 }
+                          : { opacity: 1, scale: 1 }
+                      }
+                      variants={{
+                        exit: (selectedId: FrameworkId | null) =>
+                          prefersReducedMotion
+                            ? {
+                                opacity: 1,
+                                transition: { duration: 0 },
+                              }
+                            : selectedId === framework.id
+                              ? {
+                                  opacity: 1,
+                                  scale: 1,
+                                  transition: { duration: 0.24 },
+                                }
+                              : {
+                                  opacity: 0,
+                                  scale: 0.96,
+                                  transition: { duration: 0.16 },
+                                },
+                      }}
+                      exit="exit"
+                      transition={
+                        prefersReducedMotion
+                          ? { duration: 0 }
+                          : {
+                              layout: {
+                                type: "spring",
+                                stiffness: 380,
+                                damping: 34,
+                              },
+                            }
+                      }
+                      className="border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+                    >
+                      <motion.span
+                        layoutId={
+                          prefersReducedMotion
+                            ? undefined
+                            : `framework-badge-${framework.id}`
+                        }
+                        className="block w-fit"
+                      >
+                        <FrameworkBadge frameworkId={framework.id} />
+                      </motion.span>
+                      <span className="text-petrol-950 mt-5 block text-base font-semibold">
+                        {framework.label}
+                      </span>
+                      <span className="mt-1 block text-xs font-semibold text-teal-700">
+                        {assessmentFramework?.framework.version}
+                      </span>
+                      <span className="text-petrol-600 mt-3 block text-sm leading-6">
+                        {framework.description}
+                      </span>
+                    </motion.button>
+                  );
+                })}
+            </AnimatePresence>
+          </motion.div>
+        </motion.div>
+
+        {selectedFrameworkId && selectedFramework && (
+          <div className="space-y-5">
+            <ComplianceHeader
+              disclaimer={assessment.disclaimer}
+              frameworkSelector={
+                <div
+                  ref={frameworkMenuRef}
+                  className="relative ml-auto shrink-0"
+                >
+                  <motion.button
+                    ref={frameworkTriggerRef}
+                    type="button"
+                    layoutId={
+                      prefersReducedMotion
+                        ? undefined
+                        : `framework-card-${selectedFrameworkId}`
+                    }
+                    aria-label={`Selected framework: ${
+                      selectedFrameworkOption?.label ??
+                      selectedFramework.framework.name
+                    }`}
+                    aria-haspopup="menu"
+                    aria-expanded={isFrameworkMenuOpen}
+                    onClick={() =>
+                      setIsFrameworkMenuOpen((current) => !current)
+                    }
+                    transition={
+                      prefersReducedMotion
+                        ? { duration: 0 }
+                        : {
+                            layout: {
+                              type: "spring",
+                              stiffness: 380,
+                              damping: 34,
+                            },
+                          }
+                    }
+                    className="border-petrol-950/10 text-petrol-950 hover:bg-mint-50 inline-flex min-h-11 cursor-pointer touch-manipulation items-center gap-2 rounded-xl border bg-white px-2.5 py-1.5 text-xs font-semibold shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none"
+                  >
+                    <motion.span
+                      layoutId={
+                        prefersReducedMotion
+                          ? undefined
+                          : `framework-badge-${selectedFrameworkId}`
+                      }
+                      className="block shrink-0"
+                    >
+                      <FrameworkBadge
+                        frameworkId={selectedFrameworkId}
+                        size={20}
+                      />
+                    </motion.span>
+                    <span>
+                      {selectedFrameworkOption?.shortLabel ??
+                        selectedFramework.framework.name}
+                    </span>
+                    <ChevronDown
+                      className={`text-petrol-600 h-4 w-4 transition-transform duration-200 motion-reduce:transition-none ${
+                        isFrameworkMenuOpen && !prefersReducedMotion
+                          ? "rotate-180"
+                          : ""
+                      }`}
+                      aria-hidden="true"
+                    />
+                  </motion.button>
+
+                  <AnimatePresence>
+                    {isFrameworkMenuOpen && (
+                      <motion.div
+                        role="menu"
+                        aria-label="Choose a compliance framework"
+                        initial={
+                          prefersReducedMotion
+                            ? { opacity: 1 }
+                            : { opacity: 0, y: -6, scale: 0.98 }
+                        }
+                        animate={
+                          prefersReducedMotion
+                            ? { opacity: 1 }
+                            : { opacity: 1, y: 0, scale: 1 }
+                        }
+                        exit={
+                          prefersReducedMotion
+                            ? { opacity: 0 }
+                            : { opacity: 0, y: -4, scale: 0.98 }
+                        }
+                        transition={{
+                          duration: prefersReducedMotion ? 0 : 0.16,
+                        }}
+                        onKeyDown={(event) => {
+                          if (
+                            !["ArrowDown", "ArrowUp", "Home", "End"].includes(
+                              event.key,
+                            )
+                          ) {
+                            return;
+                          }
+
+                          event.preventDefault();
+                          const menuItems = Array.from(
+                            event.currentTarget.querySelectorAll<HTMLButtonElement>(
+                              '[role="menuitem"]',
+                            ),
+                          );
+                          const currentIndex = menuItems.indexOf(
+                            document.activeElement as HTMLButtonElement,
+                          );
+                          const nextIndex =
+                            event.key === "Home"
+                              ? 0
+                              : event.key === "End"
+                                ? menuItems.length - 1
+                                : event.key === "ArrowDown"
+                                  ? (currentIndex + 1) % menuItems.length
+                                  : (currentIndex - 1 + menuItems.length) %
+                                    menuItems.length;
+                          menuItems[nextIndex]?.focus();
+                        }}
+                        className="border-petrol-950/10 shadow-card absolute top-[calc(100%+0.5rem)] right-0 z-30 w-72 max-w-[calc(100vw-3rem)] overflow-hidden rounded-2xl border bg-white p-1.5"
+                      >
+                        {FRAMEWORK_OPTIONS.map((framework) => {
+                          const selected = framework.id === selectedFrameworkId;
+                          const assessmentFramework =
+                            assessment.frameworks.find(
+                              (item) => item.framework.id === framework.id,
+                            );
+
+                          return (
+                            <button
+                              key={framework.id}
+                              type="button"
+                              role="menuitem"
+                              data-selected={selected ? "true" : undefined}
+                              onClick={() =>
+                                handleMenuFrameworkChange(framework.id)
+                              }
+                              className={`flex min-h-12 w-full cursor-pointer touch-manipulation items-center gap-3 rounded-xl px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:outline-none ${
+                                selected
+                                  ? "bg-mint-50 text-petrol-950"
+                                  : "text-petrol-700 hover:bg-mint-50/70 hover:text-petrol-950"
+                              }`}
+                            >
+                              <FrameworkBadge
+                                frameworkId={framework.id}
+                                size={20}
+                              />
+                              <span className="min-w-0 flex-1">
+                                <span className="block text-xs font-semibold">
+                                  {framework.label}
+                                  {selected && (
+                                    <span className="sr-only">
+                                      , currently selected
+                                    </span>
+                                  )}
+                                </span>
+                                <span className="text-petrol-600 mt-0.5 block text-[10px]">
+                                  {assessmentFramework?.framework.version}
+                                </span>
+                              </span>
+                              {selected && (
+                                <Check
+                                  className="h-4 w-4 shrink-0 text-teal-700"
+                                  aria-hidden="true"
+                                />
+                              )}
+                            </button>
+                          );
+                        })}
+                        <div className="border-petrol-950/8 mt-1 border-t pt-1">
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={handleShowAllFrameworks}
+                            className="text-petrol-700 hover:bg-mint-50 hover:text-petrol-950 min-h-11 w-full cursor-pointer touch-manipulation rounded-xl px-3 text-left text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:outline-none"
+                          >
+                            Show all frameworks
+                          </button>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
               }
             />
-          );
-        })}
-      </div>
+
+            {isEmpty ? (
+              <div className="border-petrol-950/6 shadow-card rounded-2xl border bg-white px-6 py-12 text-center">
+                <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-teal-50 text-teal-700">
+                  <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <h3 className="text-petrol-950 mt-4 text-sm font-semibold">
+                  Load tenant data to assess compliance evidence
+                </h3>
+                <p className="text-petrol-600 mx-auto mt-1 max-w-lg text-xs leading-5">
+                  Compliance evidence appears after your Intune configurations
+                  and assignments finish loading. Refresh the dashboard to load
+                  tenant data first.
+                </p>
+              </div>
+            ) : (
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={selectedFrameworkId}
+                  initial={
+                    prefersReducedMotion
+                      ? { opacity: 1 }
+                      : { opacity: 0, y: 10 }
+                  }
+                  animate={
+                    prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0 }
+                  }
+                  exit={
+                    prefersReducedMotion
+                      ? { opacity: 0 }
+                      : { opacity: 0, y: -6 }
+                  }
+                  transition={{
+                    duration: prefersReducedMotion ? 0 : 0.2,
+                    ease: "easeOut",
+                  }}
+                  className="space-y-5"
+                >
+                  <div
+                    className="grid gap-3 sm:grid-cols-3"
+                    aria-label={`${selectedFramework.framework.name} summary`}
+                  >
+                    <SummaryCard
+                      label="Evidence"
+                      count={selectedFramework.summary.withEvidence}
+                      total={selectedFramework.summary.totalControls}
+                      tone="green"
+                    />
+                    <SummaryCard
+                      label="Partial"
+                      count={selectedFramework.summary.partial}
+                      total={selectedFramework.summary.totalControls}
+                      tone="amber"
+                    />
+                    <SummaryCard
+                      label="No evidence"
+                      count={selectedFramework.summary.withoutEvidence}
+                      total={selectedFramework.summary.totalControls}
+                      tone="slate"
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="text-petrol-950 text-lg font-semibold">
+                        {selectedFramework.framework.name}
+                      </h2>
+                      <p className="text-petrol-600 mt-1 text-xs">
+                        {selectedFramework.framework.version}
+                      </p>
+                    </div>
+                    <div className="sm:text-right">
+                      <button
+                        type="button"
+                        onClick={() => void handleDownload()}
+                        disabled={isGenerating}
+                        aria-busy={isGenerating}
+                        className="bg-petrol-950 hover:bg-petrol-800 inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {isGenerating ? (
+                          <LoaderCircle
+                            className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <Download className="h-4 w-4" aria-hidden="true" />
+                        )}
+                        {isGenerating
+                          ? "Generating report…"
+                          : "Download report (PDF)"}
+                      </button>
+                      {downloadError && (
+                        <p className="mt-2 text-xs text-red-700" role="alert">
+                          {downloadError}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  {selectedFramework.framework.note && (
+                    <p className="text-petrol-600 text-xs leading-5">
+                      {selectedFramework.framework.note}
+                    </p>
+                  )}
+
+                  <div className="space-y-3">
+                    {sortedControls.map((control) => {
+                      const expansionKey = `${selectedFrameworkId}:${control.control.id}`;
+                      return (
+                        <ControlRow
+                          key={control.control.id}
+                          control={control}
+                          capabilitiesById={capabilitiesById}
+                          expanded={expandedControls.has(expansionKey)}
+                          onToggle={() =>
+                            setExpandedControls((current) => {
+                              const next = new Set(current);
+                              if (next.has(expansionKey))
+                                next.delete(expansionKey);
+                              else next.add(expansionKey);
+                              return next;
+                            })
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                </motion.div>
+              </AnimatePresence>
+            )}
+          </div>
+        )}
+      </LayoutGroup>
     </section>
   );
 }

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -292,7 +292,7 @@ export function DashboardContent({
         )}
 
         <DashboardBanners
-          showTip={showTipBanner && !searchQuery}
+          showTip={showTipBanner && !searchQuery && activeView !== "compliance"}
           permissionErrors={configurations.permissionErrors ?? []}
           fetchErrors={configurations.fetchErrors ?? []}
           onDismissTip={onDismissTip}

--- a/src/components/dashboard/dashboard-header.tsx
+++ b/src/components/dashboard/dashboard-header.tsx
@@ -22,10 +22,7 @@ export function DashboardHeader({
   return (
     <div className="flex flex-col gap-4 xl:flex-row xl:items-center">
       <div className="min-w-52 shrink-0">
-        <p className="text-petrol-600 text-[10px] font-bold tracking-[0.14em] uppercase">
-          Intune workspace
-        </p>
-        <h1 className="text-petrol-950 mt-1 text-2xl font-semibold tracking-[-0.035em] sm:text-[28px]">
+        <h1 className="text-petrol-950 text-2xl font-semibold tracking-[-0.035em] sm:text-[28px]">
           {title}
         </h1>
       </div>

--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -1,0 +1,70 @@
+export type FrameworkId =
+  | "bsi-it-grundschutz"
+  | "nist-800-53-r5"
+  | "nist-csf-2";
+
+const BADGE_DETAILS: Record<
+  FrameworkId,
+  { fill: string; mark: string; fontSize: number; textLength?: number }
+> = {
+  "nist-800-53-r5": {
+    fill: "#1D4ED8",
+    mark: "800-53",
+    fontSize: 9.5,
+    textLength: 23,
+  },
+  "nist-csf-2": {
+    fill: "#0F766E",
+    mark: "CSF",
+    fontSize: 11,
+  },
+  "bsi-it-grundschutz": {
+    fill: "#B91C1C",
+    mark: "BSI",
+    fontSize: 11,
+  },
+};
+
+export function FrameworkBadge({
+  frameworkId,
+  size = 40,
+}: {
+  frameworkId: FrameworkId;
+  size?: number;
+}) {
+  const details = BADGE_DETAILS[frameworkId];
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 40 40"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect width="40" height="40" rx="6" fill={details.fill} />
+      <path
+        d="M20 4.75 29 8.25v8c0 5.95-3.5 10.85-9 13.9-5.5-3.05-9-7.95-9-13.9v-8l9-3.5Z"
+        fill="none"
+        stroke="white"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <text
+        x="20"
+        y="20"
+        fill="white"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize={details.fontSize}
+        fontWeight="700"
+        textAnchor="middle"
+        letterSpacing="0.15"
+        textLength={details.textLength}
+        lengthAdjust={details.textLength ? "spacingAndGlyphs" : undefined}
+      >
+        {details.mark}
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- The Compliance Evidence view now opens with a centered framework picker (NIST SP 800-53, NIST CSF 2.0, BSI IT-Grundschutz) instead of defaulting to BSI. Selecting a framework animates the picker into a compact top-right dropdown (framer-motion shared layout, reduced-motion aware) and reveals that framework's content. Custom SVG badges per framework; government logos are legally off limits, so these are neutral marks. Selection persists locally; a menu item returns to the full picker.
- The policy-selection tip banner no longer shows on the Compliance Evidence view.
- The decorative workspace label is removed from the dashboard header.
- Fetched tenant data is cached per signed-in account, so browser back/forward navigation no longer refetches the whole tenant; the refresh button still forces a full reload.

## Test plan

- 88 unit tests passing, including new picker, persistence, reset, and dropdown accessibility tests
- npx tsc --noEmit, next lint (no new warnings), and next build all clean