### PR TITLE
Add ISO/IEC 27001:2022 and SOC 2 evidence mappings

### DIFF
--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -7,12 +7,12 @@ import { BackToTopButton } from "~/components/back-to-top-button";
 export const metadata: Metadata = {
   title: "Compliance Evidence for Intune",
   description:
-    "Map your Microsoft Intune configuration to NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz. Audit-ready evidence reports, generated from your tenant documentation.",
+    "Map your Microsoft Intune configuration to ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz. Audit-ready evidence reports, generated from your tenant documentation.",
   alternates: { canonical: "/compliance" },
   openGraph: {
     title: "Compliance Evidence for Intune | Intune Documentation",
     description:
-      "Turn your Intune tenant documentation into audit evidence for NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz.",
+      "Turn your Intune tenant documentation into audit evidence for ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz.",
     url: "/compliance",
     type: "website",
   },
@@ -20,9 +20,14 @@ export const metadata: Metadata = {
 
 const frameworks = [
   {
-    name: "BSI IT-Grundschutz",
+    name: "ISO/IEC 27001:2022",
     detail:
-      "Requirement-level mapping (A-Anforderungen) for the client Bausteine SYS.2.2.3, SYS.2.4, SYS.3.2.1, and SYS.3.2.2, verified against the Kompendium Edition 2023, with Basis, Standard, and erhöhter Schutzbedarf tiers. Only technically assessable requirements are mapped; organizational requirements remain a manual assessment.",
+      "Selected Annex A technology controls are mapped to managed-device configuration evidence by control number.",
+  },
+  {
+    name: "SOC 2",
+    detail:
+      "Selected Trust Services Criteria are mapped to managed-device configuration evidence by criterion ID.",
   },
   {
     name: "NIST SP 800-53 (Rev. 5)",
@@ -33,6 +38,11 @@ const frameworks = [
     name: "NIST Cybersecurity Framework 2.0",
     detail:
       "Evidence for Protect and Detect subcategories, from PR.DS-01 (data-at-rest protection) to DE.CM-09 (endpoint monitoring).",
+  },
+  {
+    name: "BSI IT-Grundschutz",
+    detail:
+      "Requirement-level mapping (A-Anforderungen) for the client Bausteine SYS.2.2.3, SYS.2.4, SYS.3.2.1, and SYS.3.2.2, verified against the Kompendium Edition 2023, with Basis, Standard, and erhöhter Schutzbedarf tiers. Only technically assessable requirements are mapped; organizational requirements remain a manual assessment.",
   },
 ];
 
@@ -50,7 +60,7 @@ const reportFeatures = [
   {
     title: "Results overview and key findings",
     detail:
-      "Outcomes broken down by Basis, Standard, and erhöhter Schutzbedarf tier for BSI (control family for NIST), with assigned deviations and unassigned configurations flagged up front.",
+      "Outcomes grouped by BSI requirement tier or framework control family, with assigned deviations and unassigned configurations flagged up front.",
   },
   {
     title: "Grundschutz-Check ready",
@@ -188,8 +198,10 @@ export default function CompliancePage() {
           <p className="mt-10 text-xs leading-relaxed text-slate-400">
             Compliance reports state technical evidence found in your Intune
             tenant. They are not a certification and do not replace an audit.
-            NIST publications are used with their public-domain status; BSI
-            IT-Grundschutz is referenced from the freely published Kompendium.
+            ISO/IEC 27001 and SOC 2 criteria are referenced by identifier with
+            original summaries. NIST publications are used with their
+            public-domain status; BSI IT-Grundschutz is referenced from the
+            freely published Kompendium.
           </p>
         </div>
       </main>

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -81,6 +81,12 @@ describe("ComplianceView", () => {
       }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "ISO/IEC 27001" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "SOC 2" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "NIST SP 800-53" }),
     ).toBeInTheDocument();
     expect(
@@ -89,12 +95,29 @@ describe("ComplianceView", () => {
     expect(
       screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
     ).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(5);
     expect(
       screen.queryByRole("button", { name: /Download report/ }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /SC-28/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it("reveals ISO 27001 content from the framework picker", async () => {
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+
+    await user.click(screen.getByRole("button", { name: "ISO/IEC 27001" }));
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Selected framework: ISO/IEC 27001",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /8\.24/ }),
+    ).toBeInTheDocument();
   });
 
   it("reveals the selected framework content and dropdown trigger", async () => {

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -43,6 +43,20 @@ const FRAMEWORK_OPTIONS: ReadonlyArray<{
   description: string;
 }> = [
   {
+    id: "iso-27001-2022",
+    label: "ISO/IEC 27001",
+    shortLabel: "ISO 27001",
+    description:
+      "Selected Annex A technology controls mapped to managed-device configuration evidence.",
+  },
+  {
+    id: "soc2-tsc",
+    label: "SOC 2",
+    shortLabel: "SOC 2",
+    description:
+      "Selected Trust Services Criteria mapped to managed-device configuration evidence.",
+  },
+  {
     id: "nist-800-53-r5",
     label: "NIST SP 800-53",
     shortLabel: "NIST 800-53",
@@ -652,7 +666,9 @@ export function ComplianceView({ configurations }: ComplianceViewProps) {
           <motion.div
             layout={!prefersReducedMotion}
             className={
-              selectedFrameworkId ? "grid" : "mt-8 grid gap-4 md:grid-cols-3"
+              selectedFrameworkId
+                ? "grid"
+                : "mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6"
             }
           >
             <AnimatePresence
@@ -720,7 +736,11 @@ export function ComplianceView({ configurations }: ComplianceViewProps) {
                               },
                             }
                       }
-                      className="border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+                      className={`border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none lg:col-span-2 ${
+                        framework.id === "nist-csf-2"
+                          ? "lg:col-start-2 lg:row-start-2"
+                          : ""
+                      }`}
                     >
                       <motion.span
                         layoutId={

--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -1,17 +1,25 @@
 export type FrameworkId =
   | "bsi-it-grundschutz"
   | "nist-800-53-r5"
-  | "nist-csf-2";
+  | "nist-csf-2"
+  | "iso-27001-2022"
+  | "soc2-tsc";
 
-// Text-forward wordmarks only: official government logos and insignia (the
-// NIST logotype, the BSI Bundesadler) must not be reproduced. Naming the
-// standard in our own typography is legitimate nominative use; for BSI the
-// plain national colors provide recognition without any protected emblem.
-const NIST_DETAILS: Partial<
-  Record<FrameworkId, { fill: string; variant: string }>
+// Text-forward wordmarks only: official logos, insignia, and association marks
+// must not be reproduced. The standards are named in our own typography for
+// nominative use; BSI uses plain national colors without a protected emblem.
+const WORDMARK_DETAILS: Record<
+  Exclude<FrameworkId, "bsi-it-grundschutz">,
+  { fill: string; line1: string; line2: string }
 > = {
-  "nist-800-53-r5": { fill: "#1D4ED8", variant: "SP 800-53" },
-  "nist-csf-2": { fill: "#0F766E", variant: "CSF 2.0" },
+  "iso-27001-2022": { fill: "#4338CA", line1: "ISO", line2: "27001" },
+  "soc2-tsc": { fill: "#7E22CE", line1: "SOC 2", line2: "TSC" },
+  "nist-800-53-r5": {
+    fill: "#1D4ED8",
+    line1: "NIST",
+    line2: "SP 800-53",
+  },
+  "nist-csf-2": { fill: "#0F766E", line1: "NIST", line2: "CSF 2.0" },
 };
 
 const FONT_FAMILY = "ui-sans-serif, system-ui, sans-serif";
@@ -59,7 +67,7 @@ export function FrameworkBadge({
     );
   }
 
-  const details = NIST_DETAILS[frameworkId];
+  const details = WORDMARK_DETAILS[frameworkId];
 
   return (
     <svg
@@ -69,7 +77,7 @@ export function FrameworkBadge({
       aria-hidden="true"
       focusable="false"
     >
-      <rect width="40" height="40" rx="6" fill={details?.fill ?? "#334155"} />
+      <rect width="40" height="40" rx="6" fill={details.fill} />
       <text
         x="20"
         y="19"
@@ -80,7 +88,7 @@ export function FrameworkBadge({
         textAnchor="middle"
         letterSpacing="0.6"
       >
-        NIST
+        {details.line1}
       </text>
       <text
         x="20"
@@ -93,7 +101,7 @@ export function FrameworkBadge({
         textAnchor="middle"
         letterSpacing="0.2"
       >
-        {details?.variant ?? ""}
+        {details.line2}
       </text>
     </svg>
   );

--- a/src/lib/__tests__/compliance-engine.test.ts
+++ b/src/lib/__tests__/compliance-engine.test.ts
@@ -6,8 +6,10 @@ import {
   assessFramework,
   BSI_IT_GRUNDSCHUTZ,
   compareControlIds,
+  ISO_27001,
   NIST_800_53,
   NIST_CSF,
+  SOC_2,
 } from "../compliance";
 import { defenderForEndpointPolicyFixture } from "./fixtures/intune-beta";
 
@@ -551,7 +553,7 @@ describe("framework assessment", () => {
     ).toBe("evidenceFound");
   });
 
-  it("produces a full assessment with disclaimer and both frameworks", () => {
+  it("produces a full assessment with disclaimer and all frameworks", () => {
     const data = emptyExportData();
     const assessment = assessCompliance(data);
 
@@ -560,6 +562,8 @@ describe("framework assessment", () => {
       "nist-800-53-r5",
       "nist-csf-2",
       "bsi-it-grundschutz",
+      "iso-27001-2022",
+      "soc2-tsc",
     ]);
     for (const framework of assessment.frameworks) {
       expect(framework.summary.withoutEvidence).toBe(
@@ -573,7 +577,13 @@ describe("framework assessment", () => {
       assessCapabilities(emptyExportData()).map((r) => r.capability.id),
     );
 
-    for (const framework of [NIST_800_53, NIST_CSF, BSI_IT_GRUNDSCHUTZ]) {
+    for (const framework of [
+      NIST_800_53,
+      NIST_CSF,
+      BSI_IT_GRUNDSCHUTZ,
+      ISO_27001,
+      SOC_2,
+    ]) {
       for (const [capabilityId, controlIds] of Object.entries(
         framework.mappings,
       )) {

--- a/src/lib/__tests__/compliance-report.test.ts
+++ b/src/lib/__tests__/compliance-report.test.ts
@@ -152,9 +152,29 @@ describe("compliance report PDF", () => {
     expect(renderedText).toContain("Configuration");
     expect(renderedText).toContain("SC-28");
     expect(renderedText).toContain("Technical configuration evidence detected");
-    expect(renderedText).toContain("neither a certification");
+    expect(renderedText).toContain("not a compliance certification");
     expect(renderedText).toContain("Appendix A: Evidence Register");
     expect(renderedText).not.toContain("Manuelle Bewertung");
+  });
+
+  it("renders English ISO 27001 and SOC 2 reports", async () => {
+    const isoReport = await generateComplianceReportPDF(createExportData(), {
+      frameworkId: "iso-27001-2022",
+    });
+    const isoText = extractPdfStreamText(isoReport);
+
+    expect(isoText).toContain("ISO/IEC 27001");
+    expect(isoText).toContain("8.24");
+    expect(isoText).toContain("Evidence");
+    expect(isoText).toContain("not a compliance certification");
+
+    const soc2Report = await generateComplianceReportPDF(createExportData(), {
+      frameworkId: "soc2-tsc",
+    });
+    const soc2Text = extractPdfStreamText(soc2Report);
+
+    expect(soc2Text).toContain("SOC 2");
+    expect(soc2Text).toContain("CC6.8");
   });
 
   it("labels assigned and unassigned counter-evidence without overstating risk", async () => {
@@ -179,6 +199,12 @@ describe("compliance report PDF", () => {
     );
     expect(complianceReportFileName("nist-csf-2")).toMatch(
       /Compliance-Report-NIST-CSF-2-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
+    );
+    expect(complianceReportFileName("iso-27001-2022")).toMatch(
+      /Compliance-Report-ISO-27001-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
+    );
+    expect(complianceReportFileName("soc2-tsc")).toMatch(
+      /Compliance-Report-SOC-2-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
     );
   });
 

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -1,8 +1,7 @@
 # Compliance evidence engine
 
-Maps an Intune tenant export to evidence for compliance frameworks (currently
-NIST SP 800-53 rev 5, NIST CSF 2.0, and BSI IT-Grundschutz). Not wired into
-the UI yet.
+Maps an Intune tenant export to evidence for ISO/IEC 27001:2022, SOC 2, NIST
+SP 800-53 rev 5, NIST CSF 2.0, and BSI IT-Grundschutz.
 
 ## Design rules
 
@@ -24,8 +23,10 @@ the UI yet.
    (`evidenceFound` / `partialEvidence` / `noEvidence`), never "compliant".
    `COMPLIANCE_DISCLAIMER` must accompany any rendered report.
 6. **Mappings are data.** Capability-to-control tables live in `frameworks/`
-   and can be reviewed without touching detection logic. NIST is public
-   domain; BSI mobile Bausteine (SYS.3.2.1, SYS.3.2.2) are mapped at
+   and can be reviewed without touching detection logic. ISO/IEC 27001 and the
+   SOC 2 Trust Services Criteria are referenced by identifier with original
+   summaries. NIST is public domain; BSI mobile Bausteine (SYS.3.2.1,
+   SYS.3.2.2) are mapped at
    requirement level, verified against the Edition 2023 Baustein PDFs, while
    the remaining Bausteine stay at Baustein level until verified the same way.
    Only requirements with technical Intune evidence are listed as controls;

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -2,8 +2,10 @@ import type { DetailedExportData } from "../configuration-analyzer";
 import type { ConfigurationSettingInstance } from "../intune-detailed-client";
 import { COMPLIANCE_CAPABILITIES } from "./capabilities";
 import { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
+import { ISO_27001 } from "./frameworks/iso-27001";
 import { NIST_800_53 } from "./frameworks/nist-800-53";
 import { NIST_CSF } from "./frameworks/nist-csf";
+import { SOC_2 } from "./frameworks/soc2";
 import type {
   AssignmentSummary,
   CapabilityEvidence,
@@ -424,6 +426,8 @@ export function assessCompliance(
       assessFramework(capabilities, NIST_800_53),
       assessFramework(capabilities, NIST_CSF),
       assessFramework(capabilities, BSI_IT_GRUNDSCHUTZ),
+      assessFramework(capabilities, ISO_27001),
+      assessFramework(capabilities, SOC_2),
     ],
   };
 }

--- a/src/lib/compliance/frameworks/iso-27001.ts
+++ b/src/lib/compliance/frameworks/iso-27001.ts
@@ -1,0 +1,87 @@
+import type { FrameworkDefinition } from "../types";
+
+// ISO/IEC 27001 is referenced by control number only. Titles and summaries are
+// original descriptions written for this device-management evidence mapping.
+export const ISO_27001: FrameworkDefinition = {
+  id: "iso-27001-2022",
+  name: "ISO/IEC 27001",
+  version: "2022, Annex A",
+  note: "Device-management evidence for selected technological (Annex A clause 8) controls, referenced by control number with original summaries. Organizational, people, and physical controls are out of scope for an Intune tenant export.",
+  controls: {
+    "8.1": {
+      id: "8.1",
+      title: "User endpoint devices",
+      summary:
+        "Endpoint devices that handle organizational information are secured through managed protections.",
+    },
+    "8.5": {
+      id: "8.5",
+      title: "Secure authentication",
+      summary:
+        "Authentication is required before users can access managed devices, including through device-unlock controls.",
+    },
+    "8.7": {
+      id: "8.7",
+      title: "Protection against malware",
+      summary:
+        "Antimalware protections are implemented and maintained on managed endpoints.",
+    },
+    "8.8": {
+      id: "8.8",
+      title: "Technical vulnerability management",
+      summary:
+        "Technical vulnerabilities are addressed through timely operating system updates and enforced minimum versions.",
+    },
+    "8.9": {
+      id: "8.9",
+      title: "Configuration management",
+      summary:
+        "Secure device configurations are defined and enforced across managed platforms.",
+    },
+    "8.19": {
+      id: "8.19",
+      title: "Software installation control",
+      summary:
+        "Software installation on managed systems is limited to approved sources and trusted applications.",
+    },
+    "8.20": {
+      id: "8.20",
+      title: "Network security",
+      summary:
+        "Managed device network connections are protected with enforced host firewall controls.",
+    },
+    "8.24": {
+      id: "8.24",
+      title: "Use of cryptography",
+      summary:
+        "Cryptographic safeguards protect information stored on managed devices.",
+    },
+  },
+  mappings: {
+    "windows-disk-encryption": ["8.1", "8.24"],
+    "macos-disk-encryption": ["8.1", "8.24"],
+    "android-storage-encryption": ["8.1", "8.24"],
+    "windows-realtime-antimalware": ["8.7"],
+    "windows-firewall": ["8.20"],
+    "macos-firewall": ["8.20"],
+    "windows-password-required": ["8.5"],
+    "macos-password-required": ["8.5"],
+    "ios-passcode-required": ["8.5"],
+    "android-password-required": ["8.5"],
+    "windows-automatic-updates": ["8.8"],
+    "windows-minimum-os-version": ["8.8"],
+    "macos-minimum-os-version": ["8.8"],
+    "ios-minimum-os-version": ["8.8"],
+    "android-minimum-os-version": ["8.8"],
+    "windows-secure-boot": ["8.9"],
+    "windows-code-integrity": ["8.9"],
+    "macos-system-integrity": ["8.9"],
+    "windows-telemetry-minimized": ["8.9"],
+    "windows-cortana-disabled": ["8.9"],
+    "windows-microsoft-account-blocked": ["8.9"],
+    "ios-jailbreak-block": ["8.1", "8.9"],
+    "android-device-integrity": ["8.1", "8.9"],
+    "macos-gatekeeper": ["8.19"],
+    "android-app-source-restriction": ["8.19"],
+  },
+};

--- a/src/lib/compliance/frameworks/soc2.ts
+++ b/src/lib/compliance/frameworks/soc2.ts
@@ -1,0 +1,69 @@
+import type { FrameworkDefinition } from "../types";
+
+// The AICPA Trust Services Criteria are referenced by criterion ID only.
+// Titles and summaries are original descriptions written for this mapping.
+export const SOC_2: FrameworkDefinition = {
+  id: "soc2-tsc",
+  name: "SOC 2",
+  version: "Trust Services Criteria",
+  note: "Device-management evidence for selected Common Criteria, referenced by criterion ID with original summaries. A SOC 2 examination covers far more than device configuration; this mapping supports evidence collection only.",
+  controls: {
+    "CC6.1": {
+      id: "CC6.1",
+      title: "Logical access controls",
+      summary:
+        "Managed systems use logical access measures, including device authentication and encryption of stored data.",
+    },
+    "CC6.6": {
+      id: "CC6.6",
+      title: "Protection against external threats",
+      summary:
+        "Boundary protections, including host firewalls, defend managed devices against external threats.",
+    },
+    "CC6.7": {
+      id: "CC6.7",
+      title: "Restricted data movement",
+      summary:
+        "Information movement and transmission are limited by controls that reduce external data sharing.",
+    },
+    "CC6.8": {
+      id: "CC6.8",
+      title: "Unauthorized software prevention",
+      summary:
+        "Controls prevent or detect unauthorized and malicious software on managed devices.",
+    },
+    "CC7.1": {
+      id: "CC7.1",
+      title: "Vulnerability and configuration monitoring",
+      summary:
+        "Managed endpoint configurations and software versions are monitored and maintained to address vulnerabilities.",
+    },
+  },
+  mappings: {
+    "windows-disk-encryption": ["CC6.1"],
+    "macos-disk-encryption": ["CC6.1"],
+    "android-storage-encryption": ["CC6.1"],
+    "windows-password-required": ["CC6.1"],
+    "macos-password-required": ["CC6.1"],
+    "ios-passcode-required": ["CC6.1"],
+    "android-password-required": ["CC6.1"],
+    "windows-microsoft-account-blocked": ["CC6.1"],
+    "windows-firewall": ["CC6.6"],
+    "macos-firewall": ["CC6.6"],
+    "windows-telemetry-minimized": ["CC6.7"],
+    "windows-realtime-antimalware": ["CC6.8"],
+    "macos-gatekeeper": ["CC6.8"],
+    "android-app-source-restriction": ["CC6.8"],
+    "windows-cortana-disabled": ["CC6.8"],
+    "ios-jailbreak-block": ["CC6.8"],
+    "android-device-integrity": ["CC6.8"],
+    "windows-secure-boot": ["CC6.8"],
+    "windows-code-integrity": ["CC6.8"],
+    "macos-system-integrity": ["CC6.8"],
+    "windows-automatic-updates": ["CC7.1"],
+    "windows-minimum-os-version": ["CC7.1"],
+    "macos-minimum-os-version": ["CC7.1"],
+    "ios-minimum-os-version": ["CC7.1"],
+    "android-minimum-os-version": ["CC7.1"],
+  },
+};

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -10,6 +10,8 @@ export { COMPLIANCE_CAPABILITIES } from "./capabilities";
 export { NIST_800_53 } from "./frameworks/nist-800-53";
 export { NIST_CSF } from "./frameworks/nist-csf";
 export { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
+export { ISO_27001 } from "./frameworks/iso-27001";
+export { SOC_2 } from "./frameworks/soc2";
 export type {
   CapabilityEvidence,
   CapabilityResult,

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -18,7 +18,9 @@ import type {
 export type ComplianceFrameworkId =
   | "nist-800-53-r5"
   | "nist-csf-2"
-  | "bsi-it-grundschutz";
+  | "bsi-it-grundschutz"
+  | "iso-27001-2022"
+  | "soc2-tsc";
 
 type Locale = "en" | "de";
 type RgbColor = [number, number, number];
@@ -164,7 +166,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     gapIntro:
       "No technical evidence was found. Possible implementation through these Intune settings:",
     disclaimer:
-      "This report documents technical evidence from the tenant's Microsoft Intune configuration. It is neither a certification nor an IT Grundschutz check and does not replace an audit. Missing evidence means that no supported and effectively assigned configuration was detected in the evaluated dataset.",
+      "This report documents technical evidence from the tenant's Microsoft Intune configuration. It is not a compliance certification or an IT Grundschutz check and does not replace an audit. Missing evidence means that no supported and effectively assigned configuration was detected in the evaluated dataset.",
     appendixHeading: "Appendix A: Evidence Register",
     appendixContinuation: "Appendix A (continued)",
     appendixHeaders: [
@@ -196,6 +198,8 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "nist-800-53-r5": "NIST-800-53-R5",
       "nist-csf-2": "NIST-CSF-2",
       "bsi-it-grundschutz": "BSI-IT-Grundschutz",
+      "iso-27001-2022": "ISO-27001",
+      "soc2-tsc": "SOC-2",
     },
   },
   de: {
@@ -319,6 +323,8 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "nist-800-53-r5": "NIST-800-53-R5",
       "nist-csf-2": "NIST-CSF-2",
       "bsi-it-grundschutz": "BSI-IT-Grundschutz",
+      "iso-27001-2022": "ISO-27001",
+      "soc2-tsc": "SOC-2",
     },
   },
 };
@@ -443,10 +449,16 @@ function tenantSlug(value: string): string {
     .slice(0, 64);
 }
 
+const FRAMEWORK_REPORT_CODES: Record<ComplianceFrameworkId, string> = {
+  "nist-800-53-r5": "N53",
+  "nist-csf-2": "CSF",
+  "bsi-it-grundschutz": "BSI",
+  "iso-27001-2022": "ISO",
+  "soc2-tsc": "SOC",
+};
+
 function frameworkReportCode(frameworkId: ComplianceFrameworkId): string {
-  if (frameworkId === "bsi-it-grundschutz") return "BSI";
-  if (frameworkId === "nist-800-53-r5") return "N53";
-  return "CSF";
+  return FRAMEWORK_REPORT_CODES[frameworkId];
 }
 
 function randomReportSuffix(): string {
@@ -554,9 +566,9 @@ function buildOverviewRows(
   const controlsByPrefix = new Map<string, ControlAssessment[]>();
   for (const control of controls) {
     const prefix =
-      frameworkId === "nist-csf-2"
-        ? control.control.id.split(".")[0]
-        : control.control.id.split("-")[0];
+      frameworkId === "nist-800-53-r5"
+        ? control.control.id.split("-")[0]
+        : control.control.id.split(".")[0];
     if (!prefix) continue;
     const existing = controlsByPrefix.get(prefix);
     if (existing) existing.push(control);
@@ -1332,6 +1344,8 @@ export async function generateComplianceReportPDF(
   const frameworkDisplay =
     options.frameworkId === "bsi-it-grundschutz"
       ? "BSI IT-Grundschutz-Kompendium, Edition 2023"
+      : options.frameworkId === "iso-27001-2022"
+        ? "ISO/IEC 27001:2022, Annex A"
       : `${framework.framework.name} ${framework.framework.version}`;
   doc.text(frameworkDisplay, pageWidth / 2, frameworkY, { align: "center" });
 


### PR DESCRIPTION
## Summary

Adds two frameworks as pure data mappings over the existing 25 capabilities:

- ISO/IEC 27001:2022: eight Annex A technological controls (8.1 user endpoint devices, 8.5 secure authentication, 8.7 malware protection, 8.8 technical vulnerability management, 8.9 configuration management, 8.19 software installation control, 8.20 network security, 8.24 use of cryptography), referenced by number with original summaries; no standard text reproduced
- SOC 2: five Trust Services Criteria (CC6.1, CC6.6, CC6.7, CC6.8, CC7.1), referenced by ID with original summaries

Both generate full English reports through the existing audit-grade pipeline with the established selected-controls scope disclosure. The framework picker and dropdown now list five frameworks (ISO and SOC 2 first) with text-only wordmark badges; the /compliance page lists all five.

## Test plan

- 90 unit tests passing, including new ISO/SOC 2 report content tests, mapping consistency across all five frameworks, and a five-card picker test
- tsc, lint (no new warnings), and next build clean