### PR TITLE
Keep the dashboard open while MSAL rehydrates after a refresh

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -246,6 +246,12 @@ export default function DashboardPage() {
   const isFetchingRef = useRef(false);
 
   useEffect(() => {
+    // MSAL rehydrates the signed-in account asynchronously after a hard
+    // refresh; only treat an empty account list as signed out once MSAL is
+    // idle, otherwise the refresh races straight back to the landing page.
+    if (inProgress !== "none") {
+      return;
+    }
     if (accounts.length === 0) {
       router.push("/");
     } else if (!hasFetchedRef.current && !isFetchingRef.current) {
@@ -262,7 +268,7 @@ export default function DashboardPage() {
       }
       void fetchConfigurations();
     }
-  }, [accounts, router]);
+  }, [accounts, inProgress, router]);
 
   useEffect(() => {
     if (!loading && configurations && lastFetched) {


### PR DESCRIPTION
## Summary

Refreshing /dashboard could bounce signed-in users to the landing page: MSAL restores the session asynchronously after a hard refresh, and the redirect effect treated the momentarily empty account list as signed out. The effect now waits for MSAL to report an idle interaction state before redirecting, mirroring the render-time guard that already did this correctly.

## Test plan

- 88 unit tests passing; tsc, lint (no new warnings), and next build clean
- Seven-line change scoped to the redirect effect in the dashboard page