### PR TITLE
Resolve group display names for compliance evidence and reports

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -149,7 +149,13 @@ const dashboardCache: {
   accountId: string | null;
   configurations: IntuneConfigurations | null;
   lastFetched: Date | null;
-} = { accountId: null, configurations: null, lastFetched: null };
+  groupNames: Map<string, string> | null;
+} = {
+  accountId: null,
+  configurations: null,
+  lastFetched: null,
+  groupNames: null,
+};
 
 export default function DashboardPage() {
   const { instance, accounts, inProgress } = useMsal();
@@ -168,6 +174,9 @@ export default function DashboardPage() {
   );
   const [selectAll, setSelectAll] = useState(false);
   const [lastFetched, setLastFetched] = useState<Date | null>(null);
+  const [groupNames, setGroupNames] = useState<Map<string, string> | null>(
+    null,
+  );
   const [searchQuery, setSearchQuery] = useState("");
   const [showTipBanner, setShowTipBanner] = useState(true);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -262,6 +271,7 @@ export default function DashboardPage() {
       ) {
         setConfigurations(dashboardCache.configurations);
         setLastFetched(dashboardCache.lastFetched);
+        setGroupNames(dashboardCache.groupNames);
         setHasCompletedInitialLoad(true);
         setLoading(false);
         return;
@@ -275,8 +285,58 @@ export default function DashboardPage() {
       dashboardCache.accountId = accounts[0]?.homeAccountId ?? null;
       dashboardCache.configurations = configurations;
       dashboardCache.lastFetched = lastFetched;
+      dashboardCache.groupNames = groupNames;
     }
-  }, [loading, configurations, lastFetched, accounts]);
+  }, [loading, configurations, lastFetched, groupNames, accounts]);
+
+  // Resolve assignment group ids to display names once a fetch settles, so
+  // the dashboard and compliance reports show real group names, not GUIDs.
+  useEffect(() => {
+    if (loading || !hasCompletedInitialLoad || !configurations) return;
+    if (groupNames !== null) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const groupIds = new Set<string>();
+        for (const section of configurations.sections ?? []) {
+          for (const item of section.items) {
+            for (const assignment of item.assignments ?? []) {
+              const groupId = assignment?.target?.groupId;
+              if (typeof groupId === "string" && groupId) {
+                groupIds.add(groupId);
+              }
+            }
+            const users = item.conditions?.users;
+            for (const id of [
+              ...(users?.includeGroups ?? []),
+              ...(users?.excludeGroups ?? []),
+            ]) {
+              if (typeof id === "string" && id) groupIds.add(id);
+            }
+          }
+        }
+        if (groupIds.size === 0) {
+          if (!cancelled) setGroupNames(new Map());
+          return;
+        }
+        const token = await getAccessToken();
+        const { GroupResolver } = await import("~/lib/group-resolver");
+        const resolver = new GroupResolver(token);
+        const resolved = await resolver.getGroupNames([...groupIds]);
+        if (!cancelled) setGroupNames(resolved);
+      } catch (error) {
+        console.error("Failed to resolve group names:", error);
+        if (!cancelled) setGroupNames(new Map());
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // getAccessToken is stable in behavior but recreated per render; adding it
+    // would re-run the resolver on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, hasCompletedInitialLoad, configurations, groupNames]);
 
   useEffect(() => {
     if (window.innerWidth < 768) {
@@ -344,6 +404,7 @@ export default function DashboardPage() {
       isFetchingRef.current = true;
       setLoading(true);
       setError(null);
+      setGroupNames(null);
       // Reset selections when refreshing
       setSelectedConfigs(new Set());
       setSelectAll(false);
@@ -852,6 +913,7 @@ export default function DashboardPage() {
         />
         <DashboardContent
           configurations={configurations}
+          groupNames={groupNames}
           activeView={activeView}
           searchQuery={searchQuery}
           selectedConfigs={selectedConfigs}

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -202,6 +202,36 @@ describe("ComplianceView", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows resolved group names in evidence when a name map is provided", async () => {
+    const user = userEvent.setup();
+    const grouped = structuredClone(configurations);
+    const firstItem = grouped.sections[0]?.items[0];
+    if (firstItem) {
+      firstItem.assignments = [
+        {
+          id: "assignment-1",
+          target: {
+            "@odata.type": "#microsoft.graph.groupAssignmentTarget",
+            groupId: "group-1",
+          },
+        },
+      ];
+    }
+    render(
+      <ComplianceView
+        configurations={grouped}
+        groupNames={new Map([["group-1", "Security Operations"]])}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "NIST SP 800-53" }));
+    const sc28Control = await screen.findByRole("button", { name: /SC-28/ });
+    await user.click(sc28Control);
+
+    expect(screen.getByText(/Security Operations/)).toBeInTheDocument();
+    expect(screen.queryByText(/group-1/)).not.toBeInTheDocument();
+  });
+
   it("distinguishes assigned and unassigned deviating configurations", async () => {
     const user = userEvent.setup();
     const counterConfigurations: IntuneConfigurations = {

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -32,6 +32,7 @@ import type {
 
 interface ComplianceViewProps {
   configurations: IntuneConfigurations;
+  groupNames?: Map<string, string> | null;
 }
 
 const FRAMEWORK_STORAGE_KEY = "compliance-framework";
@@ -439,12 +440,23 @@ function ComplianceHeader({
   );
 }
 
-export function ComplianceView({ configurations }: ComplianceViewProps) {
+export function ComplianceView({
+  configurations,
+  groupNames,
+}: ComplianceViewProps) {
   const { accounts } = useMsal();
   const prefersReducedMotion = useReducedMotion();
+  const assessmentData = useMemo(
+    () =>
+      ({
+        ...configurations,
+        groupNames: groupNames ?? undefined,
+      }) as unknown as DetailedExportData,
+    [configurations, groupNames],
+  );
   const assessment = useMemo(
-    () => assessCompliance(configurations as unknown as DetailedExportData),
-    [configurations],
+    () => assessCompliance(assessmentData),
+    [assessmentData],
   );
   const [selectedFrameworkId, setSelectedFrameworkId] =
     useState<FrameworkId | null>(null);
@@ -584,9 +596,7 @@ export function ComplianceView({ configurations }: ComplianceViewProps) {
     try {
       const { generateComplianceReportPDF, complianceReportFileName } =
         await import("~/lib/compliance/report-pdf");
-      const bytes = await generateComplianceReportPDF(
-        configurations as unknown as DetailedExportData,
-        {
+      const bytes = await generateComplianceReportPDF(assessmentData, {
           frameworkId: selectedFrameworkId,
           metadata: tenantLabel ? { tenantLabel } : undefined,
         },

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -19,6 +19,7 @@ import { DASHBOARD_VIEW_LABELS } from "~/components/dashboard/types";
 
 interface DashboardContentProps {
   configurations: IntuneConfigurations;
+  groupNames?: Map<string, string> | null;
   activeView: DashboardView;
   searchQuery: string;
   selectedConfigs: Set<string>;
@@ -192,6 +193,7 @@ function SettingsView({
 
 export function DashboardContent({
   configurations,
+  groupNames,
   activeView,
   searchQuery,
   selectedConfigs,
@@ -305,7 +307,10 @@ export function DashboardContent({
             onIncludeCAChange={onIncludeCAChange}
           />
         ) : activeView === "compliance" ? (
-          <ComplianceView configurations={configurations} />
+          <ComplianceView
+            configurations={configurations}
+            groupNames={groupNames}
+          />
         ) : (
           <>
             <SelectionToolbar

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -2645,7 +2645,7 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           policy.displayName || policy.name,
-          parseAssignments(policy.assignments),
+          enhanceAssignmentText(parseAssignments(policy.assignments)),
           policy.createdDateTime,
           policy.lastModifiedDateTime,
         );


### PR DESCRIPTION
## Summary

The documentation exports already resolved assignment group names, but the dashboard fetch flow never did, so the Compliance Evidence view and the compliance report PDFs showed raw GUIDs. Group.Read.All was already in the delegated scopes, so this is pure wiring:

- After each fetch settles, the dashboard collects every assigned group id (plus Conditional Access include/exclude groups) and resolves them in one batched Graph call, cached for the session alongside the tenant data
- The Compliance Evidence view and its report PDFs receive the map, so evidence rows and the evidence register show display names; failures degrade silently to ids
- Fixes the one documentation-PDF section (Windows Update Policies) that bypassed name substitution

## Test plan

- 91 unit tests passing, including a new test asserting a provided name map surfaces in evidence and the GUID does not
- tsc, lint (no new warnings), and next build clean