### PR TITLE
Replace framework shield badges with text-forward wordmarks

### DIFF
--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -3,27 +3,18 @@ export type FrameworkId =
   | "nist-800-53-r5"
   | "nist-csf-2";
 
-const BADGE_DETAILS: Record<
-  FrameworkId,
-  { fill: string; mark: string; fontSize: number; textLength?: number }
+// Text-forward wordmarks only: official government logos and insignia (the
+// NIST logotype, the BSI Bundesadler) must not be reproduced. Naming the
+// standard in our own typography is legitimate nominative use; for BSI the
+// plain national colors provide recognition without any protected emblem.
+const NIST_DETAILS: Partial<
+  Record<FrameworkId, { fill: string; variant: string }>
 > = {
-  "nist-800-53-r5": {
-    fill: "#1D4ED8",
-    mark: "800-53",
-    fontSize: 9.5,
-    textLength: 23,
-  },
-  "nist-csf-2": {
-    fill: "#0F766E",
-    mark: "CSF",
-    fontSize: 11,
-  },
-  "bsi-it-grundschutz": {
-    fill: "#B91C1C",
-    mark: "BSI",
-    fontSize: 11,
-  },
+  "nist-800-53-r5": { fill: "#1D4ED8", variant: "SP 800-53" },
+  "nist-csf-2": { fill: "#0F766E", variant: "CSF 2.0" },
 };
+
+const FONT_FAMILY = "ui-sans-serif, system-ui, sans-serif";
 
 export function FrameworkBadge({
   frameworkId,
@@ -32,7 +23,43 @@ export function FrameworkBadge({
   frameworkId: FrameworkId;
   size?: number;
 }) {
-  const details = BADGE_DETAILS[frameworkId];
+  if (frameworkId === "bsi-it-grundschutz") {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 40 40"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <rect
+          width="39"
+          height="39"
+          x="0.5"
+          y="0.5"
+          rx="6"
+          fill="#FFFFFF"
+          stroke="#E2E8F0"
+        />
+        <rect x="7" y="8" width="5" height="8" fill="#000000" />
+        <rect x="7" y="16" width="5" height="8" fill="#DD0000" />
+        <rect x="7" y="24" width="5" height="8" fill="#FFCC00" />
+        <text
+          x="16"
+          y="24.5"
+          fill="#1E293B"
+          fontFamily={FONT_FAMILY}
+          fontSize="11.5"
+          fontWeight="700"
+          letterSpacing="0.4"
+        >
+          BSI
+        </text>
+      </svg>
+    );
+  }
+
+  const details = NIST_DETAILS[frameworkId];
 
   return (
     <svg
@@ -42,28 +69,31 @@ export function FrameworkBadge({
       aria-hidden="true"
       focusable="false"
     >
-      <rect width="40" height="40" rx="6" fill={details.fill} />
-      <path
-        d="M20 4.75 29 8.25v8c0 5.95-3.5 10.85-9 13.9-5.5-3.05-9-7.95-9-13.9v-8l9-3.5Z"
-        fill="none"
-        stroke="white"
-        strokeWidth="1.75"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <rect width="40" height="40" rx="6" fill={details?.fill ?? "#334155"} />
       <text
         x="20"
-        y="20"
+        y="19"
         fill="white"
-        fontFamily="ui-sans-serif, system-ui, sans-serif"
-        fontSize={details.fontSize}
+        fontFamily={FONT_FAMILY}
+        fontSize="10.5"
         fontWeight="700"
         textAnchor="middle"
-        letterSpacing="0.15"
-        textLength={details.textLength}
-        lengthAdjust={details.textLength ? "spacingAndGlyphs" : undefined}
+        letterSpacing="0.6"
       >
-        {details.mark}
+        NIST
+      </text>
+      <text
+        x="20"
+        y="30"
+        fill="white"
+        fillOpacity="0.85"
+        fontFamily={FONT_FAMILY}
+        fontSize="6.4"
+        fontWeight="600"
+        textAnchor="middle"
+        letterSpacing="0.2"
+      >
+        {details?.variant ?? ""}
       </text>
     </svg>
   );


### PR DESCRIPTION
## Summary

Replaces the abstract shield badges in the Compliance Evidence picker and dropdown with recognition-first wordmarks: bold NIST text with the SP 800-53 or CSF 2.0 variant line (blue and teal), and a BSI badge pairing a plain black-red-gold bar with BSI text. Official logos are not usable (NIST prohibits third-party logo use outright; the BSI Bundesadler is protected federal insignia under German law), so these stick to nominative text and free national colors.

## Test plan

- 88 unit tests passing; tsc, lint (no new warnings), and next build clean
- Component API unchanged; picker, morph animation, and dropdown pick the new badges up at both sizes