### PR TITLE
Expand compliance frameworks and harden evidence assessment

### DIFF
--- a/src/app/api/intune/check-permissions/route.ts
+++ b/src/app/api/intune/check-permissions/route.ts
@@ -7,6 +7,7 @@ interface PermissionCheck {
   permission: string;
   resource: string;
   hasAccess: boolean;
+  status: "granted" | "denied" | "unavailable";
   error?: string;
 }
 
@@ -36,41 +37,49 @@ export async function GET(request: NextRequest) {
         permission: "DeviceManagementConfiguration.Read.All",
         resource: "Device Configurations",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "DeviceManagementScripts.Read.All",
         resource: "PowerShell/Shell Scripts",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "DeviceManagementApps.Read.All",
         resource: "App Configurations",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "DeviceManagementManagedDevices.Read.All",
         resource: "Managed Devices",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "DeviceManagementRBAC.Read.All",
         resource: "RBAC Settings",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "DeviceManagementServiceConfig.Read.All",
         resource: "Service Configuration",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "Group.Read.All",
         resource: "Group Information",
         hasAccess: false,
+        status: "unavailable",
       },
       {
         permission: "Policy.Read.All",
         resource: "Conditional Access Policies",
         hasAccess: false,
+        status: "unavailable",
       },
     ];
 
@@ -86,6 +95,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "DeviceManagementScripts.Read.All":
@@ -96,6 +106,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "DeviceManagementApps.Read.All":
@@ -106,6 +117,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "DeviceManagementManagedDevices.Read.All":
@@ -116,6 +128,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "DeviceManagementRBAC.Read.All":
@@ -126,6 +139,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "DeviceManagementServiceConfig.Read.All":
@@ -135,6 +149,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "Group.Read.All":
@@ -145,6 +160,7 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
 
           case "Policy.Read.All":
@@ -155,11 +171,13 @@ export async function GET(request: NextRequest) {
               .select("id")
               .get();
             check.hasAccess = true;
+            check.status = "granted";
             break;
         }
       } catch (error: any) {
         if (error?.statusCode === 403 || error?.code === "Forbidden") {
           check.hasAccess = false;
+          check.status = "denied";
           check.error = "Insufficient permissions";
         } else {
           // Other errors might be transient
@@ -176,7 +194,8 @@ export async function GET(request: NextRequest) {
     const summary = {
       totalPermissions: results.length,
       granted: results.filter((r) => r.hasAccess).length,
-      denied: results.filter((r) => !r.hasAccess).length,
+      denied: results.filter((r) => r.status === "denied").length,
+      unavailable: results.filter((r) => r.status === "unavailable").length,
       requiredForFullAccess: [
         "DeviceManagementConfiguration.Read.All",
         "DeviceManagementScripts.Read.All",

--- a/src/app/api/intune/detailed-configurations-stream/route.ts
+++ b/src/app/api/intune/detailed-configurations-stream/route.ts
@@ -150,6 +150,9 @@ export async function GET(request: NextRequest) {
         // Send final data
         sendEvent("complete", {
           data: {
+            collectedAt: configurations.collectedAt,
+            collectionStartedAt: configurations.collectionStartedAt,
+            collectionSkippedFamilies: configurations.collectionSkippedFamilies,
             permissionErrors: configurations.permissionErrors,
             fetchErrors: configurations.fetchErrors,
             summary: configurations.summary,

--- a/src/app/api/intune/detailed-configurations-stream/route.ts
+++ b/src/app/api/intune/detailed-configurations-stream/route.ts
@@ -21,11 +21,15 @@ export async function GET(request: NextRequest) {
   // Create a readable stream for Server-Sent Events
   const encoder = new TextEncoder();
 
+  let closed = false;
+  const cancelled = new AbortController();
+  const signal = AbortSignal.any([request.signal, cancelled.signal]);
   const stream = new ReadableStream({
     async start(controller) {
       try {
         // Helper function to send SSE event
         const sendEvent = (event: string, data: any) => {
+          if (closed || signal.aborted) return;
           const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
           controller.enqueue(encoder.encode(message));
         };
@@ -100,6 +104,7 @@ export async function GET(request: NextRequest) {
               status: "loading",
             });
           },
+          signal,
         );
 
         // Mark connection as completed
@@ -138,18 +143,15 @@ export async function GET(request: NextRequest) {
           includeConditionalAccess,
         );
 
-        // Safety net: ensure every step reads as completed before the payload
-        policyTypes.forEach((type) => {
-          sendEvent("progress", {
-            step: type.name,
-            stepIndex: type.stepIndex,
-            status: "completed",
-          });
-        });
+        const incomplete =
+          configurations.fetchErrors.length > 0 ||
+          configurations.permissionErrors.length > 0 ||
+          configurations.sections.some((section) => !!section.error);
 
         // Send final data
         sendEvent("complete", {
           data: {
+            collectionStatus: incomplete ? "incomplete" : "complete",
             collectedAt: configurations.collectedAt,
             collectionStartedAt: configurations.collectionStartedAt,
             collectionSkippedFamilies: configurations.collectionSkippedFamilies,
@@ -157,11 +159,16 @@ export async function GET(request: NextRequest) {
             fetchErrors: configurations.fetchErrors,
             summary: configurations.summary,
           },
-          message: "All configurations fetched successfully",
+          message: incomplete
+            ? "Collection finished with incomplete results"
+            : "All configurations fetched successfully",
         });
 
         // Close the stream
-        controller.close();
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
       } catch (error: any) {
         console.error("Error in SSE stream:", error);
 
@@ -170,9 +177,17 @@ export async function GET(request: NextRequest) {
           details: error?.stack,
         })}\n\n`;
 
-        controller.enqueue(encoder.encode(errorMessage));
-        controller.close();
+        if (!closed && !signal.aborted)
+          controller.enqueue(encoder.encode(errorMessage));
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
       }
+    },
+    cancel() {
+      closed = true;
+      cancelled.abort(new DOMException("Client disconnected", "AbortError"));
     },
   });
 

--- a/src/app/api/intune/detailed-configurations/route.ts
+++ b/src/app/api/intune/detailed-configurations/route.ts
@@ -2,28 +2,37 @@ import { type NextRequest, NextResponse } from "next/server";
 import { DetailedIntuneService } from "~/lib/intune-detailed-client";
 import { extractTenantFromRequest } from "~/lib/auth-middleware";
 
+export const maxDuration = 120;
+
 export async function GET(request: NextRequest) {
   try {
     // Log tenant access
     extractTenantFromRequest(request);
-    
+
     const authHeader = request.headers.get("Authorization");
-    
+
     if (!authHeader?.startsWith("Bearer ")) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     const accessToken = authHeader.replace("Bearer ", "");
-    const service = new DetailedIntuneService(accessToken);
-    
+    const service = new DetailedIntuneService(
+      accessToken,
+      undefined,
+      request.signal,
+    );
+
     const configurations = await service.getAllDetailedConfigurations();
 
     return NextResponse.json(configurations);
   } catch (error) {
     console.error("Error fetching detailed Intune configurations:", error);
     return NextResponse.json(
-      { error: "Failed to fetch detailed configurations", details: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 }
+      {
+        error: "Failed to fetch detailed configurations",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
     );
   }
 }

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -7,12 +7,12 @@ import { BackToTopButton } from "~/components/back-to-top-button";
 export const metadata: Metadata = {
   title: "Compliance Evidence for Intune",
   description:
-    "Map your Microsoft Intune configuration to ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz. Audit-ready evidence reports, generated from your tenant documentation.",
+    "Map your Microsoft Intune configuration to ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, and Cyber Essentials. Audit-ready evidence reports, generated from your tenant documentation.",
   alternates: { canonical: "/compliance" },
   openGraph: {
     title: "Compliance Evidence for Intune | Intune Documentation",
     description:
-      "Turn your Intune tenant documentation into audit evidence for ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST CSF 2.0, and BSI IT-Grundschutz.",
+      "Turn your Intune tenant documentation into audit evidence for ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, and Cyber Essentials.",
     url: "/compliance",
     type: "website",
   },
@@ -38,6 +38,21 @@ const frameworks = [
     name: "NIST Cybersecurity Framework 2.0",
     detail:
       "Evidence for Protect and Detect subcategories, from PR.DS-01 (data-at-rest protection) to DE.CM-09 (endpoint monitoring).",
+  },
+  {
+    name: "UK MOD Def Stan 05-138 (Issue 4)",
+    detail:
+      "Selected Objective B controls for defence suppliers under DEFCON 658, referenced by control identifier with the Cyber Risk Profile levels at which each applies.",
+  },
+  {
+    name: "NCSC Cyber Essentials",
+    detail:
+      "The five control themes (firewalls, secure configuration, security update management, user access control, malware protection) mapped to managed-device configuration evidence.",
+  },
+  {
+    name: "NIST SP 800-171 (Rev. 2)",
+    detail:
+      "Requirements for protecting controlled unclassified information, in the revision incorporated into CMMC 2.0 Level 2, such as 3.13.16 (CUI at rest) and 3.14.2 (malicious code protection).",
   },
   {
     name: "BSI IT-Grundschutz",
@@ -201,7 +216,10 @@ export default function CompliancePage() {
             ISO/IEC 27001 and SOC 2 criteria are referenced by identifier with
             original summaries. NIST publications are used with their
             public-domain status; BSI IT-Grundschutz is referenced from the
-            freely published Kompendium.
+            freely published Kompendium. Def Stan 05-138 is referenced by
+            control identifier with original summaries. Cyber Essentials content
+            is used under the Open Government Licence v3.0, and evidence never
+            indicates certification.
           </p>
         </div>
       </main>

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -52,7 +52,12 @@ const frameworks = [
   {
     name: "NIST SP 800-171 (Rev. 2)",
     detail:
-      "Requirements for protecting controlled unclassified information, in the revision incorporated into CMMC 2.0 Level 2, such as 3.13.16 (CUI at rest) and 3.14.2 (malicious code protection).",
+      "Supporting Intune evidence for 11 of 110 published requirements in the revision used by CMMC Level 2. Covers selected encryption, authentication, hardening and malware protections. This is not a complete CMMC assessment or an SPRS score.",
+  },
+  {
+    name: "NIST SP 800-171 (Rev. 3)",
+    detail:
+      "Supporting Intune evidence for 11 of 97 published requirements in the May 2024 revision, including MFA, application control, storage encryption and malicious code protection. Organization-defined parameters and remaining requirements need separate assessment. Revision 2 remains separately available for CMMC Level 2.",
   },
   {
     name: "BSI IT-Grundschutz",

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -7,18 +7,23 @@ import { BackToTopButton } from "~/components/back-to-top-button";
 export const metadata: Metadata = {
   title: "Compliance Evidence for Intune",
   description:
-    "Map your Microsoft Intune configuration to ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, and Cyber Essentials. Audit-ready evidence reports, generated from your tenant documentation.",
+    "Map your Microsoft Intune configuration to ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, Cyber Essentials, and ASD Essential Eight target Maturity Levels 1, 2 and 3. Audit-ready evidence reports, generated from your tenant documentation.",
   alternates: { canonical: "/compliance" },
   openGraph: {
     title: "Compliance Evidence for Intune | Intune Documentation",
     description:
-      "Turn your Intune tenant documentation into audit evidence for ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, and Cyber Essentials.",
+      "Turn your Intune tenant documentation into audit evidence for ISO/IEC 27001, SOC 2, NIST SP 800-53, NIST SP 800-171, NIST CSF 2.0, BSI IT-Grundschutz, UK MOD Def Stan 05-138, Cyber Essentials, and ASD Essential Eight target Maturity Levels 1, 2 and 3.",
     url: "/compliance",
     type: "website",
   },
 };
 
 const frameworks = [
+  {
+    name: "ASD Essential Eight (Maturity Levels 1, 2 and 3)",
+    detail:
+      "Choose a target maturity level in the dashboard. All eight strategies are included, with 48, 107 and 149 requirement entries for Levels 1, 2 and 3 respectively, based on ASD’s November 2023 model. Supporting Intune evidence is mapped to 3, 8 and 10 requirements respectively. Other requirements remain explicitly unassessed; the tool does not calculate an achieved maturity level.",
+  },
   {
     name: "ISO/IEC 27001:2022",
     detail:
@@ -205,7 +210,9 @@ export default function CompliancePage() {
             <p className="mb-5 text-sm leading-relaxed text-slate-600">
               The compliance evidence view is available in the dashboard for
               every signed-in user. Review framework controls and download full
-              requirement-level reports as PDF.
+              requirement-level reports as PDF. For ASD Essential Eight, select
+              Maturity Level 1, 2 or 3 to review evidence against that target
+              and include it in your PDF report and JSON evidence record.
             </p>
             <Link
               href="/dashboard"
@@ -224,7 +231,24 @@ export default function CompliancePage() {
             freely published Kompendium. Def Stan 05-138 is referenced by
             control identifier with original summaries. Cyber Essentials content
             is used under the Open Government Licence v3.0, and evidence never
-            indicates certification.
+            indicates certification. Essential Eight requirement text is
+            attributed to the Australian Signals Directorate, © Commonwealth of
+            Australia 2026, under CC BY 4.0. Local requirement identifiers and
+            evidence mappings are additions by Intune Documentation.{" "}
+            <a
+              href="https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-maturity-model"
+              className="underline"
+            >
+              ASD maturity model
+            </a>
+            {" · "}
+            <a
+              href="https://creativecommons.org/licenses/by/4.0/"
+              className="underline"
+            >
+              CC BY 4.0 licence
+            </a>
+            .
           </p>
         </div>
       </main>

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -57,7 +57,7 @@ const frameworks = [
   {
     name: "NIST SP 800-171 (Rev. 2)",
     detail:
-      "Supporting Intune evidence for 11 of 110 published requirements in the revision used by CMMC Level 2. Covers selected encryption, authentication, hardening and malware protections. This is not a complete CMMC assessment or an SPRS score.",
+      "Supporting Intune evidence for 12 of 110 published requirements in the revision used by CMMC Level 2. Covers selected encryption, authentication, hardening and malware protections. This is not a complete CMMC assessment or an SPRS score.",
   },
   {
     name: "NIST SP 800-171 (Rev. 3)",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -574,6 +574,10 @@ export default function DashboardPage() {
                       setHasCompletedInitialLoad(true);
                       setConfigurations((current) => ({
                         ...(current || EMPTY_CONFIGURATIONS),
+                        collectedAt: data.data.collectedAt,
+                        collectionStartedAt: data.data.collectionStartedAt,
+                        collectionSkippedFamilies:
+                          data.data.collectionSkippedFamilies,
                         permissionErrors: data.data.permissionErrors || [],
                         fetchErrors: data.data.fetchErrors || [],
                         summary:

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -95,7 +95,16 @@ describe("ComplianceView", () => {
     expect(
       screen.getByRole("button", { name: "BSI IT-Grundschutz" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button")).toHaveLength(5);
+    expect(
+      screen.getByRole("button", { name: "Def Stan 05-138" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cyber Essentials" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "NIST SP 800-171" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(8);
     expect(
       screen.queryByRole("button", { name: /Download report/ }),
     ).not.toBeInTheDocument();

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -83,9 +83,7 @@ describe("ComplianceView", () => {
     expect(
       screen.getByRole("button", { name: "ISO/IEC 27001" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "SOC 2" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "SOC 2" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "NIST SP 800-53" }),
     ).toBeInTheDocument();
@@ -102,9 +100,12 @@ describe("ComplianceView", () => {
       screen.getByRole("button", { name: "Cyber Essentials" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "NIST SP 800-171" }),
+      screen.getByRole("button", { name: "NIST SP 800-171 Rev. 2" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button")).toHaveLength(8);
+    expect(
+      screen.getByRole("button", { name: "NIST SP 800-171 Rev. 3" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(9);
     expect(
       screen.queryByRole("button", { name: /Download report/ }),
     ).not.toBeInTheDocument();
@@ -127,6 +128,42 @@ describe("ComplianceView", () => {
     expect(
       await screen.findByRole("button", { name: /8\.24/ }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps the stored Revision 2 selection and switches to an independent Revision 3 assessment", async () => {
+    window.localStorage.setItem("compliance-framework", "nist-800-171-r2");
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+    const selector = await screen.findByRole("button", {
+      name: "Selected framework: NIST SP 800-171 Rev. 2",
+    });
+    expect(
+      screen.getByText(/11 of 110 published requirements/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /3\.13\.16/ }),
+    ).toBeInTheDocument();
+    await user.click(selector);
+    await user.click(
+      screen.getByRole("menuitem", { name: /NIST SP 800-171 Rev\. 3/ }),
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: "Selected framework: NIST SP 800-171 Rev. 3",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/11 of 97 published requirements/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /03\.13\.08/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /3\.13\.16/ }),
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("compliance-framework")).toBe(
+      "nist-800-171-r3",
+    );
   });
 
   it("reveals the selected framework content and dropdown trigger", async () => {
@@ -284,7 +321,7 @@ describe("ComplianceView", () => {
     await user.click(screen.getByRole("button", { name: /NET.3.2/ }));
 
     expect(
-      screen.getByText("Deviating configuration detected"),
+      screen.getByText("Non-enforcing setting detected"),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Deviating configuration detected and assigned (risk)"),
@@ -333,5 +370,60 @@ describe("ComplianceView", () => {
         "A minimum version is configured; whether it is current is not assessed.",
       ).length,
     ).toBeGreaterThan(0);
+  });
+});
+
+describe("ComplianceView assessment scope", () => {
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+  it("lets users exclude platforms and preserves assessment limitations", async () => {
+    window.localStorage.setItem("compliance-framework", "bsi-it-grundschutz");
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+    await user.click(await screen.findByRole("checkbox", { name: "macOS" }));
+    expect(
+      screen.getByRole("button", { name: /SYS.2.4.A6/ }),
+    ).toHaveTextContent("Outside selected scope");
+    expect(
+      screen.getByRole("button", { name: "Download evidence record (JSON)" }),
+    ).toBeInTheDocument();
+  });
+  it("applies the selected Def Stan risk level", async () => {
+    window.localStorage.setItem("compliance-framework", "def-stan-05-138-i4");
+    const user = userEvent.setup();
+    render(<ComplianceView configurations={configurations} />);
+    await user.selectOptions(
+      await screen.findByRole("combobox", {
+        name: "Def Stan Cyber Risk Profile",
+      }),
+      "0",
+    );
+    expect(screen.getByRole("button", { name: /2317/ })).toHaveTextContent(
+      "Outside selected scope",
+    );
+  });
+  it("makes incomplete collection visible before opening individual controls", async () => {
+    window.localStorage.setItem("compliance-framework", "iso-27001-2022");
+    render(
+      <ComplianceView
+        configurations={{
+          ...configurations,
+          fetchErrors: [
+            {
+              policyId: "failed",
+              policyName: "Policy",
+              policyType: "Settings Catalog",
+              familyKey: "settingsCatalog",
+              error: "Forbidden",
+            },
+          ],
+        }}
+      />,
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Collection is incomplete",
+    );
   });
 });

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -105,7 +105,7 @@ describe("ComplianceView", () => {
     expect(
       screen.getByRole("button", { name: "NIST SP 800-171 Rev. 3" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button")).toHaveLength(9);
+    expect(screen.getAllByRole("button")).toHaveLength(10);
     expect(
       screen.queryByRole("button", { name: /Download report/ }),
     ).not.toBeInTheDocument();
@@ -426,4 +426,31 @@ describe("ComplianceView assessment scope", () => {
       "Collection is incomplete",
     );
   });
+});
+
+it("selects each Essential Eight target and updates its requirement set", async () => {
+  window.localStorage.clear();
+  const user = userEvent.setup();
+  render(<ComplianceView configurations={configurations} />);
+  await user.click(screen.getByRole("button", { name: "ASD Essential Eight" }));
+  const selector = await screen.findByRole("combobox", {
+    name: "Essential Eight target maturity level",
+  });
+  expect(selector).toHaveValue("1");
+  expect(
+    screen.getAllByText(/48 published requirement entries/).length,
+  ).toBeGreaterThan(0);
+  await user.selectOptions(selector, "2");
+  expect(
+    screen.getAllByText(/107 published requirement entries/).length,
+  ).toBeGreaterThan(0);
+  await user.selectOptions(selector, "3");
+  expect(
+    screen.getAllByText(/149 published requirement entries/).length,
+  ).toBeGreaterThan(0);
+  expect(
+    screen.getByText(/no achieved maturity level is calculated/),
+  ).toBeInTheDocument();
+  cleanup();
+  window.localStorage.clear();
 });

--- a/src/components/dashboard/__tests__/compliance-view.test.tsx
+++ b/src/components/dashboard/__tests__/compliance-view.test.tsx
@@ -138,7 +138,7 @@ describe("ComplianceView", () => {
       name: "Selected framework: NIST SP 800-171 Rev. 2",
     });
     expect(
-      screen.getByText(/11 of 110 published requirements/),
+      screen.getByText(/12 of 110 published requirements/),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /3\.13\.16/ }),

--- a/src/components/dashboard/compliance-context.tsx
+++ b/src/components/dashboard/compliance-context.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import type { DetailedExportData } from "~/lib/configuration-analyzer";
+import type {
+  AssessmentScope,
+  ComplianceAssessment,
+  CompliancePlatform,
+} from "~/lib/compliance/types";
+import { createEvidenceManifest } from "~/lib/compliance/manifest";
+
+export function ComplianceContext({
+  assessment,
+  data,
+  scope,
+  onScopeChange,
+  showRiskLevel,
+}: {
+  assessment: ComplianceAssessment;
+  data: DetailedExportData;
+  scope: AssessmentScope;
+  onScopeChange: (scope: AssessmentScope) => void;
+  showRiskLevel: boolean;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState(false);
+  const platforms: CompliancePlatform[] = [
+    "windows",
+    "macos",
+    "ios",
+    "android",
+  ];
+  const selected = scope.platforms ?? platforms;
+  const incomplete = assessment.collectionCoverage.some(
+    (row) => row.status === "incomplete" || row.status === "notCollected",
+  );
+  async function download() {
+    setDownloading(true);
+    setError(null);
+    try {
+      const manifest = await createEvidenceManifest(data, scope);
+      const url = URL.createObjectURL(
+        new Blob([JSON.stringify(manifest, null, 2)], {
+          type: "application/json",
+        }),
+      );
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "compliance-evidence.json";
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch {
+      setError("Could not generate the evidence record. Try again.");
+    } finally {
+      setDownloading(false);
+    }
+  }
+  return (
+    <section
+      aria-label="Assessment scope and collection"
+      className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 text-sm text-slate-700"
+    >
+      <fieldset>
+        <legend className="font-semibold text-slate-950">
+          Platforms in scope
+        </legend>
+        <p className="mt-1 text-xs">
+          Select the platforms included in this assessment. Policy absence does
+          not establish that a platform is out of scope. Tenant access policies
+          are assessed separately.
+        </p>
+        <div className="mt-2 flex flex-wrap gap-4">
+          {platforms.map((platform) => (
+            <label
+              key={platform}
+              className="inline-flex min-h-10 items-center gap-2"
+            >
+              <input
+                type="checkbox"
+                checked={selected.includes(platform)}
+                onChange={(event) => {
+                  const next = event.target.checked
+                    ? [...selected, platform]
+                    : selected.filter((item) => item !== platform);
+                  if (next.length) onScopeChange({ ...scope, platforms: next });
+                }}
+              />
+              {
+                {
+                  windows: "Windows",
+                  macos: "macOS",
+                  ios: "iOS / iPadOS",
+                  android: "Android",
+                  tenant: "Tenant",
+                }[platform]
+              }
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      {showRiskLevel && (
+        <label className="flex flex-wrap items-center gap-3">
+          Def Stan Cyber Risk Profile
+          <select
+            className="rounded border border-slate-300 p-2"
+            value={scope.defStanRiskLevel ?? "all"}
+            onChange={(event) =>
+              onScopeChange({
+                ...scope,
+                defStanRiskLevel:
+                  event.target.value === "all"
+                    ? undefined
+                    : (Number(event.target.value) as 0 | 1 | 2 | 3),
+              })
+            }
+          >
+            <option value="all">All levels (scope not selected)</option>
+            {[0, 1, 2, 3].map((level) => (
+              <option key={level} value={level}>
+                Level {level}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {incomplete && (
+        <p role="status" className="rounded-lg bg-amber-50 p-3 text-amber-900">
+          Collection is incomplete or a relevant source was not collected.
+          Missing evidence may reflect unavailable data.
+        </p>
+      )}
+      <p className="text-xs">
+        Collected:{" "}
+        {assessment.provenance.collectedAt ??
+          "Unknown, timestamp absent from this export"}
+        . Ruleset: {assessment.provenance.rulesetVersion}. Device state and
+        effective access have not been verified.
+      </p>
+      <details>
+        <summary className="cursor-pointer font-semibold">
+          Collection and detection coverage
+        </summary>
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full text-left text-xs">
+            <thead>
+              <tr>
+                {[
+                  "Policy family",
+                  "Collection",
+                  "Collected",
+                  "With recognized evidence",
+                  "Without recognized evidence",
+                ].map((label) => (
+                  <th key={label} className="p-2">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {assessment.collectionCoverage.map((row) => (
+                <tr key={row.family} className="border-t border-slate-100">
+                  <th scope="row" className="p-2 font-medium">
+                    {row.family}
+                    {row.errors.map((message) => (
+                      <p
+                        key={message}
+                        className="mt-1 max-w-md font-normal break-words text-amber-800"
+                      >
+                        {message}
+                      </p>
+                    ))}
+                  </th>
+                  <td className="p-2">{row.status}</td>
+                  <td className="p-2">{row.collectedPolicies}</td>
+                  <td className="p-2">{row.recognizedPolicies}</td>
+                  <td className="p-2">{row.unsupportedPolicies}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-2 text-xs">
+          Without recognized evidence includes unsupported formats, unsupported
+          settings and indeterminate values. It does not establish a missing
+          protection.
+        </p>
+      </details>
+      <button
+        type="button"
+        disabled={downloading}
+        onClick={() => void download()}
+        className="min-h-10 rounded-lg border border-slate-300 px-3 py-2 font-semibold disabled:opacity-50"
+      >
+        {downloading
+          ? "Preparing evidence record..."
+          : "Download evidence record (JSON)"}
+      </button>
+      {error && (
+        <p role="alert" className="text-red-700">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/compliance-context.tsx
+++ b/src/components/dashboard/compliance-context.tsx
@@ -15,12 +15,14 @@ export function ComplianceContext({
   scope,
   onScopeChange,
   showRiskLevel,
+  showEssentialEightLevel = false,
 }: {
   assessment: ComplianceAssessment;
   data: DetailedExportData;
   scope: AssessmentScope;
   onScopeChange: (scope: AssessmentScope) => void;
   showRiskLevel: boolean;
+  showEssentialEightLevel?: boolean;
 }) {
   const [error, setError] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
@@ -98,6 +100,36 @@ export function ComplianceContext({
           ))}
         </div>
       </fieldset>
+      {showEssentialEightLevel && (
+        <div>
+          <label className="flex flex-wrap items-center gap-3">
+            Essential Eight target maturity level
+            <select
+              className="rounded border border-slate-300 p-2"
+              value={scope.essentialEightMaturityLevel ?? 1}
+              onChange={(event) =>
+                onScopeChange({
+                  ...scope,
+                  essentialEightMaturityLevel: Number(event.target.value) as
+                    | 1
+                    | 2
+                    | 3,
+                })
+              }
+            >
+              {[1, 2, 3].map((level) => (
+                <option key={level} value={level}>
+                  Maturity Level {level}
+                </option>
+              ))}
+            </select>
+          </label>
+          <p className="mt-2 text-xs">
+            Evidence against the selected target. The tool does not calculate an
+            achieved maturity level. Default target: Level 1.
+          </p>
+        </div>
+      )}
       {showRiskLevel && (
         <label className="flex flex-wrap items-center gap-3">
           Def Stan Cyber Risk Profile

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -78,6 +78,27 @@ const FRAMEWORK_OPTIONS: ReadonlyArray<{
     description:
       "Baseline safeguards for systematic information security management.",
   },
+  {
+    id: "def-stan-05-138-i4",
+    label: "Def Stan 05-138",
+    shortLabel: "Def Stan",
+    description:
+      "UK MOD supplier controls under DEFCON 658, with the Cyber Risk Profile levels at which each applies.",
+  },
+  {
+    id: "cyber-essentials-v3",
+    label: "Cyber Essentials",
+    shortLabel: "Cyber Essentials",
+    description:
+      "The five NCSC control themes mapped to managed-device configuration evidence.",
+  },
+  {
+    id: "nist-800-171-r2",
+    label: "NIST SP 800-171",
+    shortLabel: "NIST 800-171",
+    description:
+      "Requirements for protecting controlled unclassified information, as referenced by CMMC 2.0 Level 2.",
+  },
 ];
 
 function isFrameworkId(value: string | null): value is FrameworkId {

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -768,8 +768,8 @@ export function ComplianceView({
                             }
                       }
                       className={`border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none lg:col-span-2 ${
-                        framework.id === "nist-csf-2"
-                          ? "lg:col-start-2 lg:row-start-2"
+                        framework.id === "cyber-essentials-v3"
+                          ? "lg:col-start-2 lg:row-start-3"
                           : ""
                       }`}
                     >

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -22,6 +22,13 @@ import {
 } from "~/components/dashboard/framework-badge";
 import type { IntuneConfigurations } from "~/components/dashboard/types";
 import type { DetailedExportData } from "~/lib/configuration-analyzer";
+import { ComplianceContext } from "./compliance-context";
+import { assignmentDetails } from "~/lib/compliance/assignments";
+import {
+  CAPABILITY_STATUS_LABELS,
+  frameworkCoverageLabel,
+} from "~/lib/compliance/presentation";
+import type { AssessmentScope } from "~/lib/compliance/types";
 import { assessCompliance, compareControlIds } from "~/lib/compliance";
 import type {
   CapabilityResult,
@@ -94,10 +101,17 @@ const FRAMEWORK_OPTIONS: ReadonlyArray<{
   },
   {
     id: "nist-800-171-r2",
-    label: "NIST SP 800-171",
-    shortLabel: "NIST 800-171",
+    label: "NIST SP 800-171 Rev. 2",
+    shortLabel: "NIST 171 R2",
     description:
       "Requirements for protecting controlled unclassified information, as referenced by CMMC 2.0 Level 2.",
+  },
+  {
+    id: "nist-800-171-r3",
+    label: "NIST SP 800-171 Rev. 3",
+    shortLabel: "NIST 171 R3",
+    description:
+      "May 2024 requirements for protecting controlled unclassified information. Organization-defined parameters need separate review. Select Revision 2 for CMMC Level 2.",
   },
 ];
 
@@ -122,6 +136,9 @@ function clearFrameworkSelection() {
 }
 
 const CONTROL_STATUS_ORDER: Record<ControlStatus, number> = {
+  notApplicable: 5,
+  notAssessed: -1,
+  conflictingEvidence: -2,
   evidenceFound: 0,
   partialEvidence: 1,
   noEvidence: 2,
@@ -131,6 +148,21 @@ const CONTROL_STATUS_DETAILS: Record<
   ControlStatus,
   { label: string; chipClassName: string; dotClassName: string }
 > = {
+  notApplicable: {
+    label: "Outside selected scope",
+    chipClassName: "bg-slate-100 text-slate-700",
+    dotClassName: "bg-slate-500",
+  },
+  notAssessed: {
+    label: "Not assessed",
+    chipClassName: "bg-amber-50 text-amber-800",
+    dotClassName: "bg-amber-600",
+  },
+  conflictingEvidence: {
+    label: "Mixed policy evidence",
+    chipClassName: "bg-red-50 text-red-800",
+    dotClassName: "bg-red-600",
+  },
   evidenceFound: {
     label: "Configuration evidence",
     chipClassName: "bg-emerald-50 text-emerald-800",
@@ -146,13 +178,6 @@ const CONTROL_STATUS_DETAILS: Record<
     chipClassName: "bg-slate-100 text-slate-700",
     dotClassName: "bg-slate-500",
   },
-};
-
-const CAPABILITY_STATUS_LABELS: Record<CapabilityStatus, string> = {
-  enforced: "Compliant configuration assigned",
-  configuredNotAssigned: "Configured, not assigned",
-  disabledByPolicy: "Deviating configuration detected",
-  noEvidence: "No evidence",
 };
 
 function hasLegacyConfigurations(configurations: IntuneConfigurations) {
@@ -208,7 +233,9 @@ function EvidenceList({ capability }: { capability: CapabilityResult }) {
   if (capability.evidence.length === 0) {
     return (
       <p className="text-petrol-600 mt-3 text-xs">
-        No matching Intune policy detected.
+        {capability.status === "collectionIncomplete"
+          ? "Relevant policy data is incomplete. Evidence could not be assessed."
+          : "No recognized setting detected in the available policy data."}
       </p>
     );
   }
@@ -265,7 +292,7 @@ function EvidenceList({ capability }: { capability: CapabilityResult }) {
               </div>
               <div className="min-w-0">
                 <p className="text-[9px] font-bold tracking-[0.12em] uppercase opacity-65">
-                  Observed value
+                  Configured value
                 </p>
                 <p className="mt-1 font-mono text-[10px] leading-4 break-all">
                   {isAssignedCounterEvidence
@@ -277,10 +304,19 @@ function EvidenceList({ capability }: { capability: CapabilityResult }) {
                 <p className="text-[9px] font-bold tracking-[0.12em] uppercase opacity-65">
                   Assignment
                 </p>
-                <p className="mt-1 text-xs break-words">{assignment}</p>
+                <p className="mt-1 text-xs break-words">
+                  {assignmentDetails(evidence.assignment).join("; ") ||
+                    assignment}
+                  . Effective coverage unverified.
+                </p>
               </div>
             </div>
 
+            <p className="mt-2 text-[11px]">
+              Evidence type: {evidence.kind}. Policy version:{" "}
+              {evidence.policyVersion ?? "unknown"}. Last modified:{" "}
+              {evidence.policyModifiedAt ?? "unknown"}.
+            </p>
             {(isCounterEvidence || evidence.note) && (
               <div className="mt-3 flex flex-wrap items-start gap-2 border-t border-current/10 pt-3">
                 {isCounterEvidence && (
@@ -291,7 +327,9 @@ function EvidenceList({ capability }: { capability: CapabilityResult }) {
                   >
                     {isAssignedCounterEvidence
                       ? "Deviating configuration detected and assigned (risk)"
-                      : "Deviating configuration detected, but not assigned"}
+                      : evidence.assignment.state === "unknown"
+                        ? "Non-enforcing setting; assignment unknown"
+                        : "Deviating configuration detected, but not assigned"}
                   </span>
                 )}
                 {evidence.note && (
@@ -331,6 +369,7 @@ function ControlRow({
         onClick={onToggle}
         aria-expanded={expanded}
         aria-controls={panelId}
+        aria-label={`${control.control.id} ${control.control.title}: ${CONTROL_STATUS_DETAILS[control.status].label}`}
         className="hover:bg-mint-50/60 flex min-h-16 w-full cursor-pointer items-start gap-3 px-4 py-4 text-left transition-colors focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:outline-none focus-visible:ring-inset sm:items-center sm:px-5"
       >
         <ChevronDown
@@ -362,6 +401,16 @@ function ControlRow({
           id={panelId}
           className="border-petrol-950/6 divide-petrol-950/6 divide-y border-t bg-slate-50/55 px-4 sm:px-5"
         >
+          {control.unassessedAspects.length > 0 && (
+            <div className="py-4 text-xs text-amber-900">
+              <p className="font-semibold">Still to assess</p>
+              <ul className="mt-2 list-disc space-y-1 pl-4">
+                {control.unassessedAspects.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
           {control.capabilityIds.map((capabilityId) => {
             const capability = capabilitiesById.get(capabilityId);
             if (!capability) return null;
@@ -419,7 +468,7 @@ function SummaryCard({
         {count.toLocaleString()}
       </p>
       <p className="text-petrol-600 mt-1 text-[11px] tabular-nums">
-        of {total.toLocaleString()} assessable controls
+        of {total.toLocaleString()} controls in scope
       </p>
     </div>
   );
@@ -467,13 +516,15 @@ export function ComplianceView({
 }: ComplianceViewProps) {
   const { accounts } = useMsal();
   const prefersReducedMotion = useReducedMotion();
+  const [scope, setScope] = useState<AssessmentScope>({});
   const assessmentData = useMemo(
     () =>
       ({
         ...configurations,
+        assessmentScope: scope,
         groupNames: groupNames ?? undefined,
       }) as unknown as DetailedExportData,
-    [configurations, groupNames],
+    [configurations, groupNames, scope],
   );
   const assessment = useMemo(
     () => assessCompliance(assessmentData),
@@ -618,10 +669,9 @@ export function ComplianceView({
       const { generateComplianceReportPDF, complianceReportFileName } =
         await import("~/lib/compliance/report-pdf");
       const bytes = await generateComplianceReportPDF(assessmentData, {
-          frameworkId: selectedFrameworkId,
-          metadata: tenantLabel ? { tenantLabel } : undefined,
-        },
-      );
+        frameworkId: selectedFrameworkId,
+        metadata: tenantLabel ? { tenantLabel } : undefined,
+      });
       const blob = new Blob([new Uint8Array(bytes)], {
         type: "application/pdf",
       });
@@ -767,11 +817,7 @@ export function ComplianceView({
                               },
                             }
                       }
-                      className={`border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none lg:col-span-2 ${
-                        framework.id === "cyber-essentials-v3"
-                          ? "lg:col-start-2 lg:row-start-3"
-                          : ""
-                      }`}
+                      className="border-petrol-950/8 shadow-card hover:bg-mint-50/35 group min-h-56 cursor-pointer touch-manipulation rounded-2xl border bg-white p-6 text-left transition-[border-color,background-color,box-shadow] duration-200 hover:border-teal-700/25 hover:shadow-[0_16px_40px_-30px_rgba(8,47,54,0.55)] focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none lg:col-span-2"
                     >
                       <motion.span
                         layoutId={
@@ -792,6 +838,14 @@ export function ComplianceView({
                       <span className="text-petrol-600 mt-3 block text-sm leading-6">
                         {framework.description}
                       </span>
+                      {assessmentFramework?.framework.totalRequirements !==
+                        undefined && (
+                        <span className="mt-3 block text-xs font-semibold text-teal-700">
+                          {assessmentFramework.summary.totalControls} of{" "}
+                          {assessmentFramework.framework.totalRequirements}{" "}
+                          requirements mapped; supporting evidence only.
+                        </span>
+                      )}
                     </motion.button>
                   );
                 })}
@@ -984,6 +1038,14 @@ export function ComplianceView({
               }
             />
 
+            <ComplianceContext
+              assessment={assessment}
+              data={assessmentData}
+              scope={scope}
+              onScopeChange={setScope}
+              showRiskLevel={selectedFrameworkId === "def-stan-05-138-i4"}
+            />
+
             {isEmpty ? (
               <div className="border-petrol-950/6 shadow-card rounded-2xl border bg-white px-6 py-12 text-center">
                 <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-teal-50 text-teal-700">
@@ -1028,22 +1090,36 @@ export function ComplianceView({
                     <SummaryCard
                       label="Evidence"
                       count={selectedFramework.summary.withEvidence}
-                      total={selectedFramework.summary.totalControls}
+                      total={selectedFramework.summary.applicableControls}
                       tone="green"
                     />
                     <SummaryCard
                       label="Partial"
                       count={selectedFramework.summary.partial}
-                      total={selectedFramework.summary.totalControls}
+                      total={selectedFramework.summary.applicableControls}
                       tone="amber"
                     />
                     <SummaryCard
                       label="No evidence"
                       count={selectedFramework.summary.withoutEvidence}
-                      total={selectedFramework.summary.totalControls}
+                      total={selectedFramework.summary.applicableControls}
                       tone="slate"
                     />
                   </div>
+
+                  <p className="text-xs text-slate-600">
+                    {selectedFramework.summary.conflicting} mixed evidence;{" "}
+                    {selectedFramework.summary.notAssessed} not assessed;{" "}
+                    {selectedFramework.summary.notApplicable} outside scope.
+                    Counts refer to selected mapped entries, not full framework
+                    coverage.
+                  </p>
+                  {selectedFramework.framework.totalRequirements !==
+                    undefined && (
+                    <p className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs leading-5 text-amber-950">
+                      {frameworkCoverageLabel(selectedFramework)}
+                    </p>
+                  )}
 
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div>
@@ -1085,6 +1161,21 @@ export function ComplianceView({
                   {selectedFramework.framework.note && (
                     <p className="text-petrol-600 text-xs leading-5">
                       {selectedFramework.framework.note}
+                    </p>
+                  )}
+
+                  {selectedFramework.framework.source && (
+                    <p className="text-petrol-600 text-xs">
+                      <a
+                        href={selectedFramework.framework.source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-teal-700 underline underline-offset-2"
+                      >
+                        Official publisher reference
+                      </a>{" "}
+                      (reference reviewed{" "}
+                      {selectedFramework.framework.source.verifiedAt})
                     </p>
                   )}
 

--- a/src/components/dashboard/compliance-view.tsx
+++ b/src/components/dashboard/compliance-view.tsx
@@ -51,6 +51,13 @@ const FRAMEWORK_OPTIONS: ReadonlyArray<{
   description: string;
 }> = [
   {
+    id: "essential-eight",
+    label: "ASD Essential Eight",
+    shortLabel: "Essential Eight",
+    description:
+      "Australian enterprise IT requirements with target Maturity Levels 1, 2 and 3. Configuration evidence only.",
+  },
+  {
     id: "iso-27001-2022",
     label: "ISO/IEC 27001",
     shortLabel: "ISO 27001",
@@ -388,6 +395,11 @@ function ControlRow({
             </p>
             <ControlStatusChip status={control.status} />
           </div>
+          {/^ML[123]-/.test(control.control.id) && (
+            <p className="mt-2 text-sm leading-6 text-slate-700">
+              {control.control.summary}
+            </p>
+          )}
           {control.control.tier && (
             <p className="text-petrol-600 mt-1 text-xs">
               {control.control.tier}
@@ -681,6 +693,7 @@ export function ComplianceView({
       link.download = complianceReportFileName(
         selectedFrameworkId,
         tenantLabel,
+        scope.essentialEightMaturityLevel ?? 1,
       );
       document.body.appendChild(link);
       try {
@@ -841,9 +854,15 @@ export function ComplianceView({
                       {assessmentFramework?.framework.totalRequirements !==
                         undefined && (
                         <span className="mt-3 block text-xs font-semibold text-teal-700">
-                          {assessmentFramework.summary.totalControls} of{" "}
-                          {assessmentFramework.framework.totalRequirements}{" "}
-                          requirements mapped; supporting evidence only.
+                          {framework.id === "essential-eight" ? (
+                            frameworkCoverageLabel(assessmentFramework)
+                          ) : (
+                            <>
+                              {assessmentFramework.summary.totalControls} of{" "}
+                              {assessmentFramework.framework.totalRequirements}{" "}
+                              requirements mapped; supporting evidence only.
+                            </>
+                          )}
                         </span>
                       )}
                     </motion.button>
@@ -1043,6 +1062,9 @@ export function ComplianceView({
               data={assessmentData}
               scope={scope}
               onScopeChange={setScope}
+              showEssentialEightLevel={
+                selectedFrameworkId === "essential-eight"
+              }
               showRiskLevel={selectedFrameworkId === "def-stan-05-138-i4"}
             />
 

--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -6,7 +6,8 @@ export type FrameworkId =
   | "soc2-tsc"
   | "def-stan-05-138-i4"
   | "cyber-essentials-v3"
-  | "nist-800-171-r2";
+  | "nist-800-171-r2"
+  | "nist-800-171-r3";
 
 // Text-forward wordmarks only: official logos, insignia, and association marks
 // must not be reproduced. The standards are named in our own typography for
@@ -36,7 +37,12 @@ const WORDMARK_DETAILS: Record<
   "nist-800-171-r2": {
     fill: "#1E40AF",
     line1: "NIST",
-    line2: "SP 800-171",
+    line2: "171 Rev. 2",
+  },
+  "nist-800-171-r3": {
+    fill: "#1E3A8A",
+    line1: "NIST",
+    line2: "171 Rev. 3",
   },
 };
 

--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -3,7 +3,10 @@ export type FrameworkId =
   | "nist-800-53-r5"
   | "nist-csf-2"
   | "iso-27001-2022"
-  | "soc2-tsc";
+  | "soc2-tsc"
+  | "def-stan-05-138-i4"
+  | "cyber-essentials-v3"
+  | "nist-800-171-r2";
 
 // Text-forward wordmarks only: official logos, insignia, and association marks
 // must not be reproduced. The standards are named in our own typography for
@@ -20,6 +23,21 @@ const WORDMARK_DETAILS: Record<
     line2: "SP 800-53",
   },
   "nist-csf-2": { fill: "#0F766E", line1: "NIST", line2: "CSF 2.0" },
+  "def-stan-05-138-i4": {
+    fill: "#9F1239",
+    line1: "DEF STAN",
+    line2: "05-138",
+  },
+  "cyber-essentials-v3": {
+    fill: "#0E7490",
+    line1: "CYBER",
+    line2: "ESSENTIALS",
+  },
+  "nist-800-171-r2": {
+    fill: "#1E40AF",
+    line1: "NIST",
+    line2: "SP 800-171",
+  },
 };
 
 const FONT_FAMILY = "ui-sans-serif, system-ui, sans-serif";

--- a/src/components/dashboard/framework-badge.tsx
+++ b/src/components/dashboard/framework-badge.tsx
@@ -7,7 +7,8 @@ export type FrameworkId =
   | "def-stan-05-138-i4"
   | "cyber-essentials-v3"
   | "nist-800-171-r2"
-  | "nist-800-171-r3";
+  | "nist-800-171-r3"
+  | "essential-eight";
 
 // Text-forward wordmarks only: official logos, insignia, and association marks
 // must not be reproduced. The standards are named in our own typography for
@@ -16,6 +17,7 @@ const WORDMARK_DETAILS: Record<
   Exclude<FrameworkId, "bsi-it-grundschutz">,
   { fill: string; line1: string; line2: string }
 > = {
+  "essential-eight": { fill: "#047857", line1: "ESSENTIAL", line2: "EIGHT" },
   "iso-27001-2022": { fill: "#4338CA", line1: "ISO", line2: "27001" },
   "soc2-tsc": { fill: "#7E22CE", line1: "SOC 2", line2: "TSC" },
   "nist-800-53-r5": {

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -36,6 +36,9 @@ export interface DashboardConfigurationItem {
 export type ConfigurationTypeCounts = Record<string, number>;
 
 export interface IntuneConfigurations {
+  collectedAt?: string;
+  collectionStartedAt?: string;
+  collectionSkippedFamilies?: string[];
   settingsCatalog: DashboardConfigurationItem[];
   deviceConfigurations: DashboardConfigurationItem[];
   administrativeTemplates: DashboardConfigurationItem[];

--- a/src/hooks/use-export-handler.ts
+++ b/src/hooks/use-export-handler.ts
@@ -98,6 +98,9 @@ export function useExportHandler({
 
       const selectedSections = getSelectedSections();
       const selectedData = {
+        collectedAt: configurations?.collectedAt,
+        collectionStartedAt: configurations?.collectionStartedAt,
+        collectionSkippedFamilies: configurations?.collectionSkippedFamilies,
         sections: selectedSections,
         fetchErrors: getRelevantFetchErrors(selectedSections),
         settingsCatalog:

--- a/src/lib/__tests__/compliance-actions.test.ts
+++ b/src/lib/__tests__/compliance-actions.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import { DetailedIntuneService } from "../intune-detailed-client";
+
+const collection = "/deviceManagement/deviceCompliancePolicies";
+const parent = `${collection}/policy-id`;
+const expansion =
+  "scheduledActionsForRule($expand=scheduledActionConfigurations)";
+const assignments = [
+  { target: { "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget" } },
+];
+const policy = {
+  id: "policy-id",
+  displayName: "Password requirement",
+  "@odata.type": "#microsoft.graph.windows10CompliancePolicy",
+  passwordRequired: true,
+};
+const block = { id: "block", actionType: "block", gracePeriodHours: 24 };
+const rule = {
+  id: "rule",
+  ruleName: "PasswordRequired",
+  scheduledActionConfigurations: [block],
+};
+const routingError = () =>
+  Object.assign(
+    new Error(
+      "No OData route exists that match template ~/singleton/navigation/key/navigation with http verb GET",
+    ),
+    { statusCode: 400 },
+  );
+
+function mockService(response: unknown, pages = new Map<string, unknown>()) {
+  const service = new DetailedIntuneService("test-token") as any;
+  service.retryWithBackoff = (action: () => Promise<unknown>) => action();
+  const requests: { url: string; version?: string; expand?: string }[] = [];
+  service.client = {
+    api: vi.fn((url: string) => {
+      const recorded: (typeof requests)[number] = { url };
+      requests.push(recorded);
+      const request: any = {
+        version: (version: string) => {
+          recorded.version = version;
+          return request;
+        },
+        top: () => request,
+        expand: (expand: string) => {
+          recorded.expand = expand;
+          return request;
+        },
+        get: async () => {
+          // Reproduce the reported backend rejection if the old route is used.
+          if (url.endsWith("/scheduledActionsForRule")) throw routingError();
+          if (url === collection) return { value: [policy] };
+          if (url === `${collection}('policy-id')/assignments`)
+            return { value: assignments };
+          const result = url === parent ? response : pages.get(url);
+          if (result instanceof Error) throw result;
+          if (result === undefined)
+            throw new Error(`Unexpected request: ${url}`);
+          return result;
+        },
+      };
+      return request;
+    }),
+  };
+  return { service, requests };
+}
+
+describe("compliance scheduled-action collection", () => {
+  it("uses the expanded parent when the direct relation GET is unsupported", async () => {
+    const { service, requests } = mockService({
+      ...policy,
+      scheduledActionsForRule: [rule],
+    });
+    const [result] = await service.getCompliancePoliciesDetailed();
+    expect(requests).toContainEqual({
+      url: parent,
+      version: "beta",
+      expand: expansion,
+    });
+    expect(
+      requests.some(({ url }) => url.endsWith("/scheduledActionsForRule")),
+    ).toBe(false);
+    expect(result.scheduledActionsForRule).toEqual([rule]);
+    expect(result.passwordRequired).toBe(true);
+    expect(result.assignments).toEqual(assignments);
+    expect(result.collectionStatus).toEqual({
+      assignments: "complete",
+      scheduledActionsForRule: "complete",
+    });
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+
+  it.each([
+    ["route rejection", routingError()],
+    ["forbidden", Object.assign(new Error("Forbidden"), { statusCode: 403 })],
+    ["missing expansion", { ...policy }],
+    [
+      "missing nested expansion",
+      { ...policy, scheduledActionsForRule: [{ id: "rule" }] },
+    ],
+  ])("preserves policy and assignments after %s", async (_name, response) => {
+    const { service } = mockService(response);
+    const [result] = await service.getCompliancePoliciesDetailed();
+    expect(result.passwordRequired).toBe(true);
+    expect(result.assignments).toEqual(assignments);
+    expect(result.collectionStatus).toEqual({
+      assignments: "complete",
+      scheduledActionsForRule: "incomplete",
+    });
+    expect(service.getFetchErrors()).toEqual([
+      expect.objectContaining({
+        policyId: policy.id,
+        familyKey: "compliancePolicies",
+        endpoint: `${parent}?$expand=${expansion}`,
+        error: expect.stringContaining(
+          "Scheduled noncompliance actions could not be fully collected",
+        ),
+        partial: true,
+      }),
+    ]);
+  });
+
+  it("distinguishes a confirmed empty collection from missing data", async () => {
+    const { service } = mockService({ ...policy, scheduledActionsForRule: [] });
+    const [result] = await service.getCompliancePoliciesDetailed();
+    expect(result.scheduledActionsForRule).toEqual([]);
+    expect(result.collectionStatus.scheduledActionsForRule).toBe("complete");
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+
+  it("follows both expanded rule and action continuation links", async () => {
+    const rulesNext = `https://graph.microsoft.com/beta${parent}/scheduledActionsForRule?$skiptoken=rules`;
+    const actionsNext = `https://graph.microsoft.com/beta${parent}/scheduledActionsForRule/rule/scheduledActionConfigurations?$skiptoken=actions`;
+    const email = {
+      id: "email",
+      actionType: "notification",
+      gracePeriodHours: 0,
+    };
+    const secondRule = { ...rule, id: "second-rule" };
+    const { service, requests } = mockService(
+      {
+        ...policy,
+        scheduledActionsForRule: [
+          {
+            ...rule,
+            "scheduledActionConfigurations@odata.nextLink": actionsNext,
+          },
+        ],
+        "scheduledActionsForRule@odata.nextLink": rulesNext,
+      },
+      new Map([
+        [rulesNext, { value: [secondRule] }],
+        [actionsNext, { value: [email] }],
+      ]),
+    );
+    const [result] = await service.getCompliancePoliciesDetailed();
+    expect(result.scheduledActionsForRule).toHaveLength(2);
+    expect(
+      result.scheduledActionsForRule[0].scheduledActionConfigurations,
+    ).toEqual([block, email]);
+    expect(result.collectionStatus.scheduledActionsForRule).toBe("complete");
+    expect(requests).toContainEqual({ url: rulesNext });
+    expect(requests).toContainEqual({ url: actionsNext });
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+
+  it("retains collected actions when a continuation request fails", async () => {
+    const next = `https://graph.microsoft.com/beta${parent}/scheduledActionsForRule/rule/scheduledActionConfigurations?$skiptoken=actions`;
+    const { service } = mockService(
+      {
+        ...policy,
+        scheduledActionsForRule: [
+          { ...rule, "scheduledActionConfigurations@odata.nextLink": next },
+        ],
+      },
+      new Map([
+        [next, Object.assign(new Error("Forbidden"), { statusCode: 403 })],
+      ]),
+    );
+    const [result] = await service.getCompliancePoliciesDetailed();
+    expect(
+      result.scheduledActionsForRule[0].scheduledActionConfigurations,
+    ).toEqual([block]);
+    expect(result.assignments).toEqual(assignments);
+    expect(result.collectionStatus.scheduledActionsForRule).toBe("incomplete");
+    expect(service.getFetchErrors()[0].statusCode).toBe(403);
+  });
+});

--- a/src/lib/__tests__/compliance-engine.test.ts
+++ b/src/lib/__tests__/compliance-engine.test.ts
@@ -10,6 +10,9 @@ import {
   NIST_800_53,
   NIST_CSF,
   SOC_2,
+  CYBER_ESSENTIALS,
+  DEF_STAN_05_138,
+  NIST_800_171,
 } from "../compliance";
 import { defenderForEndpointPolicyFixture } from "./fixtures/intune-beta";
 
@@ -564,12 +567,51 @@ describe("framework assessment", () => {
       "bsi-it-grundschutz",
       "iso-27001-2022",
       "soc2-tsc",
+      "def-stan-05-138-i4",
+      "cyber-essentials-v3",
+      "nist-800-171-r2",
     ]);
     for (const framework of assessment.frameworks) {
       expect(framework.summary.withoutEvidence).toBe(
         framework.summary.totalControls,
       );
     }
+  });
+
+  it("assesses Def Stan 05-138 controls with their risk profile levels", () => {
+    const assessment = assessCompliance(emptyExportData());
+    const defStan = assessment.frameworks.find(
+      (framework) => framework.framework.id === "def-stan-05-138-i4",
+    );
+    expect(defStan).toBeDefined();
+    const encryption = defStan?.controls.find(
+      (control) => control.control.id === "2317",
+    );
+    expect(encryption?.control.tier).toBe("Level 1 to Level 3");
+    expect(encryption?.capabilityIds).toEqual([
+      "windows-disk-encryption",
+      "macos-disk-encryption",
+      "android-storage-encryption",
+    ]);
+    expect(defStan?.controls.every((control) => control.control.tier)).toBe(
+      true,
+    );
+  });
+
+  it("uses the five Cyber Essentials themes as control identifiers", () => {
+    const assessment = assessCompliance(emptyExportData());
+    const cyberEssentials = assessment.frameworks.find(
+      (framework) => framework.framework.id === "cyber-essentials-v3",
+    );
+    expect(
+      cyberEssentials?.controls.map((control) => control.control.id),
+    ).toEqual([
+      "Firewalls",
+      "Malware protection",
+      "Secure configuration",
+      "Security update management",
+      "User access control",
+    ]);
   });
 
   it("keeps capability catalog and framework mappings consistent", () => {
@@ -583,6 +625,9 @@ describe("framework assessment", () => {
       BSI_IT_GRUNDSCHUTZ,
       ISO_27001,
       SOC_2,
+      DEF_STAN_05_138,
+      CYBER_ESSENTIALS,
+      NIST_800_171,
     ]) {
       for (const [capabilityId, controlIds] of Object.entries(
         framework.mappings,

--- a/src/lib/__tests__/compliance-engine.test.ts
+++ b/src/lib/__tests__/compliance-engine.test.ts
@@ -13,6 +13,7 @@ import {
   CYBER_ESSENTIALS,
   DEF_STAN_05_138,
   NIST_800_171,
+  NIST_800_171_R3,
 } from "../compliance";
 import { defenderForEndpointPolicyFixture } from "./fixtures/intune-beta";
 
@@ -261,10 +262,10 @@ describe("compliance engine", () => {
     ];
 
     expect(capabilityResult(data, "windows-disk-encryption").status).toBe(
-      "enforced",
+      "requirementAssigned",
     );
     expect(capabilityResult(data, "windows-minimum-os-version").status).toBe(
-      "enforced",
+      "requirementAssigned",
     );
 
     // Graph returns false for unset compliance booleans, so false is
@@ -274,7 +275,9 @@ describe("compliance engine", () => {
     expect(antimalware.evidence).toHaveLength(0);
 
     const encryption = capabilityResult(data, "windows-disk-encryption");
-    expect(encryption.evidence[0]?.note).toContain("block action");
+    expect(encryption.evidence[0]?.note).toContain(
+      "Marks noncompliant after 0 hours",
+    );
 
     // Same properties on a different policy type must not match.
     const crossType = emptyExportData();
@@ -306,10 +309,10 @@ describe("compliance engine", () => {
     ];
 
     expect(capabilityResult(data, "windows-secure-boot").status).toBe(
-      "enforced",
+      "requirementAssigned",
     );
     expect(capabilityResult(data, "windows-code-integrity").status).toBe(
-      "enforced",
+      "requirementAssigned",
     );
     expect(
       assessCapabilities(data).some(
@@ -373,7 +376,9 @@ describe("compliance engine", () => {
       },
     ];
 
-    expect(capabilityResult(data, "windows-firewall").status).toBe("enforced");
+    expect(capabilityResult(data, "windows-firewall").status).toBe(
+      "partialConfiguration",
+    );
   });
 
   it("treats an empty osMinimumVersion as no evidence", () => {
@@ -500,7 +505,7 @@ describe("framework assessment", () => {
 
     // SYS.3.2.1.A8 is fully evidenced (only the Android capability maps to it).
     const a8 = bsi.controls.find((c) => c.control.id === "SYS.3.2.1.A8");
-    expect(a8?.status).toBe("evidenceFound");
+    expect(a8?.status).toBe("partialEvidence");
     expect(a8?.control.tier).toBe("Basis-Anforderung");
 
     // SYS.3.2.2.A17 needs both iOS and Android integrity; only iOS is enforced.
@@ -553,7 +558,7 @@ describe("framework assessment", () => {
     ).toBe("partialEvidence");
     expect(
       bsi.controls.find((c) => c.control.id === "SYS.2.4.A4")?.status,
-    ).toBe("evidenceFound");
+    ).toBe("partialEvidence");
   });
 
   it("produces a full assessment with disclaimer and all frameworks", () => {
@@ -570,6 +575,7 @@ describe("framework assessment", () => {
       "def-stan-05-138-i4",
       "cyber-essentials-v3",
       "nist-800-171-r2",
+      "nist-800-171-r3",
     ]);
     for (const framework of assessment.frameworks) {
       expect(framework.summary.withoutEvidence).toBe(
@@ -640,9 +646,11 @@ describe("framework assessment", () => {
     const capabilities = assessCapabilities(data);
     const nist = assessFramework(capabilities, NIST_800_171);
     expect(nist.controls.find((c) => c.control.id === "3.13.1")?.status).toBe(
-      "evidenceFound",
+      "partialEvidence",
     );
-    expect(nist.controls.find((c) => c.control.id === "3.13.6")).toBeUndefined();
+    expect(
+      nist.controls.find((c) => c.control.id === "3.13.6"),
+    ).toBeUndefined();
     const defStan = assessFramework(capabilities, DEF_STAN_05_138);
     expect(
       defStan.controls.filter((c) => ["2429", "2507"].includes(c.control.id)),
@@ -677,13 +685,15 @@ describe("framework assessment", () => {
 
     const capabilities = assessCapabilities(data);
     const defStan = assessFramework(capabilities, DEF_STAN_05_138);
-    expect(defStan.controls.find((c) => c.control.id === "2213")).toBeUndefined();
+    expect(
+      defStan.controls.find((c) => c.control.id === "2213"),
+    ).toBeUndefined();
     // Password presence still supports authentication and mobile protection.
     expect(
       assessFramework(capabilities, NIST_800_171).controls.find(
         (c) => c.control.id === "3.5.2",
       )?.status,
-    ).toBe("evidenceFound");
+    ).toBe("partialEvidence");
     expect(defStan.controls.find((c) => c.control.id === "2309")?.status).toBe(
       "partialEvidence",
     );
@@ -711,7 +721,7 @@ describe("framework assessment", () => {
     const nist = assessFramework(capabilities, NIST_800_171);
     expect(nist.controls.find((c) => c.control.id === "3.4.8")).toBeUndefined();
     expect(nist.controls.find((c) => c.control.id === "3.4.9")?.status).toBe(
-      "evidenceFound",
+      "partialEvidence",
     );
     expect(
       assessFramework(capabilities, DEF_STAN_05_138).controls.find(
@@ -734,6 +744,7 @@ describe("framework assessment", () => {
       DEF_STAN_05_138,
       CYBER_ESSENTIALS,
       NIST_800_171,
+      NIST_800_171_R3,
     ]) {
       for (const [capabilityId, controlIds] of Object.entries(
         framework.mappings,

--- a/src/lib/__tests__/compliance-engine.test.ts
+++ b/src/lib/__tests__/compliance-engine.test.ts
@@ -614,6 +614,112 @@ describe("framework assessment", () => {
     ]);
   });
 
+  it("does not infer default-deny rules from enabled firewalls", () => {
+    const data = emptyExportData();
+    data.deviceConfigurations = [
+      {
+        id: "windows-firewall",
+        "@odata.type":
+          "#microsoft.graph.windows10EndpointProtectionConfiguration",
+        firewallProfileDomain: {
+          firewallEnabled: "allowed",
+          inboundConnectionsBlocked: false,
+          outboundConnectionsBlocked: false,
+        },
+        assignments: allDevicesAssignment,
+      },
+      {
+        id: "macos-firewall",
+        "@odata.type": "#microsoft.graph.macOSEndpointProtectionConfiguration",
+        firewallEnabled: true,
+        firewallBlockAllIncoming: false,
+        assignments: allDevicesAssignment,
+      },
+    ];
+
+    const capabilities = assessCapabilities(data);
+    const nist = assessFramework(capabilities, NIST_800_171);
+    expect(nist.controls.find((c) => c.control.id === "3.13.1")?.status).toBe(
+      "evidenceFound",
+    );
+    expect(nist.controls.find((c) => c.control.id === "3.13.6")).toBeUndefined();
+    const defStan = assessFramework(capabilities, DEF_STAN_05_138);
+    expect(
+      defStan.controls.filter((c) => ["2429", "2507"].includes(c.control.id)),
+    ).toEqual([]);
+    expect(defStan.summary.partial + defStan.summary.withEvidence).toBe(0);
+  });
+
+  it("does not infer credential quality from password presence", () => {
+    const data = emptyExportData();
+    data.deviceConfigurations = [
+      {
+        "@odata.type": "#microsoft.graph.windows10GeneralConfiguration",
+        passwordRequired: true,
+      },
+      {
+        "@odata.type": "#microsoft.graph.macOSGeneralDeviceConfiguration",
+        passwordRequired: true,
+      },
+      {
+        "@odata.type": "#microsoft.graph.iosGeneralDeviceConfiguration",
+        passcodeRequired: true,
+      },
+      {
+        "@odata.type": "#microsoft.graph.androidGeneralDeviceConfiguration",
+        passwordRequired: true,
+      },
+    ].map((policy, index) => ({
+      ...policy,
+      id: `password-required-${index}`,
+      assignments: allDevicesAssignment,
+    }));
+
+    const capabilities = assessCapabilities(data);
+    const defStan = assessFramework(capabilities, DEF_STAN_05_138);
+    expect(defStan.controls.find((c) => c.control.id === "2213")).toBeUndefined();
+    // Password presence still supports authentication and mobile protection.
+    expect(
+      assessFramework(capabilities, NIST_800_171).controls.find(
+        (c) => c.control.id === "3.5.2",
+      )?.status,
+    ).toBe("evidenceFound");
+    expect(defStan.controls.find((c) => c.control.id === "2309")?.status).toBe(
+      "partialEvidence",
+    );
+  });
+
+  it("maps app sources to installation restrictions, not execution allow lists", () => {
+    const data = emptyExportData();
+    data.deviceConfigurations = [
+      {
+        id: "macos-app-sources",
+        "@odata.type": "#microsoft.graph.macOSEndpointProtectionConfiguration",
+        gatekeeperAllowedAppSource: "macAppStoreAndIdentifiedDevelopers",
+        assignments: allDevicesAssignment,
+      },
+      {
+        id: "android-personal-app-sources",
+        "@odata.type":
+          "#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration",
+        workProfileBlockPersonalAppInstallsFromUnknownSources: true,
+        assignments: allDevicesAssignment,
+      },
+    ];
+
+    const capabilities = assessCapabilities(data);
+    const nist = assessFramework(capabilities, NIST_800_171);
+    expect(nist.controls.find((c) => c.control.id === "3.4.8")).toBeUndefined();
+    expect(nist.controls.find((c) => c.control.id === "3.4.9")?.status).toBe(
+      "evidenceFound",
+    );
+    expect(
+      assessFramework(capabilities, DEF_STAN_05_138).controls.find(
+        (c) => c.control.id === "2409",
+      ),
+    ).toBeUndefined();
+  });
+
   it("keeps capability catalog and framework mappings consistent", () => {
     const capabilityIds = new Set(
       assessCapabilities(emptyExportData()).map((r) => r.capability.id),

--- a/src/lib/__tests__/compliance-engine.test.ts
+++ b/src/lib/__tests__/compliance-engine.test.ts
@@ -576,11 +576,12 @@ describe("framework assessment", () => {
       "cyber-essentials-v3",
       "nist-800-171-r2",
       "nist-800-171-r3",
+      "essential-eight",
     ]);
     for (const framework of assessment.frameworks) {
-      expect(framework.summary.withoutEvidence).toBe(
-        framework.summary.totalControls,
-      );
+      expect(
+        framework.summary.withoutEvidence + framework.summary.notAssessed,
+      ).toBe(framework.summary.totalControls);
     }
   });
 

--- a/src/lib/__tests__/compliance-integrity.test.ts
+++ b/src/lib/__tests__/compliance-integrity.test.ts
@@ -1,0 +1,638 @@
+import { describe, expect, it, vi } from "vitest";
+import { assessCapabilities, assessCompliance } from "../compliance/engine";
+import { createEvidenceManifest } from "../compliance/manifest";
+import { assignmentDetails } from "../compliance/assignments";
+import { DetailedIntuneService } from "../intune-detailed-client";
+import type { DetailedExportData } from "../configuration-analyzer";
+import type { ComplianceCapability } from "../compliance/types";
+
+const assigned = [
+  { target: { "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget" } },
+];
+const policy = (
+  type: string,
+  settings: Record<string, unknown>,
+  id = "policy",
+) => ({
+  id,
+  displayName: id,
+  "@odata.type": `#microsoft.graph.${type}`,
+  assignments: assigned,
+  ...settings,
+});
+function data(...policies: any[]): DetailedExportData {
+  return {
+    settingsCatalog: [],
+    deviceConfigurations: policies,
+    administrativeTemplates: [],
+    compliancePolicies: [],
+    securityBaselines: [],
+    scripts: { windows: [], macOS: [] },
+  };
+}
+function capability(exportData: DetailedExportData, id: string) {
+  return assessCapabilities(exportData).find(
+    (result) => result.capability.id === id,
+  )!;
+}
+
+describe("evidence integrity regressions", () => {
+  it("surfaces contradictory behavior-monitoring settings across assigned policies", () => {
+    const enabled = policy("windows10GeneralConfiguration", {
+      defenderRequireBehaviorMonitoring: true,
+    });
+    const disabled = {
+      ...policy("windows10GeneralConfiguration", {
+        defenderRequireBehaviorMonitoring: false,
+      }),
+      id: "disabled",
+    };
+    expect(
+      capability(data(enabled, disabled), "windows-behavior-monitoring").status,
+    ).toBe("conflictingEvidence");
+  });
+  it.each([
+    [{ rtpEnabled: true }, "requirementAssigned"],
+    [{ defenderEnabled: true, rtpEnabled: false }, "noEvidence"],
+    [{ antivirusRequired: true }, "noEvidence"],
+  ])("uses real-time protection semantics for %j", (settings, status) => {
+    expect(
+      capability(
+        data(policy("windows10CompliancePolicy", settings)),
+        "windows-realtime-antimalware",
+      ).status,
+    ).toBe(status);
+  });
+  it("records antivirus presence without claiming Defender real-time protection", () => {
+    const result = capability(
+      data(policy("windows10CompliancePolicy", { antivirusRequired: true })),
+      "windows-antivirus-required",
+    );
+    expect(result.status).toBe("requirementAssigned");
+    expect(result.evidence[0]?.kind).toBe("complianceRequirement");
+  });
+  it("recognizes fully managed Android integrity requirements", () => {
+    const result = capability(
+      data(
+        policy("androidDeviceOwnerCompliancePolicy", {
+          securityBlockJailbrokenDevices: true,
+        }),
+      ),
+      "android-device-integrity",
+    );
+    expect(result.status).toBe("requirementAssigned");
+  });
+  it("keeps disabled firewall profiles visible in the capability and framework", () => {
+    const exportData = data(
+      policy("windows10EndpointProtectionConfiguration", {
+        firewallProfileDomain: { firewallEnabled: "allowed" },
+        firewallProfilePublic: { firewallEnabled: "blocked" },
+      }),
+    );
+    expect(capability(exportData, "windows-firewall").status).toBe(
+      "conflictingEvidence",
+    );
+    const iso = assessCompliance(exportData).frameworks.find(
+      (framework) => framework.framework.id === "iso-27001-2022",
+    )!;
+    expect(
+      iso.controls.find((control) => control.control.id === "8.20")?.status,
+    ).toBe("conflictingEvidence");
+  });
+  it("requires all firewall profiles on the same policy", () => {
+    const domain = policy(
+      "windows10EndpointProtectionConfiguration",
+      { firewallProfileDomain: { firewallEnabled: "allowed" } },
+      "domain",
+    );
+    const other = policy(
+      "windows10EndpointProtectionConfiguration",
+      {
+        firewallProfilePrivate: { firewallEnabled: "allowed" },
+        firewallProfilePublic: { firewallEnabled: "allowed" },
+      },
+      "other",
+    );
+    expect(capability(data(domain, other), "windows-firewall").status).toBe(
+      "partialConfiguration",
+    );
+    expect(
+      capability(
+        data({
+          ...domain,
+          firewallProfilePrivate: { firewallEnabled: "allowed" },
+          firewallProfilePublic: { firewallEnabled: "allowed" },
+        }),
+        "windows-firewall",
+      ).status,
+    ).toBe("enforced");
+  });
+  it("does not drop disabled duplicate catalog values", () => {
+    const id = "device_vendor_msft_bitlocker_requiredeviceencryption";
+    const result = capability(
+      data(
+        policy("deviceManagementConfigurationPolicy", {
+          settings: [0, 1].map((value) => ({
+            settingInstance: {
+              settingDefinitionId: id,
+              choiceSettingValue: { value: `${id}_${value}` },
+            },
+          })),
+        }),
+      ),
+      "windows-disk-encryption",
+    );
+    expect(result.status).toBe("conflictingEvidence");
+    expect(result.evidence.map((item) => item.verdict).sort()).toEqual([
+      "disabled",
+      "enforced",
+    ]);
+  });
+  it("preserves filters and exclusions in portable evidence", () => {
+    const result = capability(
+      data(
+        policy("windows10CompliancePolicy", {
+          bitLockerEnabled: true,
+          assignments: [
+            {
+              target: {
+                ...assigned[0]!.target,
+                deviceAndAppManagementAssignmentFilterId: "corporate-windows",
+                deviceAndAppManagementAssignmentFilterType: "include",
+              },
+            },
+            {
+              target: {
+                "@odata.type":
+                  "#microsoft.graph.exclusionGroupAssignmentTarget",
+                groupId: "exempt",
+              },
+            },
+          ],
+        }),
+      ),
+      "windows-disk-encryption",
+    );
+    const assignment = result.evidence[0]!.assignment;
+    expect(assignment).toMatchObject({
+      state: "assigned",
+      exclusions: ["Group: exempt"],
+      filters: [{ id: "corporate-windows", mode: "include" }],
+      coverage: "unverified",
+    });
+    expect(assignmentDetails(assignment).join(" ")).toContain(
+      "Excluded: Group: exempt",
+    );
+  });
+  it.each([
+    undefined,
+    [{ target: { "@odata.type": "#microsoft.graph.futureAssignmentTarget" } }],
+  ])("preserves unknown assignment state for %j", (assignments) => {
+    expect(
+      capability(
+        data(
+          policy("windows10CompliancePolicy", {
+            bitLockerEnabled: true,
+            assignments,
+          }),
+        ),
+        "windows-disk-encryption",
+      ).status,
+    ).toBe("assignmentUnknown");
+  });
+  it("retains grace periods and the Conditional Access dependency", () => {
+    const result = capability(
+      data(
+        policy("iosCompliancePolicy", {
+          securityBlockJailbrokenDevices: true,
+          scheduledActionsForRule: [
+            {
+              scheduledActionConfigurations: [
+                { actionType: "block", gracePeriodHours: 720 },
+              ],
+            },
+          ],
+        }),
+      ),
+      "ios-jailbreak-block",
+    );
+    expect(result.evidence[0]?.note).toContain("720 hours");
+    expect(result.evidence[0]?.note).toContain("Conditional Access");
+    expect(result.status).toBe("requirementAssigned");
+  });
+  it("uses explicit platform scope and leaves unsupported controls unassessed", () => {
+    const exportData = data(
+      policy("windows10CompliancePolicy", { bitLockerEnabled: true }),
+    );
+    exportData.assessmentScope = { platforms: ["windows"] };
+    const result = assessCompliance(exportData);
+    const nist = result.frameworks.find(
+      (framework) => framework.framework.id === "nist-800-53-r5",
+    )!;
+    expect(
+      nist.controls.find((control) => control.control.id === "SC-28")
+        ?.capabilityIds,
+    ).toEqual(["windows-disk-encryption"]);
+    const bsi = result.frameworks.find(
+      (framework) => framework.framework.id === "bsi-it-grundschutz",
+    )!;
+    expect(
+      bsi.controls.find((control) => control.control.id === "SYS.2.4.A6")
+        ?.status,
+    ).toBe("notApplicable");
+    exportData.assessmentScope = { platforms: ["ios"] };
+    const iosNist = assessCompliance(exportData).frameworks.find(
+      (framework) => framework.framework.id === "nist-800-53-r5",
+    )!;
+    expect(
+      iosNist.controls.find((control) => control.control.id === "SC-7")?.status,
+    ).toBe("notAssessed");
+  });
+  it("does not infer scope from empty platform inventory or policy absence", () => {
+    const exportData = data();
+    exportData.deviceCounts = { windows: 20, macos: 0, android: 0, ios: 0 };
+    expect(capability(exportData, "macos-disk-encryption").status).toBe(
+      "noEvidence",
+    );
+  });
+  it("filters Def Stan levels without changing other frameworks", () => {
+    const result = assessCompliance(data(), { defStanRiskLevel: 0 });
+    const defStan = result.frameworks.find(
+      (framework) => framework.framework.id === "def-stan-05-138-i4",
+    )!;
+    expect(defStan.summary.applicableControls).toBe(0);
+    expect(defStan.summary.notApplicable).toBe(defStan.summary.totalControls);
+    expect(
+      result.frameworks.find(
+        (framework) => framework.framework.id === "iso-27001-2022",
+      )?.summary.notApplicable,
+    ).toBe(0);
+  });
+  it("keeps minimum OS evidence partial even when a value is present", () => {
+    const bsi = assessCompliance(
+      data(policy("macOSCompliancePolicy", { osMinimumVersion: "10.1" })),
+    ).frameworks.find(
+      (framework) => framework.framework.id === "bsi-it-grundschutz",
+    )!;
+    const control = bsi.controls.find(
+      (control) => control.control.id === "SYS.2.4.A6",
+    )!;
+    expect(control.status).toBe("partialEvidence");
+    expect(control.unassessedAspects.join(" ")).toContain("support");
+  });
+  it("reports collection failures as not assessed rather than absent", () => {
+    const exportData = data();
+    exportData.fetchErrors = [
+      {
+        policyId: "N/A",
+        policyName: "Settings Catalog",
+        policyType: "Settings Catalog",
+        error: "Forbidden",
+      },
+    ];
+    const result = assessCompliance(exportData);
+    expect(
+      result.collectionCoverage.find((row) => row.family === "settingsCatalog")
+        ?.status,
+    ).toBe("incomplete");
+    expect(capability(exportData, "windows-disk-encryption").status).toBe(
+      "collectionIncomplete",
+    );
+    expect(
+      result.frameworks[0]!.controls.find(
+        (control) => control.control.id === "SC-28",
+      )?.status,
+    ).toBe("notAssessed");
+  });
+});
+
+describe("compound detectors and legacy representations", () => {
+  it.each([
+    ["full", "monday", "enforced"],
+    ["quick", "everyday", "enforced"],
+    ["disabled", "monday", "disabledByPolicy"],
+    ["full", "noScheduledScan", "disabledByPolicy"],
+    ["userDefined", "monday", "noEvidence"],
+  ])("evaluates periodic scans %s/%s", (scan, day, status) => {
+    expect(
+      capability(
+        data(
+          policy("windows10GeneralConfiguration", {
+            defenderScanType: scan,
+            defenderSystemScanSchedule: day,
+            defenderScheduledScanTime: "02:00:00",
+          }),
+        ),
+        "windows-periodic-antimalware-scan",
+      ).status,
+    ).toBe(status);
+  });
+  it.each([
+    [2, 7, 2, false, "enforced"],
+    [8, 7, 0, false, "disabledByPolicy"],
+    [0, 7, 0, true, "disabledByPolicy"],
+    [undefined, 7, 0, false, "noEvidence"],
+  ])(
+    "checks the complete quality-update timing tuple",
+    (deferral, deadline, grace, paused, status) => {
+      expect(
+        capability(
+          data(
+            policy("windowsUpdateForBusinessConfiguration", {
+              automaticUpdateMode: "autoInstallAtMaintenanceTime",
+              qualityUpdatesDeferralPeriodInDays: deferral,
+              deadlineForQualityUpdatesInDays: deadline,
+              deadlineGracePeriodInDays: grace,
+              qualityUpdatesPaused: paused,
+            }),
+          ),
+          "windows-quality-update-deadline",
+        ).status,
+      ).toBe(status);
+    },
+  );
+  it.each([
+    "auditComponentsAndStoreApps",
+    "auditComponentsStoreAppsAndSmartlocker",
+  ])("does not count application-control audit mode %s", (mode) => {
+    expect(
+      capability(
+        data(
+          policy("windows10EndpointProtectionConfiguration", {
+            appLockerApplicationControl: mode,
+          }),
+        ),
+        "windows-application-control",
+      ).status,
+    ).toBe("disabledByPolicy");
+  });
+  it.each([
+    ["enabled", "AND", ["mfa", "compliantDevice"], "enforced"],
+    ["enabled", "OR", ["mfa"], "enforced"],
+    ["enabled", "OR", ["mfa", "compliantDevice"], "noEvidence"],
+    ["enabledForReportingButNotEnforced", "AND", ["mfa"], "noEvidence"],
+    ["disabled", "AND", ["mfa"], "noEvidence"],
+  ])(
+    "evaluates enabled CA requirements without optional OR grants",
+    (state, operator, builtInControls, status) => {
+      const exportData = data();
+      exportData.conditionalAccessPolicies = [
+        {
+          id: "ca",
+          state,
+          grantControls: { operator, builtInControls },
+          conditions: {
+            users: { includeUsers: ["All"], excludeGroups: ["emergency"] },
+            applications: { includeApplications: ["All"] },
+          },
+        },
+      ];
+      const result = capability(exportData, "tenant-mfa-required");
+      expect(result.status).toBe(status);
+      if (status === "enforced")
+        expect(result.evidence[0]?.assignment.targets.join(" ")).toContain(
+          "emergency",
+        );
+    },
+  );
+  it("does not accept an OR alternative in authentication strength as mandatory MFA", () => {
+    const exportData = data();
+    exportData.conditionalAccessPolicies = [
+      policy("conditionalAccessPolicy", {
+        state: "enabled",
+        grantControls: {
+          operator: "OR",
+          builtInControls: ["mfa"],
+          authenticationStrength: { id: "strength" },
+        },
+        conditions: {
+          users: { includeUsers: ["All"] },
+          applications: { includeApplications: ["All"] },
+        },
+      }),
+    ];
+    expect(capability(exportData, "tenant-mfa-required").status).toBe(
+      "noEvidence",
+    );
+  });
+  it("detects verified OMA-URI settings without coercing strings to numbers", () => {
+    const uri = "./Device/Vendor/MSFT/BitLocker/RequireDeviceEncryption";
+    expect(
+      capability(
+        data(
+          policy("windows10CustomConfiguration", {
+            omaSettings: [{ omaUri: uri, value: 1 }],
+          }),
+        ),
+        "windows-disk-encryption",
+      ).status,
+    ).toBe("enforced");
+    expect(
+      capability(
+        data(
+          policy("windows10CustomConfiguration", {
+            omaSettings: [{ omaUri: uri, value: "1" }],
+          }),
+        ),
+        "windows-disk-encryption",
+      ).status,
+    ).toBe("noEvidence");
+  });
+  it.each(["administrativeTemplate", "securityBaseline"] as const)(
+    "matches exact verified %s identifiers only",
+    (source) => {
+      const rule: ComplianceCapability = {
+        id: "fixture",
+        name: "Fixture",
+        description: "Adapter test",
+        platform: "windows",
+        signals: [
+          {
+            source,
+            settingId: "verified-definition",
+            enforcedWhen: { kind: "equals", value: true },
+          },
+        ],
+      };
+      const exportData = data(
+        policy("fixture", {
+          definitionValues: [
+            { definition: { id: "verified-definition" }, enabled: true },
+          ],
+          categories: [
+            {
+              settings: [
+                { definitionId: "verified-definition", valueJson: "true" },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(assessCapabilities(exportData, [rule])[0]?.status).toBe(
+        "enforced",
+      );
+      rule.signals = [
+        {
+          source,
+          settingId: "lookalike",
+          enforcedWhen: { kind: "equals", value: true },
+        },
+      ];
+      expect(assessCapabilities(exportData, [rule])[0]?.status).toBe(
+        "noEvidence",
+      );
+    },
+  );
+});
+
+describe("collection and reproducibility", () => {
+  it("reports incomplete policy metadata even when a legacy export has no error ledger", () => {
+    const exportData = data(
+      policy("windows10GeneralConfiguration", {
+        passwordRequired: true,
+        collectionStatus: { assignments: "incomplete" },
+      }),
+    );
+    exportData.collectedAt = "2026-09-04T10:00:00Z";
+    const result = assessCompliance(exportData);
+    expect(
+      result.collectionCoverage.find(
+        (row) => row.family === "deviceConfigurations",
+      )?.status,
+    ).toBe("incomplete");
+    expect(
+      result.capabilities.find(
+        (item) => item.capability.id === "windows-password-required",
+      )?.status,
+    ).toBe("assignmentUnknown");
+  });
+  it.each([
+    ["getWindowsScriptsDetailed", "/deviceManagement/deviceManagementScripts"],
+    ["getMacOSScriptsDetailed", "/deviceManagement/deviceShellScripts"],
+    [
+      "getAppConfigurationsDetailed",
+      "/deviceAppManagement/mobileAppConfigurations",
+    ],
+  ])(
+    "retains detail and assignment failures in %s",
+    async (method, endpoint) => {
+      const service = new DetailedIntuneService("test-token") as any;
+      service.retryWithBackoff = (action: () => Promise<unknown>) => action();
+      service.client = {
+        api: vi.fn((url: string) => {
+          const request: any = {
+            version: () => request,
+            select: () => request,
+            top: () => request,
+            get: async () => {
+              if (url === endpoint)
+                return { value: [{ id: "policy", displayName: "Policy" }] };
+              throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+            },
+          };
+          return request;
+        }),
+      };
+      const policies = await service[method]();
+      expect(policies[0].collectionStatus).toEqual({
+        details: "incomplete",
+        assignments: "incomplete",
+      });
+      expect(service.getFetchErrors()).toHaveLength(2);
+      expect(service.getFetchErrors()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            statusCode: 403,
+            endpoint: `${endpoint}('policy')/assignments`,
+          }),
+          expect.objectContaining({
+            statusCode: 403,
+            endpoint: `${endpoint}('policy')`,
+          }),
+        ]),
+      );
+    },
+  );
+  it.each([
+    [
+      "getDeviceConfigurationsDetailed",
+      "/deviceManagement/deviceConfigurations",
+      "windows10GeneralConfiguration",
+    ],
+    [
+      "getCompliancePoliciesDetailed",
+      "/deviceManagement/deviceCompliancePolicies",
+      "windows10CompliancePolicy",
+    ],
+  ])(
+    "preserves failed assignment requests in %s",
+    async (method, endpoint, type) => {
+      const service = new DetailedIntuneService("test-token") as any;
+      service.retryWithBackoff = (action: () => Promise<unknown>) => action();
+      service.client = {
+        api: vi.fn((url: string) => {
+          const request: any = {
+            version: () => request,
+            top: () => request,
+            expand: () => request,
+            get: async () => {
+              if (url === endpoint)
+                return { value: [policy(type, { passwordRequired: true })] };
+              if (url.endsWith("/assignments"))
+                throw Object.assign(new Error("Forbidden"), {
+                  statusCode: 403,
+                });
+              return { value: [] };
+            },
+          };
+          return request;
+        }),
+      };
+      const policies = await service[method]();
+      expect(policies[0].collectionStatus.assignments).toBe("incomplete");
+      expect(service.getFetchErrors()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            statusCode: 403,
+            endpoint: expect.stringContaining("/assignments"),
+          }),
+        ]),
+      );
+      expect(
+        capability(data(...policies), "windows-password-required").status,
+      ).toBe("assignmentUnknown");
+    },
+  );
+  it("fingerprints source snapshots and preserves policy provenance", async () => {
+    const exportData = data(
+      policy("windows10GeneralConfiguration", {
+        passwordRequired: true,
+        version: 3,
+        lastModifiedDateTime: "2026-09-01T00:00:00Z",
+      }),
+    );
+    exportData.collectedAt = "2026-09-04T10:00:00Z";
+    const first = await createEvidenceManifest(exportData);
+    const second = await createEvidenceManifest(exportData, {
+      platforms: ["windows"],
+    });
+    expect(first.snapshotSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(second.snapshotSha256).toBe(first.snapshotSha256);
+    expect(second.rulesetSha256).toBe(first.rulesetSha256);
+    expect(first.assessment.provenance.collectedAt).toBe(
+      exportData.collectedAt,
+    );
+    expect(
+      first.assessment.capabilities.find(
+        (result) => result.capability.id === "windows-password-required",
+      )?.evidence[0],
+    ).toMatchObject({
+      policyVersion: "3",
+      policyModifiedAt: "2026-09-01T00:00:00Z",
+    });
+    exportData.deviceConfigurations[0].passwordRequired = false;
+    expect((await createEvidenceManifest(exportData)).snapshotSha256).not.toBe(
+      first.snapshotSha256,
+    );
+  });
+});

--- a/src/lib/__tests__/compliance-integrity.test.ts
+++ b/src/lib/__tests__/compliance-integrity.test.ts
@@ -516,6 +516,10 @@ describe("collection and reproducibility", () => {
   ])(
     "retains detail and assignment failures in %s",
     async (method, endpoint) => {
+      const resource =
+        method === "getAppConfigurationsDetailed"
+          ? `${endpoint}('policy')`
+          : `${endpoint}/policy`;
       const service = new DetailedIntuneService("test-token") as any;
       service.retryWithBackoff = (action: () => Promise<unknown>) => action();
       service.client = {
@@ -543,11 +547,11 @@ describe("collection and reproducibility", () => {
         expect.arrayContaining([
           expect.objectContaining({
             statusCode: 403,
-            endpoint: `${endpoint}('policy')/assignments`,
+            endpoint: `${resource}/assignments`,
           }),
           expect.objectContaining({
             statusCode: 403,
-            endpoint: `${endpoint}('policy')`,
+            endpoint: resource,
           }),
         ]),
       );

--- a/src/lib/__tests__/compliance-integrity.test.ts
+++ b/src/lib/__tests__/compliance-integrity.test.ts
@@ -329,7 +329,7 @@ describe("compound detectors and legacy representations", () => {
   });
   it.each([
     [2, 7, 2, false, "enforced"],
-    [8, 7, 0, false, "disabledByPolicy"],
+    [8, 7, 0, false, "noEvidence"],
     [0, 7, 0, true, "disabledByPolicy"],
     [undefined, 7, 0, false, "noEvidence"],
   ])(
@@ -639,4 +639,84 @@ describe("collection and reproducibility", () => {
       first.snapshotSha256,
     );
   });
+});
+
+it("keeps ancillary action failures visible without invalidating unrelated evidence", () => {
+  const input = data();
+  input.collectedAt = "2026-09-07T10:00:00Z";
+  input.compliancePolicies = [
+    policy("windows10CompliancePolicy", {
+      collectionStatus: {
+        assignments: "complete",
+        scheduledActionsForRule: "incomplete",
+      },
+    }),
+  ];
+  input.fetchErrors = [
+    {
+      policyId: "policy",
+      policyName: "Actions",
+      policyType: "Compliance Policies",
+      familyKey: "compliancePolicies",
+      endpoint:
+        "/deviceManagement/deviceCompliancePolicies/policy?$expand=scheduledActionsForRule($expand=scheduledActionConfigurations)",
+      error: "HTTP 400",
+      partial: true,
+    },
+  ];
+  const result = assessCompliance(input);
+  expect(
+    result.collectionCoverage.find((r) => r.family === "compliancePolicies")
+      ?.status,
+  ).toBe("incomplete");
+  expect(capability(input, "windows-disk-encryption").status).toBe(
+    "noEvidence",
+  );
+  input.compliancePolicies[0].collectionStatus.assignments = "incomplete";
+  expect(capability(input, "windows-disk-encryption").status).toBe(
+    "collectionIncomplete",
+  );
+});
+
+it("preserves unknown detail failures as evidence-incomplete", () => {
+  const input = data(
+    policy("windows10GeneralConfiguration", { hasFetchError: true }),
+  );
+  expect(capability(input, "windows-disk-encryption").status).toBe(
+    "collectionIncomplete",
+  );
+});
+
+it("recognizes a firewall compliance requirement without treating it as profile configuration", () => {
+  const input = data(
+    policy("windows10CompliancePolicy", { activeFirewallRequired: true }),
+  );
+  expect(capability(input, "windows-firewall").status).toBe(
+    "requirementAssigned",
+  );
+  input.deviceConfigurations.push(
+    policy(
+      "windows10EndpointProtectionConfiguration",
+      { firewallProfileDomain: { firewallEnabled: "allowed" } },
+      "domain-only",
+    ),
+  );
+  expect(capability(input, "windows-firewall").status).toBe(
+    "requirementAssigned",
+  );
+});
+
+it("does not report a 21-day update ring as assigned counter-evidence", () => {
+  const input = data(
+    policy("windowsUpdateForBusinessConfiguration", {
+      qualityUpdatesDeferralPeriodInDays: 14,
+      deadlineForQualityUpdatesInDays: 7,
+      deadlineGracePeriodInDays: 0,
+      qualityUpdatesPaused: false,
+      automaticUpdateMode: "autoInstallAtMaintenanceTime",
+    }),
+  );
+  const result = capability(input, "windows-quality-update-deadline");
+  expect(result.status).toBe("noEvidence");
+  expect(result.evidence).toHaveLength(0);
 });

--- a/src/lib/__tests__/compliance-report.test.ts
+++ b/src/lib/__tests__/compliance-report.test.ts
@@ -132,7 +132,7 @@ describe("compliance report PDF", () => {
       "Technischer Konfigurationsnachweis erkannt",
     );
     expect(renderedText).toContain("SYS.3.2.2.A17");
-    expect(renderedText).toContain("Kein technischer Nachweis gefunden");
+    expect(renderedText).toContain("Nicht bewertet");
     expect(renderedText).toContain("ersetzt keine");
     expect(renderedText).toContain("Assigned BitLocker evidence policy");
     expect(renderedText).toContain("Einstellungskatalog");
@@ -295,7 +295,8 @@ describe("compliance report PDF", () => {
         {
           id: "unmapped-unassigned",
           displayName: "Unmapped unassigned configuration",
-          "@odata.type": "#microsoft.graph.macOSEndpointProtectionConfiguration",
+          "@odata.type":
+            "#microsoft.graph.macOSEndpointProtectionConfiguration",
           ...unassignedSettings,
           assignments: [],
         },
@@ -306,9 +307,11 @@ describe("compliance report PDF", () => {
       );
       expect(unmappedText).toContain("Assigned deviating configurations: 0");
       expect(unmappedText).toContain(
-        "Compliant configurations without assignment: 0",
+        "Configured settings without assignment: 0",
       );
-      expect(unmappedText).toContain("No prioritized findings were identified.");
+      expect(unmappedText).toContain(
+        "No prioritized findings were identified.",
+      );
       expect(unmappedText).not.toContain("Unmapped assigned deviation");
       expect(unmappedText).not.toContain("Unmapped unassigned configuration");
 
@@ -342,9 +345,7 @@ describe("compliance report PDF", () => {
         await generateComplianceReportPDF(data, { frameworkId }),
       );
       expect(mixedText).toContain("Assigned deviating configurations: 1.");
-      expect(mixedText).toContain(
-        "Compliant configurations without assignment: 1.",
-      );
+      expect(mixedText).toContain("Configured settings without assignment: 1.");
       expect(mixedText).toContain("Mapped assigned deviation");
       expect(mixedText).toContain("Mapped unassigned configuration");
       expect(mixedText).not.toContain("Unmapped assigned deviation");
@@ -398,8 +399,14 @@ describe("compliance report PDF", () => {
     });
 
     for (const ordering of [
-      [policy("zzz-policy", "Zebra Baseline"), policy("aaa-policy", "Alpha Baseline")],
-      [policy("aaa-policy", "Alpha Baseline"), policy("zzz-policy", "Zebra Baseline")],
+      [
+        policy("zzz-policy", "Zebra Baseline"),
+        policy("aaa-policy", "Alpha Baseline"),
+      ],
+      [
+        policy("aaa-policy", "Alpha Baseline"),
+        policy("zzz-policy", "Zebra Baseline"),
+      ],
     ]) {
       const data = { ...createExportData(), settingsCatalog: ordering };
       const bytes = await generateComplianceReportPDF(data, {
@@ -435,5 +442,27 @@ describe("compliance report PDF", () => {
     for (const capability of COMPLIANCE_CAPABILITIES) {
       expect(GERMAN_CAPABILITY_NAMES[capability.id]).toBeTruthy();
     }
+  });
+
+  it("does not label counter-evidence with an unreadable assignment as unassigned", async () => {
+    const data = createExportData();
+    data.deviceConfigurations = [
+      {
+        id: "unknown-firewall",
+        displayName: "Unknown firewall assignment",
+        "@odata.type":
+          "#microsoft.graph.windows10EndpointProtectionConfiguration",
+        firewallProfileDomain: { firewallEnabled: "blocked" },
+        assignments: [],
+        collectionStatus: { assignments: "incomplete" },
+      },
+    ];
+    const text = extractPdfStreamText(
+      await generateComplianceReportPDF(data, {
+        frameworkId: "iso-27001-2022",
+      }),
+    );
+    expect(text).toContain("blocked \\(assignment unknown\\)");
+    expect(text).not.toContain("blocked \\(not assigned\\)");
   });
 });

--- a/src/lib/__tests__/compliance-report.test.ts
+++ b/src/lib/__tests__/compliance-report.test.ts
@@ -250,6 +250,108 @@ describe("compliance report PDF", () => {
     expect(nist171Text).toContain("3.13.16");
   });
 
+  it.each([
+    {
+      frameworkId: "cyber-essentials-v3" as const,
+      disabledSettingId: "device_vendor_msft_bitlocker_requiredeviceencryption",
+      disabledValue: "device_vendor_msft_bitlocker_requiredeviceencryption_0",
+      unassignedSettings: { fileVaultEnabled: true },
+    },
+    {
+      frameworkId: "def-stan-05-138-i4" as const,
+      disabledSettingId:
+        "vendor_msft_firewall_mdmstore_domainprofile_enablefirewall",
+      disabledValue:
+        "vendor_msft_firewall_mdmstore_domainprofile_enablefirewall_false",
+      unassignedSettings: { firewallEnabled: true },
+    },
+  ])(
+    "scopes summary counters to mapped capabilities for $frameworkId",
+    async ({
+      frameworkId,
+      disabledSettingId,
+      disabledValue,
+      unassignedSettings,
+    }) => {
+      const data = createExportData();
+      data.compliancePolicies = [];
+      data.fetchErrors = [];
+      data.settingsCatalog = [
+        {
+          id: "unmapped-deviation",
+          name: "Unmapped assigned deviation",
+          assignments: allDevicesAssignment,
+          settings: [
+            {
+              settingInstance: {
+                settingDefinitionId: disabledSettingId,
+                choiceSettingValue: { value: disabledValue },
+              },
+            },
+          ],
+        },
+      ];
+      data.deviceConfigurations = [
+        {
+          id: "unmapped-unassigned",
+          displayName: "Unmapped unassigned configuration",
+          "@odata.type": "#microsoft.graph.macOSEndpointProtectionConfiguration",
+          ...unassignedSettings,
+          assignments: [],
+        },
+      ];
+
+      const unmappedText = extractPdfStreamText(
+        await generateComplianceReportPDF(data, { frameworkId }),
+      );
+      expect(unmappedText).toContain("Assigned deviating configurations: 0");
+      expect(unmappedText).toContain(
+        "Compliant configurations without assignment: 0",
+      );
+      expect(unmappedText).toContain("No prioritized findings were identified.");
+      expect(unmappedText).not.toContain("Unmapped assigned deviation");
+      expect(unmappedText).not.toContain("Unmapped unassigned configuration");
+
+      // Relevant signals must still appear when mixed with excluded capabilities.
+      data.settingsCatalog.push({
+        id: "mapped-deviation",
+        name: "Mapped assigned deviation",
+        assignments: allDevicesAssignment,
+        settings: [
+          {
+            settingInstance: {
+              settingDefinitionId:
+                "device_vendor_msft_policy_config_defender_allowrealtimemonitoring",
+              choiceSettingValue: {
+                value:
+                  "device_vendor_msft_policy_config_defender_allowrealtimemonitoring_0",
+              },
+            },
+          },
+        ],
+      });
+      data.deviceConfigurations.push({
+        id: "mapped-unassigned",
+        displayName: "Mapped unassigned configuration",
+        "@odata.type": "#microsoft.graph.windows10GeneralConfiguration",
+        microsoftAccountBlocked: true,
+        assignments: [],
+      });
+
+      const mixedText = extractPdfStreamText(
+        await generateComplianceReportPDF(data, { frameworkId }),
+      );
+      expect(mixedText).toContain("Assigned deviating configurations: 1.");
+      expect(mixedText).toContain(
+        "Compliant configurations without assignment: 1.",
+      );
+      expect(mixedText).toContain("Mapped assigned deviation");
+      expect(mixedText).toContain("Mapped unassigned configuration");
+      expect(mixedText).not.toContain("Unmapped assigned deviation");
+      expect(mixedText).not.toContain("Unmapped unassigned configuration");
+    },
+  );
+
   it("includes every body evidence reference in the appendix", async () => {
     const report = await generateComplianceReportPDF(createExportData(), {
       frameworkId: "bsi-it-grundschutz",

--- a/src/lib/__tests__/compliance-report.test.ts
+++ b/src/lib/__tests__/compliance-report.test.ts
@@ -206,6 +206,48 @@ describe("compliance report PDF", () => {
     expect(complianceReportFileName("soc2-tsc")).toMatch(
       /Compliance-Report-SOC-2-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
     );
+    expect(complianceReportFileName("def-stan-05-138-i4")).toMatch(
+      /Compliance-Report-Def-Stan-05-138-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
+    );
+    expect(complianceReportFileName("cyber-essentials-v3")).toMatch(
+      /Compliance-Report-Cyber-Essentials-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
+    );
+    expect(complianceReportFileName("nist-800-171-r2")).toMatch(
+      /Compliance-Report-NIST-800-171-R2-\d{4}-\d{2}-\d{2}-\d{4}\.pdf/,
+    );
+  });
+
+  it("renders English Def Stan 05-138, Cyber Essentials and NIST 800-171 reports", async () => {
+    const defStanReport = await generateComplianceReportPDF(
+      createExportData(),
+      {
+        frameworkId: "def-stan-05-138-i4",
+      },
+    );
+    const defStanText = extractPdfStreamText(defStanReport);
+    expect(defStanText).toContain("Def Stan 05-138");
+    expect(defStanText).toContain("2317");
+    expect(defStanText).toContain("Level 1 to Level 3");
+    expect(defStanText).toContain("not a compliance certification");
+
+    const cyberEssentialsReport = await generateComplianceReportPDF(
+      createExportData(),
+      { frameworkId: "cyber-essentials-v3" },
+    );
+    const cyberEssentialsText = extractPdfStreamText(cyberEssentialsReport);
+    expect(cyberEssentialsText).toContain("Cyber Essentials");
+    expect(cyberEssentialsText).toContain("Security update management");
+    expect(cyberEssentialsText).toContain("Open Government Licence");
+
+    const nist171Report = await generateComplianceReportPDF(
+      createExportData(),
+      {
+        frameworkId: "nist-800-171-r2",
+      },
+    );
+    const nist171Text = extractPdfStreamText(nist171Report);
+    expect(nist171Text).toContain("NIST SP 800-171");
+    expect(nist171Text).toContain("3.13.16");
   });
 
   it("includes every body evidence reference in the appendix", async () => {

--- a/src/lib/__tests__/compliance-report.test.ts
+++ b/src/lib/__tests__/compliance-report.test.ts
@@ -466,3 +466,36 @@ describe("compliance report PDF", () => {
     expect(text).not.toContain("blocked \\(not assigned\\)");
   });
 });
+
+it("paginates oversized evidence-register rows without drawing text below the page", async () => {
+  const data = createExportData();
+  data.conditionalAccessPolicies = [
+    {
+      id: "large-ca",
+      displayName: "Large MFA policy",
+      "@odata.type": "#microsoft.graph.conditionalAccessPolicy",
+      state: "enabled",
+      grantControls: { operator: "AND", builtInControls: ["mfa"] },
+      conditions: {
+        users: {
+          includeUsers: ["All"],
+          excludeGroups: Array.from(
+            { length: 80 },
+            (_, i) => `00000000-0000-0000-0000-${String(i).padStart(12, "0")}`,
+          ),
+        },
+        applications: { includeApplications: ["All"] },
+      },
+    },
+  ];
+  const text = extractPdfStreamText(
+    await generateComplianceReportPDF(data, { frameworkId: "nist-800-171-r2" }),
+  );
+  const positions = [
+    ...text.matchAll(/(-?\d+(?:\.\d+)?) (-?\d+(?:\.\d+)?) Td/g),
+  ];
+  expect(positions.length).toBeGreaterThan(100);
+  expect(positions.every((match) => Number(match[2]) >= 0)).toBe(true);
+  expect(text).toContain("Appendix A");
+  expect(text).toContain("Large MFA policy");
+});

--- a/src/lib/__tests__/configuration-sections.test.ts
+++ b/src/lib/__tests__/configuration-sections.test.ts
@@ -85,6 +85,7 @@ describe("normalized configuration sections", () => {
         assigned: 1,
         unassigned: 0,
         unknown: 0,
+        notApplicable: 0,
       },
       {
         key: "mobileApps",
@@ -93,6 +94,7 @@ describe("normalized configuration sections", () => {
         assigned: 0,
         unassigned: 1,
         unknown: 0,
+        notApplicable: 0,
       },
     ]);
   });
@@ -146,3 +148,48 @@ it("does not turn unavailable or malformed assignment reads into missing assignm
   });
   expect(analytics.topGroups).toEqual([["All Devices", 1]]);
 });
+
+it.each([false, true])(
+  "does not classify Conditional Access conditions as unknown Intune assignments (sections=%s)",
+  (sections) => {
+    const ca = {
+      id: "ca",
+      state: "enabled",
+      conditions: { users: { includeUsers: ["All"] } },
+    };
+    const input = {
+      settingsCatalog: [],
+      deviceConfigurations: [],
+      administrativeTemplates: [],
+      compliancePolicies: [],
+      securityBaselines: [],
+      scripts: { windows: [], macOS: [] },
+      ...(sections
+        ? {
+            sections: [
+              {
+                key: "conditionalAccessPolicies",
+                familyKey: "conditionalAccessPolicies",
+                label: "Conditional Access",
+                selectionPrefix: "ca",
+                items: [ca],
+              },
+            ],
+          }
+        : { conditionalAccessPolicies: [ca] }),
+    };
+    const result = analyzeConfigurations(input);
+    expect(result).toMatchObject({
+      totalConfigs: 1,
+      assignmentApplicableConfigs: 0,
+      assignmentNotApplicableConfigs: 1,
+      assignedConfigs: 0,
+      unassignedConfigs: 0,
+      unknownAssignmentConfigs: 0,
+    });
+    expect(result.inventory.find((r) => r.total === 1)).toMatchObject({
+      notApplicable: 1,
+      unknown: 0,
+    });
+  },
+);

--- a/src/lib/__tests__/configuration-sections.test.ts
+++ b/src/lib/__tests__/configuration-sections.test.ts
@@ -46,7 +46,19 @@ describe("normalized configuration sections", () => {
           familyKey: "settingsCatalog",
           label: "Settings Catalog",
           selectionPrefix: "catalog",
-          items: [{ id: "policy-1", assignments: [{ id: "assignment-1" }] }],
+          items: [
+            {
+              id: "policy-1",
+              assignments: [
+                {
+                  target: {
+                    "@odata.type":
+                      "#microsoft.graph.allDevicesAssignmentTarget",
+                  },
+                },
+              ],
+            },
+          ],
         },
         {
           key: "mobileApps",
@@ -71,8 +83,66 @@ describe("normalized configuration sections", () => {
         label: "Settings Catalog",
         total: 1,
         assigned: 1,
+        unassigned: 0,
+        unknown: 0,
       },
-      { key: "mobileApps", label: "Mobile apps", total: 1, assigned: 0 },
+      {
+        key: "mobileApps",
+        label: "Mobile apps",
+        total: 1,
+        assigned: 0,
+        unassigned: 1,
+        unknown: 0,
+      },
     ]);
   });
+});
+
+it("does not turn unavailable or malformed assignment reads into missing assignments", () => {
+  const target = {
+    "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget",
+  };
+  const analytics = analyzeConfigurations({
+    settingsCatalog: [
+      { assignments: [{ target }] },
+      { assignments: [] },
+      { assignments: [], collectionStatus: { assignments: "incomplete" } },
+      {
+        assignments: [{ target }],
+        collectionStatus: { assignments: "incomplete" },
+      },
+      {},
+      { assignments: [{ id: "unrecognized" }] },
+      {
+        assignments: [
+          {
+            target: {
+              "@odata.type": "#microsoft.graph.exclusionGroupAssignmentTarget",
+              groupId: "excluded",
+            },
+          },
+        ],
+      },
+    ],
+    deviceConfigurations: [],
+    administrativeTemplates: [],
+    compliancePolicies: [],
+    securityBaselines: [],
+    scripts: { windows: [], macOS: [] },
+    windowsUpdatePolicies: [{ assignments: [] }],
+  });
+  expect(analytics).toMatchObject({
+    totalConfigs: 8,
+    assignedConfigs: 1,
+    unassignedConfigs: 3,
+    unknownAssignmentConfigs: 4,
+  });
+  expect(analytics.inventory.reduce((n, row) => n + row.total, 0)).toBe(8);
+  expect(analytics.inventory[0]).toMatchObject({
+    total: 7,
+    assigned: 1,
+    unassigned: 2,
+    unknown: 4,
+  });
+  expect(analytics.topGroups).toEqual([["All Devices", 1]]);
 });

--- a/src/lib/__tests__/defender-policy-export.test.ts
+++ b/src/lib/__tests__/defender-policy-export.test.ts
@@ -140,3 +140,51 @@ describe("Defender policy exports", () => {
     expect(documentXml).not.toContain(">Configuration evidence<");
   });
 });
+
+it.each(["PDF", "Word"])(
+  "preserves parsed baseline and list values in %s output",
+  async (format) => {
+    const data = createExportData();
+    data.settingsCatalog = [];
+    data.securityBaselines = [
+      {
+        id: "baseline",
+        displayName: "Baseline example",
+        settings: [
+          { definitionId: "sample", valueJson: '"baseline-value-example"' },
+        ],
+        categories: [{ id: "category", displayName: "Security" }],
+        assignments: [],
+        collectionStatus: { assignments: "incomplete" },
+      },
+    ] as any;
+    data.administrativeTemplates = [
+      {
+        id: "template",
+        displayName: "List example",
+        assignments: [],
+        definitionValues: [
+          {
+            enabled: true,
+            definition: { displayName: "Sites" },
+            presentationValues: [
+              { values: [{ name: "Site", value: "list-value-example" }] },
+            ],
+          },
+        ],
+      },
+    ] as any;
+    const result =
+      format === "PDF"
+        ? await generateDetailedPDF(data)
+        : await generateDetailedDOCX(data);
+    const text =
+      format === "PDF"
+        ? extractPdfStreamText(result.buffer)
+        : extractZipEntry(result.buffer, "word/document.xml");
+    expect(text).toContain("baseline-value-example");
+    expect(text).toContain("list-value-example");
+    expect(text).toContain("Assignments unavailable");
+    expect(result.errors).toEqual([]);
+  },
+);

--- a/src/lib/__tests__/defender-policy-export.test.ts
+++ b/src/lib/__tests__/defender-policy-export.test.ts
@@ -103,6 +103,10 @@ describe("Defender policy exports", () => {
     expect(renderedText).toContain("intunedocumentation.com/dashboard");
     // The exclusions-only Defender fixture must not produce evidence claims.
     expect(renderedText).not.toContain("Evidence found");
+    expect(renderedText).toContain("Rev. 2");
+    expect(renderedText).toContain("Rev. 3");
+    expect(renderedText).toContain("11 of 110 published requirements");
+    expect(renderedText).toContain("11 of 97 published requirements");
   });
 
   it("renders a Defender-managed policy through the ordinary Word policy path", async () => {
@@ -125,6 +129,10 @@ describe("Defender policy exports", () => {
     const documentXml = extractZipEntry(result.buffer, "word/document.xml");
 
     expect(documentXml).toContain("Compliance Evidence Preview");
+    expect(documentXml).toContain("Rev. 2");
+    expect(documentXml).toContain("Rev. 3");
+    expect(documentXml).toContain("11 of 110 published requirements");
+    expect(documentXml).toContain("11 of 97 published requirements");
     expect(documentXml).toContain("BSI IT-Grundschutz");
     expect(documentXml).toContain("not a compliance certification");
     expect(documentXml).toContain("intunedocumentation.com/dashboard");

--- a/src/lib/__tests__/defender-policy-export.test.ts
+++ b/src/lib/__tests__/defender-policy-export.test.ts
@@ -211,3 +211,43 @@ it.each(["PDF", "Word"])(
     expect(result.errors).toEqual([]);
   },
 );
+
+it("provides populated Word contents links with valid section bookmarks", async () => {
+  const result = await generateDetailedDOCX(createExportData());
+  const xml = extractZipEntry(result.buffer, "word/document.xml");
+  const anchors = [...xml.matchAll(/w:hyperlink[^>]*w:anchor="([^"]+)"/g)].map(
+    (match) => match[1],
+  );
+  expect(anchors.length).toBeGreaterThan(1);
+  for (const anchor of anchors) expect(xml).toContain(`w:name="${anchor}"`);
+  expect(new Set(anchors).size).toBe(anchors.length);
+  expect(xml).not.toContain("Update Field");
+  expect(xml).not.toMatch(/w:instrText[^>]*>\s*TOC/);
+});
+
+it.each(["PDF", "Word"])(
+  "reports unavailable assignments separately in the full %s summary",
+  async (format) => {
+    const data = createExportData();
+    data.settingsCatalog = [
+      {
+        id: "unknown",
+        name: "Unreadable policy",
+        settings: [],
+        assignments: [],
+        collectionStatus: { assignments: "incomplete" },
+      },
+    ];
+    const result =
+      format === "PDF"
+        ? await generateDetailedPDF(data)
+        : await generateDetailedDOCX(data);
+    const text =
+      format === "PDF"
+        ? extractPdfStreamText(result.buffer)
+        : extractZipEntry(result.buffer, "word/document.xml");
+    expect(text).toContain("Unknown");
+    expect(text).not.toContain("have no group assignment");
+    expect(text).toContain("Assignments unavailable");
+  },
+);

--- a/src/lib/__tests__/defender-policy-export.test.ts
+++ b/src/lib/__tests__/defender-policy-export.test.ts
@@ -188,3 +188,26 @@ it.each(["PDF", "Word"])(
     expect(result.errors).toEqual([]);
   },
 );
+
+it.each(["PDF", "Word"])(
+  "carries Essential Eight Level 3 into the full %s preview",
+  async (format) => {
+    const data = createExportData();
+    data.assessmentScope = { essentialEightMaturityLevel: 3 };
+    const result =
+      format === "PDF"
+        ? await generateDetailedPDF(data)
+        : await generateDetailedDOCX(data);
+    const text =
+      format === "PDF"
+        ? extractPdfStreamText(result.buffer)
+        : extractZipEntry(result.buffer, "word/document.xml");
+    expect(text).toContain("target Maturity Level 3");
+    expect(text).toContain("149 published requirement entries");
+    expect(text).toContain(
+      "Application control is implemented on internet-facing servers.",
+    );
+    expect(text).not.toContain("target Maturity Level 1");
+    expect(result.errors).toEqual([]);
+  },
+);

--- a/src/lib/__tests__/defender-policy-export.test.ts
+++ b/src/lib/__tests__/defender-policy-export.test.ts
@@ -105,7 +105,7 @@ describe("Defender policy exports", () => {
     expect(renderedText).not.toContain("Evidence found");
     expect(renderedText).toContain("Rev. 2");
     expect(renderedText).toContain("Rev. 3");
-    expect(renderedText).toContain("11 of 110 published requirements");
+    expect(renderedText).toContain("12 of 110 published requirements");
     expect(renderedText).toContain("11 of 97 published requirements");
   });
 
@@ -131,7 +131,7 @@ describe("Defender policy exports", () => {
     expect(documentXml).toContain("Compliance Evidence Preview");
     expect(documentXml).toContain("Rev. 2");
     expect(documentXml).toContain("Rev. 3");
-    expect(documentXml).toContain("11 of 110 published requirements");
+    expect(documentXml).toContain("12 of 110 published requirements");
     expect(documentXml).toContain("11 of 97 published requirements");
     expect(documentXml).toContain("BSI IT-Grundschutz");
     expect(documentXml).toContain("not a compliance certification");
@@ -222,6 +222,9 @@ it("provides populated Word contents links with valid section bookmarks", async 
   for (const anchor of anchors) expect(xml).toContain(`w:name="${anchor}"`);
   expect(new Set(anchors).size).toBe(anchors.length);
   expect(xml).not.toContain("Update Field");
+  expect(extractZipEntry(result.buffer, "word/settings.xml")).not.toContain(
+    "w:updateFields",
+  );
   expect(xml).not.toMatch(/w:instrText[^>]*>\s*TOC/);
 });
 

--- a/src/lib/__tests__/essential-eight.test.ts
+++ b/src/lib/__tests__/essential-eight.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { assessCompliance, essentialEightFramework } from "../compliance";
+import type { DetailedExportData } from "../configuration-analyzer";
+import { COMPLIANCE_CAPABILITIES } from "../compliance/capabilities";
+import { createEvidenceManifest } from "../compliance/manifest";
+import { generateComplianceReportPDF } from "../compliance/report-pdf";
+import { extractPdfStreamText } from "./helpers/pdf-text";
+import source from "../compliance/frameworks/essential-eight-requirements.json";
+
+const data = (
+  level: 1 | 2 | 3 = 1,
+  values: Record<string, unknown> = {},
+): DetailedExportData => ({
+  assessmentScope: { essentialEightMaturityLevel: level },
+  settingsCatalog: [],
+  administrativeTemplates: [],
+  compliancePolicies: [],
+  securityBaselines: [],
+  scripts: { windows: [], macOS: [] },
+  deviceConfigurations: [
+    {
+      id: "endpoint",
+      displayName: "Example endpoint",
+      "@odata.type":
+        "#microsoft.graph.windows10EndpointProtectionConfiguration",
+      assignments: [
+        {
+          target: {
+            "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget",
+          },
+        },
+      ],
+      ...values,
+    },
+  ],
+});
+const assess = (input: DetailedExportData) =>
+  assessCompliance(input).frameworks.find(
+    (f) => f.framework.id === "essential-eight",
+  )!;
+
+describe("Essential Eight target maturity", () => {
+  it.each([
+    [1, 48],
+    [2, 107],
+    [3, 149],
+  ] as const)("includes every Level %s requirement", (level, count) => {
+    const framework = essentialEightFramework(level);
+    expect(Object.keys(framework.controls)).toHaveLength(count);
+    expect(
+      new Set(Object.values(framework.controls).map((c) => c.title)).size,
+    ).toBe(8);
+    expect(
+      new Set(
+        source.requirements.filter((r) => r.level === level).map((r) => r.id),
+      ).size,
+    ).toBe(count);
+    const known = new Set(COMPLIANCE_CAPABILITIES.map((c) => c.id));
+    for (const [capability, ids] of Object.entries(framework.mappings)) {
+      expect(known.has(capability)).toBe(true);
+      for (const id of ids) expect(framework.controls[id]).toBeDefined();
+    }
+    const result = assess(data(level));
+    expect(result.summary.withEvidence).toBe(0);
+    expect(
+      result.controls
+        .filter((c) => c.control.title === "Regular backups")
+        .every((c) => c.status === "notAssessed"),
+    ).toBe(true);
+    expect(result.framework.version).toContain(
+      `target Maturity Level ${level}`,
+    );
+  });
+  it("does not invent maturity zero or silently accept invalid targets", () => {
+    expect(() => essentialEightFramework(0 as any)).toThrow();
+    expect(() => essentialEightFramework(4 as any)).toThrow();
+    expect(
+      assessCompliance({ ...data(), assessmentScope: undefined }).scope
+        .essentialEightMaturityLevel,
+    ).toBe(1);
+  });
+  it("only introduces Win32 macro restrictions at Levels 2 and 3", () => {
+    const values = { defenderOfficeMacroCodeAllowWin32ImportsType: "block" };
+    expect(
+      assess(data(1, values)).controls.some((c) =>
+        c.capabilityIds.includes("windows-office-macro-win32-block"),
+      ),
+    ).toBe(false);
+    for (const level of [2, 3] as const) {
+      const row = assess(data(level, values)).controls.find((c) =>
+        c.capabilityIds.includes("windows-office-macro-win32-block"),
+      )!;
+      expect(row.status).toBe("partialEvidence");
+    }
+  });
+  it.each(["auditMode", "warn", "disable", "userDefined"])(
+    "does not count %s as blocking",
+    (mode) => {
+      const row = assess(
+        data(2, { defenderOfficeAppsLaunchChildProcessType: mode }),
+      ).controls.find((c) =>
+        c.capabilityIds.includes("windows-office-child-process-block"),
+      )!;
+      expect(row.enforcedCapabilityIds).toEqual([]);
+      expect(row.status).not.toBe("partialEvidence");
+    },
+  );
+  it("does not credit Level 3 protections at lower levels", () => {
+    for (const level of [1, 2] as const)
+      expect(
+        essentialEightFramework(level).mappings["windows-credential-guard"],
+      ).toBeUndefined();
+    expect(
+      essentialEightFramework(3).mappings["windows-credential-guard"],
+    ).toHaveLength(1);
+    expect(
+      Object.values(essentialEightFramework(3).controls).some((c) =>
+        c.summary.includes("48 hours"),
+      ),
+    ).toBe(true);
+  });
+  it("preserves selected target and changes ruleset hash without changing snapshot hash", async () => {
+    const one = await createEvidenceManifest(data(1));
+    const three = await createEvidenceManifest(data(3));
+    expect(one.snapshotSha256).toBe(three.snapshotSha256);
+    expect(one.rulesetSha256).not.toBe(three.rulesetSha256);
+    expect(three.assessment.scope.essentialEightMaturityLevel).toBe(3);
+  });
+  it.each([1, 2, 3] as const)(
+    "exports the Level %s requirements and target disclaimer to PDF",
+    async (level) => {
+      const bytes = await generateComplianceReportPDF(data(level), {
+        frameworkId: "essential-eight",
+      });
+      const text = extractPdfStreamText(bytes);
+      expect(text).toContain(`Maturity Level ${level}`);
+      expect(text).toContain(`ML${level}-BK-01`);
+      expect(text).toContain("achieved maturity");
+      expect(text).toContain(
+        "Application control is implemented on workstations.",
+      );
+    },
+  );
+});
+
+it("keeps urgent patches, phishing resistance and backups explicitly unmapped", () => {
+  for (const level of [1, 2, 3] as const) {
+    const framework = essentialEightFramework(level);
+    const mapped = new Set(Object.values(framework.mappings).flat());
+    for (const control of Object.values(framework.controls)) {
+      if (
+        control.summary.includes("48 hours") ||
+        control.summary.includes("phishing-resistant") ||
+        control.title === "Regular backups"
+      )
+        expect(mapped.has(control.id)).toBe(false);
+    }
+    expect(mapped.size).toBe({ 1: 3, 2: 8, 3: 10 }[level]);
+  }
+});
+it("preserves conflicting ASR policies and explicit platform scope", () => {
+  const input = data(2, { defenderOfficeAppsLaunchChildProcessType: "block" });
+  input.deviceConfigurations.push({
+    ...input.deviceConfigurations[0]!,
+    id: "counter",
+    defenderOfficeAppsLaunchChildProcessType: "auditMode",
+  });
+  const row = assess(input).controls.find((c) =>
+    c.capabilityIds.includes("windows-office-child-process-block"),
+  )!;
+  expect(row.status).toBe("conflictingEvidence");
+  input.assessmentScope = {
+    essentialEightMaturityLevel: 2,
+    platforms: ["macos"],
+  };
+  const scoped = assess(input).controls.find(
+    (c) => c.control.id === row.control.id,
+  )!;
+  expect(scoped.status).toBe("notApplicable");
+});

--- a/src/lib/__tests__/essential-eight.test.ts
+++ b/src/lib/__tests__/essential-eight.test.ts
@@ -139,6 +139,23 @@ describe("Essential Eight target maturity", () => {
       expect(text).toContain(
         "Application control is implemented on workstations.",
       );
+      const contentsStart = text.indexOf("(Table of Contents) Tj");
+      const contentsEnd = text.indexOf("(Summary) Tj", contentsStart);
+      // The first Summary entry belongs to the contents. Stop at the body
+      // Summary heading, which follows the contents page's text stream.
+      const bodyStart = text.indexOf("(Summary) Tj", contentsEnd + 1);
+      expect(contentsStart).toBeGreaterThan(0);
+      expect(bodyStart).toBeGreaterThan(contentsEnd);
+      const contents = text.slice(contentsStart, bodyStart);
+      const strategies = new Set(
+        Object.values(essentialEightFramework(level).controls).map(
+          (control) => control.title,
+        ),
+      );
+      for (const strategy of strategies) {
+        expect(contents.split(`(${strategy}) Tj`)).toHaveLength(2);
+      }
+      expect(contents).not.toMatch(/ML[123]-[A-Z]+-\d+/);
     },
   );
 });

--- a/src/lib/__tests__/graph-request.test.ts
+++ b/src/lib/__tests__/graph-request.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createGraphLimiter,
+  retryGraphRequest,
+  retryAfterMs,
+} from "../graph-request";
+import { createGraphClient } from "../graph-client";
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+describe("Graph request policy", () => {
+  it.each([400, 401, 403, 404])(
+    "does not retry permanent HTTP %s",
+    async (statusCode) => {
+      const action = vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("failed"), { statusCode }));
+      await expect(retryGraphRequest(action)).rejects.toThrow("failed");
+      expect(action).toHaveBeenCalledTimes(1);
+    },
+  );
+  it("retries SDK-wrapped network failures but not wrapped aborts", async () => {
+    vi.useFakeTimers();
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("fetch failed"), {
+          statusCode: -1,
+          code: "TypeError",
+        }),
+      )
+      .mockResolvedValueOnce("recovered");
+    const pending = retryGraphRequest(action);
+    await vi.runAllTimersAsync();
+    expect(await pending).toBe("recovered");
+    const aborted = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("aborted"), {
+          statusCode: -1,
+          code: "AbortError",
+        }),
+      );
+    await expect(retryGraphRequest(aborted)).rejects.toThrow("aborted");
+    expect(aborted).toHaveBeenCalledTimes(1);
+  });
+  it("retries an all-GET batch envelope through the real SDK", async () => {
+    vi.useFakeTimers();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { code: "TooManyRequests", message: "busy" },
+          }),
+          {
+            status: 429,
+            headers: { "Retry-After": "2", "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            responses: [{ id: "1", status: 200, body: { id: "a" } }],
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetch);
+    const pending = createGraphClient("test")
+      .api("/$batch")
+      .post({ requests: [{ id: "1", method: "GET", url: "/groups/a" }] });
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect((await pending).responses[0].status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+  it("does not retry writes or batches containing inner writes", async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { code: "ServiceUnavailable", message: "busy" },
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetch);
+    await expect(
+      createGraphClient("test")
+        .api("/$batch")
+        .post({
+          requests: [{ id: "1", method: "POST", url: "/groups", body: {} }],
+        }),
+    ).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+  it("honors Retry-After and does not sleep after the final attempt", async () => {
+    vi.useFakeTimers();
+    const action = vi.fn().mockRejectedValue(
+      Object.assign(new Error("busy"), {
+        statusCode: 429,
+        headers: new Headers({ "Retry-After": "2" }),
+      }),
+    );
+    const assertion = expect(
+      retryGraphRequest(action, { maxAttempts: 2 }),
+    ).rejects.toThrow("busy");
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(action).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await assertion;
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("accepts mixed-case headers and HTTP dates", () => {
+    expect(retryAfterMs({ headers: { "Retry-After": "3" } })).toBe(3000);
+    expect(
+      retryAfterMs(
+        { headers: { "retry-after": "Wed, 01 Jan 2025 00:00:05 GMT" } },
+        Date.parse("2025-01-01T00:00:00Z"),
+      ),
+    ).toBe(5000);
+    expect(
+      retryAfterMs({ headers: { "retry-after": "garbage" } }),
+    ).toBeUndefined();
+  });
+  it("does not multiply exhausted retries through nested callers", async () => {
+    const action = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("busy"), { statusCode: 503 }));
+    await expect(
+      retryGraphRequest(() => retryGraphRequest(action, { maxAttempts: 1 })),
+    ).rejects.toThrow("busy");
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+  it("cancels backoff immediately when the collection is aborted", async () => {
+    vi.useFakeTimers();
+    const abort = new AbortController();
+    const action = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("busy"), { statusCode: 503, retryAfter: 90 }),
+      );
+    const assertion = expect(
+      retryGraphRequest(action, { signal: abort.signal }),
+    ).rejects.toThrow("cancelled");
+    await vi.advanceTimersByTimeAsync(1);
+    abort.abort(new Error("cancelled"));
+    await assertion;
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("shares a concurrency limit and removes cancelled queued requests", async () => {
+    const run = createGraphLimiter(1);
+    let release!: () => void;
+    const first = run(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const abort = new AbortController();
+    const queued = vi.fn(async () => 2);
+    const assertion = expect(run(queued, abort.signal)).rejects.toThrow(
+      "cancelled",
+    );
+    abort.abort(new Error("cancelled"));
+    await assertion;
+    release();
+    await first;
+    expect(queued).not.toHaveBeenCalled();
+    expect(await run(async () => 3)).toBe(3);
+  });
+  it("prevents Graph calls after a collection is cancelled", async () => {
+    const signal = AbortSignal.abort(new Error("cancelled"));
+    const client = createGraphClient("test", { signal });
+    await expect(client.api("/deviceManagement/intents").get()).rejects.toThrow(
+      "cancelled",
+    );
+  });
+});

--- a/src/lib/__tests__/graph-review-regressions.test.ts
+++ b/src/lib/__tests__/graph-review-regressions.test.ts
@@ -1,0 +1,337 @@
+import { analyzeConfigurations } from "../configuration-analyzer";
+import { IntuneService } from "../graph-client";
+import { describe, it, expect, vi } from "vitest";
+import { DetailedIntuneService } from "../intune-detailed-client";
+import { collectAllPagesWithStatus } from "../graph-paging";
+import { summarizeAssignments } from "../compliance/assignments";
+import { assessCapabilities } from "../compliance/engine";
+import { INTUNE_POLICY_REGISTRY } from "../intune-policy-registry";
+import { IntuneConfigurationService } from "../intune-graph-client";
+import { GroupResolver } from "../group-resolver";
+const forbidden = () =>
+  Object.assign(new Error("Forbidden"), { statusCode: 403 });
+const assigned = [
+  { target: { "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget" } },
+];
+function client(read: (path: string, expand?: string) => any) {
+  return {
+    api(path: string) {
+      let expand: string | undefined;
+      const q: any = {
+        get: () => Promise.resolve().then(() => read(path, expand)),
+      };
+      for (const key of ["version", "select", "filter", "top"])
+        q[key] = () => q;
+      q.expand = (value: string) => {
+        expand = value;
+        return q;
+      };
+      return q;
+    },
+  };
+}
+function service(read: (path: string, expand?: string) => any) {
+  const s = new DetailedIntuneService("test") as any;
+  s.client = client(read);
+  s.retryWithBackoff = (fn: () => Promise<any>) => fn();
+  return s;
+}
+describe("Graph review regressions", () => {
+  it.each(["iOS", "Android", "Windows"])(
+    "retains all platforms when %s app-protection paging fails",
+    async (failed) => {
+      const paths: Record<string, string> = {
+        iOS: "ios",
+        Android: "android",
+        Windows: "windows",
+      };
+      const s = service((path) => {
+        if (path.includes("next")) throw forbidden();
+        if (path.endsWith("/assignments")) return { value: assigned };
+        if (path.endsWith("/apps")) return { value: [] };
+        const platform = Object.keys(paths).find((key) =>
+          path.includes(`/${paths[key]}ManagedAppProtections`),
+        )!;
+        return {
+          value: [{ id: platform }],
+          ...(platform === failed
+            ? { "@odata.nextLink": "https://graph.microsoft.com/beta/next" }
+            : {}),
+        };
+      });
+      const items = await s.getAppProtectionPoliciesDetailed();
+      expect(items.map((p: any) => p.platform).sort()).toEqual([
+        "Android",
+        "Windows",
+        "iOS",
+      ]);
+      expect(items.every((p: any) => p.assignments.length === 1)).toBe(true);
+      expect(s.getFetchErrors()).toHaveLength(1);
+      expect(s.getFetchErrors()[0].policyType).toBe(
+        `${failed} App Protection Policies`,
+      );
+    },
+  );
+  it.each([[], assigned])(
+    "marks partial registry assignments unknown for first page %j",
+    async (first) => {
+      const s = service((path) => {
+        if (path === "/policies") return { value: [{ id: "p" }] };
+        if (path.endsWith("/assignments"))
+          return {
+            value: first,
+            "@odata.nextLink": "https://graph.microsoft.com/beta/next",
+          };
+        throw forbidden();
+      });
+      const section = await s.fetchRegistrySection({
+        key: "test",
+        path: "/policies",
+        family: "applications",
+        label: "Test",
+        childCollections: [{ property: "assignments", path: "assignments" }],
+      });
+      const item = section.items[0];
+      expect(section.error.partial).toBe(true);
+      expect(item.collectionStatus.assignments).toBe("incomplete");
+      expect(
+        summarizeAssignments(
+          item.assignments,
+          new Map(),
+          item.collectionStatus.assignments === "incomplete",
+        ).state,
+      ).toBe("unknown");
+    },
+  );
+  it("uses baseline parent expansion after the live category route rejection", async () => {
+    const s = service((path, expand) => {
+      if (path === "/deviceManagement/intents") return { value: [{ id: "b" }] };
+      if (path.endsWith("/categories"))
+        throw Object.assign(new Error("No OData route exists"), {
+          statusCode: 400,
+        });
+      if (expand === "categories") return { categories: [{ id: "category" }] };
+      return { value: path.endsWith("/assignments") ? assigned : [] };
+    });
+    const [baseline] = await s.getSecurityBaselinesDetailed();
+    expect(baseline.categories).toHaveLength(1);
+    expect(baseline.collectionStatus.categories).toBe("complete");
+    expect(s.getFetchErrors()).toEqual([]);
+  });
+  it("keeps failed baseline categories visible without invalidating unrelated capabilities", () => {
+    const d: any = {
+      settingsCatalog: [],
+      deviceConfigurations: [],
+      administrativeTemplates: [],
+      compliancePolicies: [],
+      securityBaselines: [
+        {
+          id: "b",
+          settings: [],
+          assignments: [],
+          collectionStatus: {
+            categories: "incomplete",
+            settings: "complete",
+            assignments: "complete",
+          },
+        },
+      ],
+      scripts: { windows: [], macOS: [] },
+      fetchErrors: [
+        {
+          familyKey: "securityBaselines",
+          endpoint: "/deviceManagement/intents/b?$expand=categories",
+          error: "failed",
+        },
+      ],
+    };
+    expect(
+      assessCapabilities(d).find((c) => c.capability.id === "windows-firewall")
+        ?.status,
+    ).toBe("noEvidence");
+  });
+  it("excludes non-assignable registry types without hiding unknown assignments on assignable types", () => {
+    const input: any = {
+      settingsCatalog: [],
+      deviceConfigurations: [],
+      administrativeTemplates: [],
+      compliancePolicies: [],
+      securityBaselines: [],
+      scripts: { windows: [], macOS: [] },
+      sections: [
+        {
+          key: "roleDefinitions",
+          familyKey: "assignmentAndRbac",
+          label: "Roles",
+          items: [{ id: "role" }],
+        },
+        {
+          key: "deviceManagementSettings",
+          familyKey: "tenantAndService",
+          label: "Tenant",
+          items: [{ id: "tenant" }],
+        },
+        {
+          key: "windowsFeatureUpdateProfiles",
+          familyKey: "windowsUpdateProfiles",
+          label: "Updates",
+          items: [{ id: "update" }],
+        },
+        {
+          key: "settingsCatalog",
+          familyKey: "settingsCatalog",
+          label: "Settings",
+          items: [{ id: "assigned", assignments: assigned }],
+        },
+      ],
+    };
+    const result = analyzeConfigurations(input);
+    expect(result).toMatchObject({
+      assignedConfigs: 1,
+      unknownAssignmentConfigs: 1,
+      assignmentNotApplicableConfigs: 2,
+      assignmentApplicableConfigs: 2,
+    });
+  });
+  it("includes supported update and application assignment relations", () => {
+    for (const key of [
+      "windowsFeatureUpdateProfiles",
+      "windowsQualityUpdateProfiles",
+      "windowsQualityUpdatePolicies",
+      "windowsDriverUpdateProfiles",
+      "mobileApps",
+      "policySets",
+    ]) {
+      expect(
+        INTUNE_POLICY_REGISTRY.find(
+          (e) => e.key === key,
+        )?.childCollections?.some((c) => c.property === "assignments"),
+      ).toBe(true);
+    }
+  });
+  it.each([{}, { value: null }])(
+    "does not mark malformed paging responses complete: %j",
+    async (page) => {
+      expect(
+        (
+          await collectAllPagesWithStatus(client(() => page) as any, {
+            value: [{ id: "kept" }],
+            "@odata.nextLink": "next",
+          })
+        ).complete,
+      ).toBe(false);
+    },
+  );
+  it("stops repeated links without issuing repeated requests", async () => {
+    const read = vi.fn(() => ({
+      value: [{ id: "one" }],
+      "@odata.nextLink": "next",
+    }));
+    const r = await collectAllPagesWithStatus(client(read) as any, {
+      value: [],
+      "@odata.nextLink": "next",
+    });
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(r).toMatchObject({ complete: false, items: [{ id: "one" }] });
+  });
+  it("follows a valid empty page with a nextLink", async () => {
+    expect(
+      await collectAllPagesWithStatus(
+        client(() => ({ value: [{ id: "next" }] })) as any,
+        { value: [], "@odata.nextLink": "next" },
+      ),
+    ).toMatchObject({ complete: true, items: [{ id: "next" }] });
+  });
+  it("preserves the other platform in the legacy app-protection collector", async () => {
+    const legacy = new IntuneService("test") as any;
+    legacy.client = client((path) => {
+      if (path.includes("next")) throw forbidden();
+      if (path.includes("iosManagedAppProtections"))
+        return { value: [{ id: "ios" }] };
+      return {
+        value: [{ id: "android" }],
+        "@odata.nextLink": "https://graph.microsoft.com/beta/next",
+      };
+    });
+    expect(
+      (await legacy.getAppProtectionPolicies()).map((p: any) => p.id),
+    ).toEqual(["ios", "android"]);
+    expect(legacy.getFetchErrors()).toHaveLength(1);
+  });
+  it("exposes legacy collection failures instead of silently returning an empty inventory", async () => {
+    const s = new IntuneConfigurationService("test") as any;
+    s.client = client(() => {
+      throw forbidden();
+    });
+    const result = await s.getAllDeviceConfigurations();
+    expect(result.collectionStatus).toBe("incomplete");
+    expect(result.fetchErrors.length).toBeGreaterThan(0);
+  });
+  it("retries throttled inner groups together after the longest Retry-After", async () => {
+    vi.useFakeTimers();
+    try {
+      const resolver = new GroupResolver("test") as any;
+      const post = vi
+        .fn()
+        .mockResolvedValueOnce({
+          responses: [
+            { id: "0", status: 429, headers: { "Retry-After": "1" } },
+            { id: "1", status: 503, headers: { "Retry-After": "2" } },
+          ],
+        })
+        .mockResolvedValueOnce({
+          responses: [
+            { id: "0", status: 200, body: { id: "a", displayName: "A" } },
+            { id: "1", status: 200, body: { id: "b", displayName: "B" } },
+          ],
+        });
+      resolver.client = {
+        api: () => {
+          const q: any = { version: () => q, post };
+          return q;
+        },
+      };
+      const pending = resolver.getGroupNames(["a", "b"]);
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(post).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect([...(await pending).values()]).toEqual(["A", "B"]);
+      expect(post).toHaveBeenCalledTimes(2);
+      expect(post.mock.calls[1]?.[0].requests).toHaveLength(2);
+      expect(resolver.getWarnings()).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it("retains collected update-ring assignments when its details fail", async () => {
+    const s = service((path) => {
+      if (path === "/deviceManagement/deviceConfigurations")
+        return { value: [{ id: "ring", assignments: [] }] };
+      if (path.endsWith("/assignments")) return { value: assigned };
+      throw forbidden();
+    });
+    const [ring] = await s.getWindowsUpdatePoliciesDetailed();
+    expect(ring).toMatchObject({
+      hasFetchError: true,
+      assignments: assigned,
+      collectionStatus: { details: "incomplete", assignments: "complete" },
+    });
+    expect(ring.fetchErrorMessage).toContain("Forbidden");
+  });
+  it("preserves group IDs and warnings for denied inner batch requests", async () => {
+    const resolver = new GroupResolver("test") as any;
+    resolver.client = {
+      api: () => {
+        const q: any = {
+          version: () => q,
+          post: async () => ({ responses: [{ id: "0", status: 403 }] }),
+        };
+        return q;
+      },
+    };
+    expect((await resolver.getGroupNames(["group-id"])).get("group-id")).toBe(
+      "group-id",
+    );
+    expect(resolver.getWarnings()).toHaveLength(1);
+  });
+});

--- a/src/lib/__tests__/graph-route-status.test.ts
+++ b/src/lib/__tests__/graph-route-status.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+const mocks = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@microsoft/microsoft-graph-client", () => ({
+  Client: {
+    init: () => ({
+      api: (path: string) => {
+        const q: any = {
+          version: () => q,
+          top: () => q,
+          select: () => q,
+          get: () => mocks.get(path),
+        };
+        return q;
+      },
+    }),
+  },
+}));
+vi.mock("../auth-middleware", () => ({ extractTenantFromRequest: vi.fn() }));
+vi.mock("../intune-detailed-client", () => ({
+  DetailedIntuneService: class {
+    callback: any;
+    constructor(_token: string, callback: any) {
+      this.callback = callback;
+    }
+    async getAllDetailedConfigurations() {
+      this.callback({
+        step: "Compliance Policies",
+        type: "error",
+        message: "Incomplete",
+      });
+      return {
+        sections: [],
+        fetchErrors: [{ error: "Graph failed" }],
+        permissionErrors: [],
+        summary: {},
+      };
+    }
+  },
+}));
+import { GET as permissions } from "../../app/api/intune/check-permissions/route";
+import { GET as stream } from "../../app/api/intune/detailed-configurations-stream/route";
+
+describe("Graph route status", () => {
+  it("separates denied permissions from transient probe failures", async () => {
+    mocks.get.mockImplementation(async (path: string) => {
+      if (path === "/groups")
+        throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+      if (path === "/deviceManagement/managedDevices")
+        throw Object.assign(new Error("Unavailable"), { statusCode: 503 });
+      return { value: [] };
+    });
+    const response = await permissions(
+      new Request("http://localhost/api", {
+        headers: { Authorization: "Bearer test" },
+      }) as any,
+    );
+    const body = await response.json();
+    expect(body.summary).toMatchObject({
+      denied: 1,
+      unavailable: 1,
+      granted: 6,
+    });
+  });
+  it("does not overwrite a failed stream step with success or claim a complete collection", async () => {
+    const response = await stream(
+      new Request("http://localhost/api", {
+        headers: { Authorization: "Bearer test" },
+      }) as any,
+    );
+    const body = await response.text();
+    expect(body).toContain('"collectionStatus":"incomplete"');
+    expect(body).toContain(
+      '"step":"Compliance Policies","stepIndex":5,"status":"error"',
+    );
+    expect(body).not.toContain(
+      '"step":"Compliance Policies","stepIndex":5,"status":"completed"',
+    );
+    expect(body).not.toContain("All configurations fetched successfully");
+  });
+});

--- a/src/lib/__tests__/intune-detailed-client.test.ts
+++ b/src/lib/__tests__/intune-detailed-client.test.ts
@@ -38,8 +38,12 @@ describe("Settings Catalog definition enrichment", () => {
   it("does not cache a failed batch as a permanent miss", async () => {
     const get = vi
       .fn()
-      .mockRejectedValueOnce(new Error("temporary failure"))
-      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockRejectedValueOnce(
+        Object.assign(new Error("temporary failure"), { statusCode: 503 }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("temporary failure"), { statusCode: 503 }),
+      )
       .mockResolvedValueOnce({
         value: [{ id: "retryable", displayName: "Recovered" }],
       });

--- a/src/lib/__tests__/nist-800-171-r3.test.ts
+++ b/src/lib/__tests__/nist-800-171-r3.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import type { DetailedExportData } from "../configuration-analyzer";
+import { assessCompliance, NIST_800_171_R3 } from "../compliance";
+import { createEvidenceManifest } from "../compliance/manifest";
+import {
+  complianceReportFileName,
+  generateComplianceReportPDF,
+} from "../compliance/report-pdf";
+import { extractPdfStreamText } from "./helpers/pdf-text";
+
+function policy(type: string, values: Record<string, unknown>) {
+  return {
+    id: type,
+    displayName: type,
+    "@odata.type": `#microsoft.graph.${type}`,
+    assignments: [
+      {
+        target: {
+          "@odata.type": "#microsoft.graph.allDevicesAssignmentTarget",
+        },
+      },
+    ],
+    ...values,
+  };
+}
+
+function data(...policies: ReturnType<typeof policy>[]): DetailedExportData {
+  return {
+    collectedAt: "2026-09-05T00:00:00Z",
+    settingsCatalog: [],
+    deviceConfigurations: policies,
+    administrativeTemplates: [],
+    compliancePolicies: [],
+    securityBaselines: [],
+    scripts: { windows: [], macOS: [] },
+  };
+}
+
+function assessment(exportData: DetailedExportData) {
+  return assessCompliance(exportData).frameworks.find(
+    (item) => item.framework.id === "nist-800-171-r3",
+  )!;
+}
+
+describe("NIST SP 800-171 Revision 3", () => {
+  it("keeps revision metadata and published coverage separate in the evidence record", async () => {
+    const { assessment: result } = await createEvidenceManifest(data());
+    const r2 = result.frameworks.find(
+      (item) => item.framework.id === "nist-800-171-r2",
+    )!;
+    const r3 = result.frameworks.find(
+      (item) => item.framework.id === "nist-800-171-r3",
+    )!;
+    expect(r2.framework.version).toContain("CMMC");
+    expect(r2.framework.totalRequirements).toBe(110);
+    expect(r3.framework.version).toBe("Rev. 3 (May 2024)");
+    expect(r3.framework.totalRequirements).toBe(97);
+    expect(r2.summary.totalControls).toBe(11);
+    expect(r3.summary.totalControls).toBe(11);
+    expect(r3.framework.source?.url).toBe(
+      "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
+    );
+    for (const withdrawn of ["03.01.19", "03.04.09", "03.13.16", "03.14.05"])
+      expect(
+        r3.controls.some((control) => control.control.id === withdrawn),
+      ).toBe(false);
+  });
+
+  it("maps storage encryption to the revised requirements without claiming transmission coverage", () => {
+    const r3 = assessment(
+      data(
+        policy("windows10EndpointProtectionConfiguration", {
+          bitLockerEncryptDevice: true,
+        }),
+      ),
+    );
+    for (const id of ["03.01.18", "03.13.08"])
+      expect(r3.controls.find((item) => item.control.id === id)?.status).toBe(
+        "partialEvidence",
+      );
+    expect(
+      r3.controls
+        .find((item) => item.control.id === "03.13.08")
+        ?.unassessedAspects.join(" "),
+    ).toContain("transmission");
+    expect(r3.controls.every((item) => item.status !== "evidenceFound")).toBe(
+      true,
+    );
+  });
+
+  it("keeps ordinary credential requirements separate from MFA", () => {
+    const exportData = data(
+      policy("windows10GeneralConfiguration", { passwordRequired: true }),
+    );
+    expect(
+      assessment(exportData).controls.find(
+        (item) => item.control.id === "03.05.03",
+      )?.status,
+    ).toBe("noEvidence");
+    exportData.conditionalAccessPolicies = [
+      policy("conditionalAccessPolicy", {
+        state: "enabled",
+        conditions: {
+          users: { includeUsers: ["All"] },
+          applications: { includeApplications: ["All"] },
+        },
+        grantControls: { operator: "AND", builtInControls: ["mfa"] },
+      }),
+    ];
+    expect(
+      assessment(exportData).controls.find(
+        (item) => item.control.id === "03.05.03",
+      )?.status,
+    ).toBe("partialEvidence");
+  });
+
+  it("folds periodic scans into malicious-code protection while retaining the scan-frequency gap", () => {
+    const r3 = assessment(
+      data(
+        policy("windows10GeneralConfiguration", {
+          defenderScanType: "quick",
+          defenderSystemScanSchedule: "everyday",
+          defenderScheduledScanTime: "02:00:00",
+        }),
+      ),
+    );
+    const malware = r3.controls.find((item) => item.control.id === "03.14.02")!;
+    expect(malware.enforcedCapabilityIds).toContain(
+      "windows-periodic-antimalware-scan",
+    );
+    expect(malware.status).toBe("partialEvidence");
+    expect(malware.unassessedAspects.join(" ")).toContain(
+      "organization-defined scan frequency",
+    );
+  });
+
+  it("does not treat app-store restrictions as an executable allow list", () => {
+    const r3 = assessment(
+      data(
+        policy("macOSEndpointProtectionConfiguration", {
+          gatekeeperAllowedAppSource: "macAppStoreAndIdentifiedDevelopers",
+        }),
+      ),
+    );
+    expect(
+      r3.controls.find((item) => item.control.id === "03.04.08")?.status,
+    ).toBe("noEvidence");
+    expect(NIST_800_171_R3.mappings["macos-gatekeeper"]).toEqual([]);
+    expect(NIST_800_171_R3.mappings["windows-application-control"]).toEqual([
+      "03.04.08",
+    ]);
+    expect(
+      NIST_800_171_R3.controls["03.14.01"]?.unassessedAspects?.join(" "),
+    ).toContain("organization-defined remediation period");
+  });
+
+  it("exports the correct revision, coverage and requirement families in its dedicated PDF", async () => {
+    const bytes = await generateComplianceReportPDF(
+      data(
+        policy("windows10EndpointProtectionConfiguration", {
+          bitLockerEncryptDevice: true,
+        }),
+      ),
+      { frameworkId: "nist-800-171-r3" },
+    );
+    const text = extractPdfStreamText(bytes);
+    expect(complianceReportFileName("nist-800-171-r3")).toContain(
+      "NIST-800-171-R3",
+    );
+    expect(text).toContain("Rev. 3");
+    expect(text).toContain("11 of 97 published requirements");
+    expect(text).toContain("03.13.08");
+    expect(text).toContain("03.14.02");
+    expect(text).toContain("(03.13) Tj");
+    expect(text).not.toContain("03.14.05");
+    expect(text).not.toContain("NIST-800-171-R2");
+  });
+});

--- a/src/lib/__tests__/nist-800-171-r3.test.ts
+++ b/src/lib/__tests__/nist-800-171-r3.test.ts
@@ -55,7 +55,7 @@ describe("NIST SP 800-171 Revision 3", () => {
     expect(r2.framework.totalRequirements).toBe(110);
     expect(r3.framework.version).toBe("Rev. 3 (May 2024)");
     expect(r3.framework.totalRequirements).toBe(97);
-    expect(r2.summary.totalControls).toBe(11);
+    expect(r2.summary.totalControls).toBe(12);
     expect(r3.summary.totalControls).toBe(11);
     expect(r3.framework.source?.url).toBe(
       "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
@@ -175,4 +175,13 @@ describe("NIST SP 800-171 Revision 3", () => {
     expect(text).not.toContain("03.14.05");
     expect(text).not.toContain("NIST-800-171-R2");
   });
+});
+
+it("maps Revision 2 MFA to 3.5.3 and credential protection to configuration settings", async () => {
+  const { NIST_800_171 } = await import(
+    "../compliance/frameworks/nist-800-171"
+  );
+  expect(NIST_800_171.mappings["tenant-mfa-required"]).toEqual(["3.5.3"]);
+  expect(NIST_800_171.mappings["windows-credential-guard"]).toEqual(["3.4.2"]);
+  expect(NIST_800_171.controls["3.5.3"]?.evidenceStrength).toBe("supporting");
 });

--- a/src/lib/__tests__/script-assignments.test.ts
+++ b/src/lib/__tests__/script-assignments.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { DetailedIntuneService } from "../intune-detailed-client";
+
+const assignment = {
+  target: {
+    groupId: "group-example",
+    deviceAndAppManagementAssignmentFilterId: "filter-example",
+    deviceAndAppManagementAssignmentFilterType: "exclude",
+  },
+};
+const routeError = () =>
+  Object.assign(
+    new Error(
+      "No OData route exists that match template ~/singleton/navigation/key/navigation with http verb GET",
+    ),
+    { statusCode: 400 },
+  );
+const forbidden = () =>
+  Object.assign(new Error("Forbidden"), { statusCode: 403 });
+
+describe.each([
+  ["macOS", "deviceShellScripts", "getMacOSScriptsDetailed"],
+  ["Windows", "deviceManagementScripts", "getWindowsScriptsDetailed"],
+])("%s script assignments", (_platform, family, method) => {
+  function setup(
+    direct: unknown,
+    expanded: unknown = { assignments: [assignment] },
+    next?: unknown,
+  ) {
+    const root = `/deviceManagement/${family}`;
+    const parent = `${root}/script-id`;
+    const nextLink = `https://graph.microsoft.com/beta${parent}/assignments?$skiptoken=next`;
+    const service = new DetailedIntuneService("test-token") as any;
+    service.retryWithBackoff = (fn: () => Promise<unknown>) => fn();
+    const requests: {
+      url: string;
+      expand?: string;
+      version?: string;
+      select?: string;
+    }[] = [];
+    service.client = {
+      api: (url: string) => {
+        const entry: (typeof requests)[number] = { url };
+        requests.push(entry);
+        const request: any = {
+          version: (v: string) => {
+            entry.version = v;
+            return request;
+          },
+          expand: (v: string) => {
+            entry.expand = v;
+            return request;
+          },
+          select: (v: string) => {
+            entry.select = v;
+            return request;
+          },
+          top: () => request,
+          get: async () => {
+            if (url.includes("('")) throw routeError();
+            let result: unknown;
+            if (url === root)
+              result = {
+                value: [
+                  {
+                    id: "script-id",
+                    displayName: "Example",
+                    runAsAccount: "system",
+                  },
+                ],
+              };
+            else if (url === parent)
+              result = entry.expand
+                ? expanded
+                : {
+                    scriptContent:
+                      Buffer.from("echo example").toString("base64"),
+                  };
+            else if (url === `${parent}/assignments`) result = direct;
+            else if (url === nextLink) result = next;
+            else throw new Error(`Unexpected request ${url}`);
+            if (result instanceof Error) throw result;
+            return result;
+          },
+        };
+        return request;
+      },
+    };
+    return {
+      service,
+      requests,
+      parent,
+      nextLink,
+      read: () => service[method](),
+    };
+  }
+  it("uses canonical routes and retains content, targets and filters", async () => {
+    const { read, requests, service } = setup({ value: [assignment] });
+    const [result] = await read();
+    expect(result.assignments).toEqual([assignment]);
+    expect(result.scriptContent).toBe("echo example");
+    expect(result.collectionStatus).toEqual({
+      details: "complete",
+      assignments: "complete",
+    });
+    expect(requests.some((r) => r.url.includes("('") || r.expand)).toBe(false);
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+  it("recovers routing errors through parent expansion and follows pagination", async () => {
+    const state = setup(routeError());
+    const expanded = {
+      assignments: [assignment],
+      "assignments@odata.nextLink": state.nextLink,
+    };
+    const { read, requests, service, parent } = setup(routeError(), expanded, {
+      value: [{ target: { groupId: "second" } }],
+    });
+    const [result] = await read();
+    expect(result.assignments).toHaveLength(2);
+    expect(requests).toContainEqual({
+      url: parent,
+      version: "beta",
+      expand: "assignments",
+    });
+    expect(requests).toContainEqual({ url: state.nextLink });
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+  it("does not hide permission errors behind a fallback", async () => {
+    const { read, requests, service } = setup(forbidden());
+    const [result] = await read();
+    expect(result.scriptContent).toBe("echo example");
+    expect(result.collectionStatus.assignments).toBe("incomplete");
+    expect(requests.some((r) => r.expand)).toBe(false);
+    expect(service.getFetchErrors()[0].statusCode).toBe(403);
+  });
+  it.each([{}, forbidden()])(
+    "marks omitted or failed expansions incomplete",
+    async (expanded) => {
+      const { read, service } = setup(routeError(), expanded);
+      const [result] = await read();
+      expect(result.collectionStatus.assignments).toBe("incomplete");
+      expect(result.scriptContent).toBe("echo example");
+      expect(service.getFetchErrors()[0].endpoint).toContain(
+        "?$expand=assignments",
+      );
+    },
+  );
+  it("accepts a confirmed empty expansion", async () => {
+    const { read, service } = setup(routeError(), { assignments: [] });
+    const [result] = await read();
+    expect(result.assignments).toEqual([]);
+    expect(result.collectionStatus.assignments).toBe("complete");
+    expect(service.getFetchErrors()).toEqual([]);
+  });
+  it("retains partial assignments when an expanded continuation fails", async () => {
+    const state = setup(routeError());
+    const { read, service } = setup(
+      routeError(),
+      {
+        assignments: [assignment],
+        "assignments@odata.nextLink": state.nextLink,
+      },
+      forbidden(),
+    );
+    const [result] = await read();
+    expect(result.assignments).toEqual([assignment]);
+    expect(result.collectionStatus.assignments).toBe("incomplete");
+    expect(service.getFetchErrors()[0].statusCode).toBe(403);
+  });
+});

--- a/src/lib/__tests__/value-parsing.test.ts
+++ b/src/lib/__tests__/value-parsing.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatValue,
+  parseAdministrativeTemplate,
+  parseAssignments,
+  parseComplianceRules,
+  parseSecurityBaseline,
+  extractSettingValue,
+} from "../configuration-parser";
+
+describe("documentation value integrity", () => {
+  it("preserves structured pairs, zero, false, and heterogeneous lists", () => {
+    expect(
+      formatValue([
+        { name: "Server", value: "example.com" },
+        { value: 0 },
+        { value: false },
+        null,
+        "tail",
+      ]),
+    ).toBe("Server: example.com\n0\nDisabled\nNot configured\ntail");
+    expect(formatValue(["first", { value: 0 }])).toBe("first\n0");
+  });
+  it("preserves literal technical strings", () => {
+    expect(
+      extractSettingValue({
+        id: "x",
+        settingInstance: {
+          settingDefinitionId: "x",
+          simpleSettingValue: { value: "device_vendor_msft_custom_value" },
+        },
+      } as any).value,
+    ).toBe("device_vendor_msft_custom_value");
+  });
+  it("reads Administrative Template list presentations", () => {
+    expect(
+      parseAdministrativeTemplate([
+        {
+          enabled: true,
+          presentationValues: [
+            { values: [{ name: "Site", value: "example.com" }] },
+          ],
+        },
+      ])[0]?.value,
+    ).toBe("Values: Site: example.com");
+  });
+  it.each(["group", "allDevices", "allLicensedUsers"])(
+    "retains filters on %s assignments",
+    (kind) => {
+      const target =
+        kind === "group"
+          ? { groupId: "group" }
+          : { "@odata.type": `#microsoft.graph.${kind}AssignmentTarget` };
+      expect(
+        parseAssignments([
+          {
+            target: {
+              ...target,
+              deviceAndAppManagementAssignmentFilterId: "filter",
+              deviceAndAppManagementAssignmentFilterType: "exclude",
+            },
+          },
+        ]),
+      ).toContain("Filter (Exclude): filter");
+    },
+  );
+  it("distinguishes unavailable assignments and partial results", () => {
+    expect(parseAssignments([], "incomplete")).toContain("unavailable");
+    expect(parseAssignments([], "complete")).toBe("Not assigned");
+    expect(
+      parseAssignments([{ target: { groupId: "group" } }], "incomplete"),
+    ).toBe("Group: group (collection incomplete)");
+  });
+  it("omits collection metadata and preserves unavailable action status", () => {
+    const rules = parseComplianceRules({
+      passwordRequired: true,
+      configType: "Compliance Policy",
+      collectionStatus: { scheduledActionsForRule: "incomplete" },
+      scheduledActionsForRule: [],
+    });
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.action).toContain("Actions unavailable");
+  });
+  it.each([
+    [12, "12 hours"],
+    [36, "36 hours"],
+    [24, "1 day"],
+    [0, "immediately"],
+  ])("preserves %s hour action timing", (hours, label) => {
+    expect(
+      parseComplianceRules({
+        passwordRequired: true,
+        scheduledActionsForRule: [
+          {
+            scheduledActionConfigurations: [
+              { actionType: "block", gracePeriodHours: hours },
+            ],
+          },
+        ],
+      })[0]?.action,
+    ).toBe(`Mark device noncompliant${hours === 0 ? " " : " after "}${label}`);
+  });
+  it("reads baseline JSON values including zero and false", () => {
+    const settings = parseSecurityBaseline(
+      [],
+      [
+        { definitionId: "one", valueJson: "false" },
+        { definitionId: "two", valueJson: "0" },
+        { definitionId: "three", valueJson: '"literal"' },
+      ],
+    )[0]?.settings;
+    expect(settings?.map((s) => s.value)).toEqual(["Disabled", "0", "literal"]);
+    expect(
+      parseSecurityBaseline([
+        {
+          displayName: "Legacy",
+          settings: [{ definitionId: "legacy", boolValue: false }],
+        },
+      ])[0]?.settings[0]?.value,
+    ).toBe("Disabled");
+  });
+});

--- a/src/lib/client-export-resolver.ts
+++ b/src/lib/client-export-resolver.ts
@@ -37,6 +37,7 @@ interface SelectedData {
 
 export interface ResolvedExportData extends SelectedData {
   groupNames: Map<string, string>;
+  resolutionWarnings?: string[];
   deviceCounts: Record<string, number>;
 }
 
@@ -51,6 +52,7 @@ export async function resolveExportData(
 ): Promise<ResolvedExportData> {
   // Resolve group names
   let groupNames = new Map<string, string>();
+  const resolutionWarnings: string[] = [];
   try {
     onProgress?.({ stage: "groups", message: "Resolving group names..." });
 
@@ -101,6 +103,12 @@ export async function resolveExportData(
 
     if (allGroupIds.size > 0) {
       groupNames = await groupResolver.getGroupNames(Array.from(allGroupIds));
+      resolutionWarnings.push(...groupResolver.getWarnings());
+      if (resolutionWarnings.length)
+        onProgress?.({
+          stage: "groups",
+          message: `${resolutionWarnings.length} group names could not be resolved; identifiers are preserved.`,
+        });
 
       data.sections
         ?.find((section) => section.key === "roleAssignments")
@@ -148,7 +156,23 @@ export async function resolveExportData(
 
   return {
     ...data,
+    fetchErrors: [
+      ...(data.fetchErrors ?? []),
+      ...(resolutionWarnings.length
+        ? [
+            {
+              policyId: "group-name-resolution",
+              policyName: "Group name resolution",
+              policyType: "Group names",
+              familyKey: "groupNames",
+              error: resolutionWarnings.join(" "),
+              partial: true,
+            },
+          ]
+        : []),
+    ],
     groupNames,
     deviceCounts,
+    resolutionWarnings,
   };
 }

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -38,6 +38,16 @@ UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
    the five themes serve as identifiers because the document has none, and the
    logo is excluded from the licence. Do not add frameworks that require a
    commercial license (for example CIS Benchmarks or CIS Controls).
+7. **Match the control's technical requirement.** Firewall activation is not
+   evidence of default-deny rules, password presence is not evidence of
+   credential quality, and app-source restrictions are not evidence of an
+   executable allow/block list. Def Stan controls 2213, 2409, 2429 and 2507,
+   and NIST SP 800-171 requirements 3.4.8 and 3.13.6, are omitted until suitable
+   detectors exist. App-source restrictions map to NIST 3.4.9 instead.
+8. **Keep findings within the selected framework.** Report deviation and
+   unassigned-configuration counts include only capabilities mapped to that
+   framework's listed controls. Unmapped capabilities, such as encryption for
+   Cyber Essentials, must not affect those counts.
 
 ## Adding a signal
 

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -1,12 +1,12 @@
 # Compliance evidence engine
 
 Maps an Intune tenant export to evidence for ISO/IEC 27001:2022, SOC 2, NIST
-SP 800-53 rev 5, NIST SP 800-171 rev 2, NIST CSF 2.0, BSI IT-Grundschutz,
+SP 800-53 rev 5, NIST SP 800-171 revisions 2 and 3, NIST CSF 2.0, BSI IT-Grundschutz,
 UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
 
 ## Design rules
 
-1. **Precision over recall.** Coverage is only claimed when a known setting is
+1. **Precision over recall.** Configuration evidence is only claimed when a known setting is
    present with the value that actually enforces the capability, on a policy
    with at least one non-exclusion assignment. Anything unrecognized produces
    no claim in either direction. False negatives are fixed by adding signals to
@@ -17,9 +17,15 @@ UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
    path and a typed predicate.
 3. **Counter-evidence is surfaced.** A setting explicitly configured to the
    non-enforcing value (for example BitLocker set to "not required") is
-   reported as `disabled`, never as coverage.
+   reported as `disabled`, never as coverage. Assigned positive and negative
+   evidence produces `conflictingEvidence`. This means mixed policy evidence,
+   not proof of an effective conflict on a device. Required setting groups,
+   such as the three Windows firewall profiles, must occur together on one
+   assigned policy. Different policies are not combined into a complete profile.
 4. **Assignment-aware.** Enforcing policies that are unassigned (or assigned
    via exclusions only) yield `configuredNotAssigned`, not `enforced`.
+   Failed or missing assignment reads yield `assignmentUnknown`. Filters and
+   exclusion targets are preserved, and effective coverage remains unverified.
 5. **No verdicts.** Output statuses are evidence statements
    (`evidenceFound` / `partialEvidence` / `noEvidence`), never "compliant".
    `COMPLIANCE_DISCLAIMER` must accompany any rendered report.
@@ -48,6 +54,94 @@ UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
    unassigned-configuration counts include only capabilities mapped to that
    framework's listed controls. Unmapped capabilities, such as encryption for
    Cyber Essentials, must not affect those counts.
+
+## NIST SP 800-171 revisions
+
+Revision 2 (`nist-800-171-r2`) remains available for CMMC Level 2 and has
+supporting mappings for 11 of its 110 published requirements. Revision 3
+(`nist-800-171-r3`, May 2024) is a separate assessment with supporting mappings
+for 11 of its 97 active requirements. These counts describe mapping coverage,
+not satisfied requirements or a compliance score. Unmapped requirements need
+separate assessment, including requirements that cannot be assessed through
+Intune. Neither report produces a CMMC certification or an SPRS score.
+
+Revision 3 is independently mapped to the [official NIST publication](https://csrc.nist.gov/pubs/sp/800/171/r3/final).
+It combines mobile encryption under 03.01.18, transmission and storage
+confidentiality under 03.13.08, and periodic scanning under 03.14.02. Withdrawn
+requirements are not retained as active controls. MFA maps to 03.05.03, not to
+ordinary password requirements. Only application-control enforcement supports
+03.04.08; app-source restrictions alone do not establish allow-by-exception.
+
+Organization-defined parameters (such as remediation periods and scan
+frequencies), effective enforcement and remaining requirement elements are
+explicitly unassessed. A configured 14-day update schedule does not establish
+that an organization's required remediation period is met. Revision 3 is not
+an automatic replacement for Revision 2 in CMMC assessments; see the
+[official CMMC FAQ](https://dodcio.defense.gov/cmmc/FAQs/).
+
+## Evidence semantics and scope (ruleset 2026.09.2)
+
+`CapabilityEvidence.kind` distinguishes a configuration setting, a compliance
+requirement and an access policy. The legacy `enforced` identifier means a
+recognized setting is configured on an assigned policy; the displayed label is
+"Setting configured and assigned". Compliance requirements use
+`requirementAssigned`. Neither status proves a device's actual state.
+
+A compliance scheduled action named `block` marks a device noncompliant after
+its grace period. It does not prove resource access is blocked. Enabled
+Conditional Access policies are assessed independently, including grant
+operators and preserved conditions. Report-only, disabled and optional OR
+grants are not counted as mandatory requirements. Effective sign-in access is
+always unverified by this configuration-only engine.
+
+Pass `assessmentScope` on an export, or the second argument to
+`assessCompliance`, to select platforms and a Def Stan risk level. The dashboard
+provides these controls. Policy absence and empty inventory counts never
+automatically exclude platforms. Platform-specific BSI requirements outside
+scope become `notApplicable`; a general control lacking a detector for the
+selected platform becomes `notAssessed`. Outside-scope controls do not affect
+the applicable denominator or deviation counters. Tenant access capabilities
+are independent of endpoint platform selection.
+
+Framework controls carry evidence strength, mapping granularity, publisher
+references and explicitly unassessed aspects. Supporting mappings stay partial
+even when every registered detector matches. A minimum OS version does not
+establish hardware support or patch currency. Update deadline evidence checks
+the configured timing tuple and pause state, not actual release-to-install
+time. Scan evidence checks a configured scan type, day and time, not execution.
+All frameworks remain selected technical subsets, not complete audit programs.
+
+## Collection, formats and provenance
+
+The collector preserves partial relation pages and records relation errors.
+Policy-level assignment status survives exported data, so a failed request
+cannot become a confirmed empty assignment. Security baselines now collect
+their actual `/settings` relation separately from category metadata.
+
+Supported adapters are Settings Catalog values, exact Graph properties,
+verified OMA-URIs, Administrative Template definition IDs and security baseline
+definition IDs. The last two require individually verified identifier bindings;
+unrecognized definitions are exposed in coverage and never matched by title.
+Legacy adapters accept typed values and do not coerce arbitrary strings into
+booleans or numbers. Script contents are not evaluated as deployment evidence.
+
+The coverage ledger lists collection state and policies with and without a
+recognized evidence match. The latter includes unsupported settings/formats and
+indeterminate values, not just absent protections. Older exports without a
+collection timestamp retain unknown collection provenance.
+
+The JSON evidence record and dedicated PDF contain the snapshot timestamp,
+policy version and modification time, ruleset version, selected scope, remaining
+requirements and SHA-256 fingerprints. Snapshot fingerprints use canonical JSON
+with sorted object keys (Map group names become objects); branding and assessment
+scope are excluded. Array order is retained. Ruleset fingerprints cover the
+version, signal definitions, control metadata and mappings. Bump the ruleset
+version whenever evaluation logic changes. Fingerprints detect changes; they
+are not signatures or independent proof of authentic tenant data.
+
+Publisher references use Microsoft, BSI, NIST, NCSC, ISO, AICPA and GOV.UK.
+Reference review dates are not certification or independent validation of every
+licensed standard requirement. Third-party document mirrors are not sources.
 
 ## Adding a signal
 

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -1,7 +1,8 @@
 # Compliance evidence engine
 
 Maps an Intune tenant export to evidence for ISO/IEC 27001:2022, SOC 2, NIST
-SP 800-53 rev 5, NIST CSF 2.0, and BSI IT-Grundschutz.
+SP 800-53 rev 5, NIST SP 800-171 rev 2, NIST CSF 2.0, BSI IT-Grundschutz,
+UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
 
 ## Design rules
 
@@ -30,8 +31,13 @@ SP 800-53 rev 5, NIST CSF 2.0, and BSI IT-Grundschutz.
    requirement level, verified against the Edition 2023 Baustein PDFs, while
    the remaining Bausteine stay at Baustein level until verified the same way.
    Only requirements with technical Intune evidence are listed as controls;
-   organizational requirements are intentionally absent. Do not add frameworks
-   that require a commercial license (for example CIS Benchmarks).
+   organizational requirements are intentionally absent. Def Stan 05-138 is
+   marked "Copying Only as Agreed with DStan", so it is referenced by control
+   identifier with original titles and summaries, never the official wording.
+   Cyber Essentials is Crown copyright under the Open Government Licence v3.0;
+   the five themes serve as identifiers because the document has none, and the
+   logo is excluded from the licence. Do not add frameworks that require a
+   commercial license (for example CIS Benchmarks or CIS Controls).
 
 ## Adding a signal
 

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -118,6 +118,14 @@ Policy-level assignment status survives exported data, so a failed request
 cannot become a confirmed empty assignment. Security baselines now collect
 their actual `/settings` relation separately from category metadata.
 
+Compliance scheduled actions are read by expanding the parent policy with
+`scheduledActionsForRule($expand=scheduledActionConfigurations)`, avoiding the
+direct relation GET rejected by some Intune backends. Both expanded collections
+follow continuation links. Missing or failed action reads are explicitly marked
+incomplete; successfully collected policy settings, assignments and partial
+action results are retained. This request pattern is also used by
+[Microsoft365DSC](https://github.com/microsoft/Microsoft365DSC/blob/Dev/Modules/Microsoft365DSC/DscResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1).
+
 Supported adapters are Settings Catalog values, exact Graph properties,
 verified OMA-URIs, Administrative Template definition IDs and security baseline
 definition IDs. The last two require individually verified identifier bindings;

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -2,7 +2,8 @@
 
 Maps an Intune tenant export to evidence for ISO/IEC 27001:2022, SOC 2, NIST
 SP 800-53 rev 5, NIST SP 800-171 revisions 2 and 3, NIST CSF 2.0, BSI IT-Grundschutz,
-UK MOD Def Stan 05-138 Issue 4, and NCSC Cyber Essentials.
+UK MOD Def Stan 05-138 Issue 4, NCSC Cyber Essentials, and ASD Essential Eight
+with target Maturity Levels 1, 2 and 3.
 
 ## Design rules
 
@@ -158,3 +159,43 @@ where a non-enforcing value exists, `disabledWhen`. Verify the exact
 `settingDefinitionId` or Graph property against a real tenant export or the
 Microsoft Graph documentation before adding it, and cover it in
 `src/lib/__tests__/compliance-engine.test.ts`.
+
+## ASD Essential Eight target levels (ruleset 2026.09.3)
+
+Essential Eight is one framework with target Maturity Levels 1, 2 and 3.
+The default target is Level 1. `assessmentScope.essentialEightMaturityLevel`
+selects the target for the engine, JSON manifest, framework PDF and full
+PDF/Word previews. The dashboard selector passes this scope into its PDF and
+JSON downloads. Full documentation generated without scope uses the labelled
+Level 1 default. This is a target evidence review, never an achieved maturity
+rating or a percentage maturity score.
+
+The checked-in `frameworks/essential-eight-requirements.json` reproduces all
+requirement entries from Appendices A, B and C of ASD's November 2023 model:
+48, 107 and 149 entries, respectively, across all eight strategies. Local
+`ML1-PA-01` style identifiers preserve appendix, strategy and row position;
+they are not official ISM identifiers. Repeated requirements in different
+strategies remain separate. No runtime download or website dependency is needed.
+
+Sources verified 6 September 2026:
+
+- [ASD Essential Eight maturity model](https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-maturity-model), November 2023.
+- [ASD assessment process guide](https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-assessment-process-guide), for assessment boundaries and effectiveness requirements.
+- [ASD ISM mapping](https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-maturity-model-and-ism-mapping), October 2024. This implementation uses the model's own appendix entries, not ISM control numbering.
+- [ASD consultation on evolution](https://www.cyber.gov.au/about-us/view-all-content/news/consultation-on-evolution-of-essential-eight), June 2026. The proposed Essentials series is not substituted for the published model.
+- [Microsoft endpoint-protection schema](https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10endpointprotectionconfiguration?view=graph-rest-beta), for Office/Adobe ASR enums. `block` for attack-surface enums and `enable` for the Adobe protection enum are blocking values; audit and warning modes do not count.
+
+Requirements are reproduced under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+attributed to the Australian Signals Directorate, © Commonwealth of Australia
+2026, in accordance with [ASD's copyright notice](https://www.cyber.gov.au/about-us/copyright).
+Local identifiers, mappings and limitation notes are additions by this project.
+No official logos or endorsement claims are included.
+
+Only exact, verified detector-to-requirement bindings produce supporting evidence.
+A 14-day Windows update configuration is not evidence for the separate 48-hour
+patch requirement, nor application patching. Generic MFA does not prove phishing
+resistance. Credential Guard does not prove Remote Credential Guard or LSA
+protection. Memory integrity compliance requirements do not prove device state.
+Adobe Reader protection does not establish protection of every PDF application.
+Backups, recovery exercises, incident response, access reviews, rule validation,
+central logging and other unmapped requirements remain explicitly unassessed.

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -59,7 +59,7 @@ with target Maturity Levels 1, 2 and 3.
 ## NIST SP 800-171 revisions
 
 Revision 2 (`nist-800-171-r2`) remains available for CMMC Level 2 and has
-supporting mappings for 11 of its 110 published requirements. Revision 3
+supporting mappings for 12 of its 110 published requirements. Revision 3
 (`nist-800-171-r3`, May 2024) is a separate assessment with supporting mappings
 for 11 of its 97 active requirements. These counts describe mapping coverage,
 not satisfied requirements or a compliance score. Unmapped requirements need
@@ -199,3 +199,17 @@ protection. Memory integrity compliance requirements do not prove device state.
 Adobe Reader protection does not establish protection of every PDF application.
 Backups, recovery exercises, incident response, access reviews, rule validation,
 central logging and other unmapped requirements remain explicitly unassessed.
+
+
+## Pre-merge evidence corrections (ruleset 2026.09.4)
+
+Quality-update timing above the shared 14-day evidence threshold is indeterminate,
+not an assigned deviation across frameworks with different remediation periods.
+Explicitly paused updates still produce counter-evidence. Scheduled noncompliance
+actions and app relation collection warnings remain in collection coverage but do
+not invalidate settings evidence; missing settings, details and assignments still do.
+NIST Revision 2 MFA evidence maps to 3.5.3, and Credential Guard supports 3.4.2.
+Conditional Access is excluded from Intune assignment coverage because it uses
+conditions rather than an assignment relation. The Word contents are populated
+section links and do not request field refresh on open. Oversized PDF evidence
+register rows continue across pages without omitting condition values.

--- a/src/lib/compliance/README.md
+++ b/src/lib/compliance/README.md
@@ -213,3 +213,15 @@ Conditional Access is excluded from Intune assignment coverage because it uses
 conditions rather than an assignment relation. The Word contents are populated
 section links and do not request field refresh on open. Oversized PDF evidence
 register rows continue across pages without omitting condition values.
+
+### Graph collection reliability (ruleset 2026.09.5)
+
+Baseline category reads fall back to parent expansion on the observed OData route rejection. Category-only failures remain visible in collection coverage without invalidating settings or assignment evidence. App-protection paging preserves each platform independently, including partial pages, before enriching retained policies.
+
+Registry entries now collect assignment relations supported by Microsoft's published beta metadata, including update profiles, apps, scripts, scope tags and policy sets. Every collected child has an explicit completeness status. A partial assignment read is unknown, even when its first page is empty or contains an inclusion.
+
+Paging rejects malformed collection responses and repeated continuation links while retaining retrieved items. Valid empty pages with a continuation link remain supported. A shared Graph request policy bounds each client's GET and batch concurrency to six, retries transient HTTP and SDK-wrapped network failures with Retry-After support, and prevents nested retry multiplication. Detailed collection has a 105-second budget inside the 120-second API route limit; disconnects cancel collection, and exhausted budgets produce partial-result diagnostics. This is a per-request-client limit, not a tenant-wide limit across concurrent exports.
+
+The two legacy collection APIs retain their existing payload fields and now include `fetchErrors` and `collectionStatus`. Permission probes distinguish denied access from unavailable probes. Streaming completion reports incomplete results instead of claiming all reads succeeded. Group-name batch failures preserve group identifiers and expose resolution warnings; assignment targeting never depends on successful name resolution. Transient inner batch failures are retried together after one shared wait per retry pass, with at most two retry passes per batch. Only batches containing exclusively GET requests receive automatic envelope retries. Registry types without an assignment relation are excluded from assignment coverage as not applicable. Update-ring detail failures retain collected assignments and explicit incomplete-detail markers.
+
+Validation includes fault-injection regression tests and sampled read-only Greybeard lab calls against the actual modified collector methods. Empty lab families, every subtype, and large-tenant load are not covered by that sample. Microsoft beta schemas are referenced at https://github.com/microsoftgraph/msgraph-metadata/blob/master/schemas/beta-Prod.csdl.

--- a/src/lib/compliance/additional-capabilities.ts
+++ b/src/lib/compliance/additional-capabilities.ts
@@ -1,0 +1,208 @@
+import type { ComplianceCapability, GraphPropertySignal } from "./types";
+
+const compliance = "windows10CompliancePolicy";
+const general = "windows10GeneralConfiguration";
+const endpoint = "windows10EndpointProtectionConfiguration";
+const bool = (type: string, propertyPath: string): GraphPropertySignal => ({
+  source: "graphProperty",
+  odataTypes: [type],
+  propertyPath,
+  enforcedWhen: { kind: "equals", value: true },
+  // A compliance requirement set to false says nothing about device state.
+  ...(type === compliance
+    ? {}
+    : { disabledWhen: { kind: "equals" as const, value: false } }),
+});
+const endpointDocs =
+  "https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10endpointprotectionconfiguration?view=graph-rest-beta";
+const generalDocs =
+  "https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10generalconfiguration?view=graph-rest-beta";
+const complianceDocs =
+  "https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10compliancepolicy?view=graph-rest-beta";
+
+export const ADDITIONAL_CAPABILITIES: readonly ComplianceCapability[] = [
+  {
+    id: "windows-antivirus-required",
+    platform: "windows",
+    name: "Antivirus presence required",
+    description:
+      "A Windows compliance policy requires registered antivirus software. This does not establish real-time protection or a particular vendor.",
+    documentationUrl: complianceDocs,
+    signals: [
+      bool(compliance, "antivirusRequired"),
+      bool(compliance, "defenderEnabled"),
+    ],
+  },
+  {
+    id: "windows-periodic-antimalware-scan",
+    platform: "windows",
+    name: "Periodic antimalware scans configured",
+    description:
+      "A scheduled quick or full scan has an explicit day and time. Successful execution and exclusions need separate review.",
+    documentationUrl: generalDocs,
+    signals: [{ source: "policyCheck", check: "scheduledAntivirusScan" }],
+  },
+  {
+    id: "windows-quality-update-deadline",
+    platform: "windows",
+    name: "Quality update timing within 14 days",
+    description:
+      "Automatic installation is configured, updates are not paused, and deferral plus deadline plus grace is at most 14 days. Actual installation timing and application updates remain unassessed.",
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windowsupdateforbusinessconfiguration?view=graph-rest-beta",
+    signals: [{ source: "policyCheck", check: "qualityUpdateDeadline" }],
+  },
+  {
+    id: "windows-application-control",
+    platform: "windows",
+    name: "Application control in enforcement mode",
+    description:
+      "Windows application control is configured to enforce a trusted application policy. Audit-only modes are not enforcement evidence; approved software and exceptions still need review.",
+    documentationUrl: endpointDocs,
+    signals: [
+      {
+        source: "graphProperty",
+        odataTypes: [endpoint],
+        propertyPath: "appLockerApplicationControl",
+        enforcedWhen: {
+          kind: "oneOf",
+          values: [
+            "enforceComponentsAndStoreApps",
+            "enforceComponentsStoreAppsAndSmartlocker",
+          ],
+        },
+        disabledWhen: {
+          kind: "oneOf",
+          values: [
+            "auditComponentsAndStoreApps",
+            "auditComponentsStoreAppsAndSmartlocker",
+          ],
+        },
+      },
+    ],
+  },
+  {
+    id: "windows-behavior-monitoring",
+    platform: "windows",
+    name: "Antimalware behavior monitoring",
+    description:
+      "Microsoft Defender behavior monitoring is configured. Detection events and response effectiveness are unassessed.",
+    documentationUrl: generalDocs,
+    signals: [
+      bool(general, "defenderRequireBehaviorMonitoring"),
+      bool(endpoint, "defenderAllowBehaviorMonitoring"),
+    ],
+  },
+  {
+    id: "windows-network-inspection",
+    platform: "windows",
+    name: "Antimalware network inspection",
+    description:
+      "Microsoft Defender network inspection is configured. Observed network detections and response are unassessed.",
+    documentationUrl: generalDocs,
+    signals: [
+      bool(general, "defenderRequireNetworkInspectionSystem"),
+      bool(endpoint, "defenderAllowIntrusionPreventionSystem"),
+    ],
+  },
+  {
+    id: "windows-memory-integrity",
+    platform: "windows",
+    name: "Memory integrity requirement (HVCI)",
+    description:
+      "Windows compliance requires hardware-backed memory integrity attestation.",
+    documentationUrl: complianceDocs,
+    signals: [bool(compliance, "memoryIntegrityEnabled")],
+  },
+  {
+    id: "windows-virtualization-security",
+    platform: "windows",
+    name: "Virtualization-based security",
+    description:
+      "Virtualization-based security is configured or required by compliance policy.",
+    documentationUrl: complianceDocs,
+    signals: [
+      bool(compliance, "virtualizationBasedSecurityEnabled"),
+      bool(endpoint, "deviceGuardEnableVirtualizationBasedSecurity"),
+    ],
+  },
+  {
+    id: "windows-credential-guard",
+    platform: "windows",
+    name: "Credential Guard configuration",
+    description:
+      "Credential Guard is configured. Hardware prerequisites, LSA monitoring and actual device activation are unassessed.",
+    documentationUrl: endpointDocs,
+    signals: [
+      {
+        source: "graphProperty",
+        odataTypes: [endpoint],
+        propertyPath: "deviceGuardLocalSystemAuthorityCredentialGuardSettings",
+        enforcedWhen: {
+          kind: "oneOf",
+          values: ["enableWithUEFILock", "enableWithoutUEFILock"],
+        },
+        disabledWhen: { kind: "equals", value: "disable" },
+      },
+    ],
+  },
+  {
+    id: "windows-credential-theft-protection",
+    platform: "windows",
+    name: "Credential theft reduction rule",
+    description:
+      "The Defender attack surface reduction rule protecting LSASS credentials is enabled; exclusions and actual enforcement are unassessed.",
+    documentationUrl: endpointDocs,
+    signals: [
+      {
+        source: "graphProperty",
+        odataTypes: [endpoint],
+        propertyPath: "defenderPreventCredentialStealingType",
+        enforcedWhen: { kind: "equals", value: "enable" },
+        disabledWhen: { kind: "oneOf", values: ["auditMode", "warn"] },
+      },
+    ],
+  },
+  {
+    id: "tenant-mfa-required",
+    platform: "tenant",
+    name: "Conditional Access MFA requirement",
+    description:
+      "An enabled Conditional Access policy requires MFA for its configured users and applications. Exclusions, other conditions and effective sign-ins require review.",
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessgrantcontrols?view=graph-rest-1.0",
+    signals: [{ source: "policyCheck", check: "conditionalAccessMfa" }],
+  },
+  {
+    id: "tenant-compliant-device-required",
+    platform: "tenant",
+    name: "Conditional Access compliant-device requirement",
+    description:
+      "An enabled Conditional Access policy requires compliant devices for its configured scope. This is not proof that a particular device or sign-in is blocked.",
+    documentationUrl:
+      "https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessgrantcontrols?view=graph-rest-1.0",
+    signals: [
+      { source: "policyCheck", check: "conditionalAccessCompliantDevice" },
+    ],
+  },
+  ...(["ios", "android"] as const).map((platform) => ({
+    id: `${platform}-app-data-transfer`,
+    platform,
+    name: `Managed app data transfer restrictions (${platform === "ios" ? "iOS" : "Android"})`,
+    description:
+      "Managed app policy limits outgoing data transfers. Targeted apps, exclusions and effective app protection need separate review.",
+    documentationUrl: `https://learn.microsoft.com/en-us/graph/api/resources/intune-mam-${platform}managedappprotection?view=graph-rest-beta`,
+    signals: [
+      {
+        source: "graphProperty" as const,
+        odataTypes: [`${platform}ManagedAppProtection`],
+        propertyPath: "allowedOutboundDataTransferDestinations",
+        enforcedWhen: {
+          kind: "oneOf" as const,
+          values: ["managedApps", "none"],
+        },
+        disabledWhen: { kind: "equals" as const, value: "allApps" },
+      },
+    ],
+  })),
+];

--- a/src/lib/compliance/assignments.ts
+++ b/src/lib/compliance/assignments.ts
@@ -1,0 +1,87 @@
+import type { AssignmentSummary } from "./types";
+
+export function summarizeAssignments(
+  assignments: unknown,
+  groupNames: ReadonlyMap<string, string> = new Map(),
+  incomplete = false,
+): AssignmentSummary {
+  const summary: AssignmentSummary = {
+    state: "unknown",
+    targets: [],
+    exclusions: [],
+    filters: [],
+    coverage: "unverified",
+  };
+  if (!Array.isArray(assignments)) return summary;
+  let unknownTarget = false;
+  for (const assignment of assignments) {
+    const target = assignment?.target;
+    if (!target || typeof target["@odata.type"] !== "string") {
+      unknownTarget = true;
+      continue;
+    }
+    const type = target["@odata.type"]
+      .replace(/^#?(microsoft\.graph\.)?/, "")
+      .toLowerCase();
+    let label: string;
+    if (type === "alldevicesassignmenttarget") label = "All Devices";
+    else if (
+      ["alllicensedusersassignmenttarget", "allusersassignmenttarget"].includes(
+        type,
+      )
+    )
+      label = "All Users";
+    else if (
+      ["groupassignmenttarget", "exclusiongroupassignmenttarget"].includes(
+        type,
+      ) &&
+      typeof target.groupId === "string" &&
+      target.groupId
+    )
+      label = `Group: ${groupNames.get(target.groupId) ?? target.groupName ?? target.groupId}`;
+    else {
+      unknownTarget = true;
+      continue;
+    }
+    if (type === "exclusiongroupassignmenttarget")
+      summary.exclusions.push(label);
+    else summary.targets.push(label);
+    const id = target.deviceAndAppManagementAssignmentFilterId;
+    const mode = target.deviceAndAppManagementAssignmentFilterType;
+    if (typeof id === "string" && id && mode !== "none") {
+      summary.filters.push({
+        target: label,
+        id,
+        mode: typeof mode === "string" ? mode : "unknown",
+      });
+      if (!["include", "exclude"].includes(mode)) unknownTarget = true;
+    } else if (mode && mode !== "none") {
+      unknownTarget = true;
+      summary.filters.push({
+        target: label,
+        id: "unknown",
+        mode: String(mode),
+      });
+    }
+  }
+  summary.state =
+    incomplete || unknownTarget
+      ? "unknown"
+      : summary.targets.length
+        ? "assigned"
+        : "notAssigned";
+  return summary;
+}
+
+export function assignmentDetails(assignment: AssignmentSummary): string[] {
+  return [
+    ...assignment.targets,
+    ...assignment.exclusions.map((target) => `Excluded: ${target}`),
+    ...assignment.filters.map(
+      (filter) => `Filter ${filter.mode}: ${filter.id} (${filter.target})`,
+    ),
+    ...(assignment.state === "unknown"
+      ? ["Assignment collection incomplete or unavailable"]
+      : []),
+  ];
+}

--- a/src/lib/compliance/capabilities.ts
+++ b/src/lib/compliance/capabilities.ts
@@ -1,3 +1,5 @@
+import { LEGACY_SIGNALS } from "./legacy-signals";
+import { ADDITIONAL_CAPABILITIES } from "./additional-capabilities";
 import type { ComplianceCapability } from "./types";
 
 // Every signal asserts a concrete Intune setting with the value that actually
@@ -5,7 +7,7 @@ import type { ComplianceCapability } from "./types";
 // non-enforcing value is recorded as counter-evidence via disabledWhen.
 // Settings not listed here are never counted, in either direction.
 
-export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
+const CORE_CAPABILITIES: readonly ComplianceCapability[] = [
   {
     id: "windows-disk-encryption",
     platform: "windows",
@@ -77,13 +79,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
       {
         source: "graphProperty",
         odataTypes: ["windows10CompliancePolicy"],
-        propertyPath: "defenderEnabled",
-        enforcedWhen: { kind: "equals", value: true },
-      },
-      {
-        source: "graphProperty",
-        odataTypes: ["windows10CompliancePolicy"],
-        propertyPath: "antivirusRequired",
+        propertyPath: "rtpEnabled",
         enforcedWhen: { kind: "equals", value: true },
       },
     ],
@@ -92,6 +88,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
     id: "windows-firewall",
     platform: "windows",
     name: "Host firewall (Windows Firewall)",
+    requiredGroups: ["domain", "private", "public"],
     description:
       "The Windows Firewall is required to be active on managed devices.",
     signals: [
@@ -100,6 +97,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "settingsCatalog",
         settingDefinitionId:
           "vendor_msft_firewall_mdmstore_domainprofile_enablefirewall",
+        requirementGroup: "domain",
         enforcedWhen: {
           kind: "equals",
           value:
@@ -115,6 +113,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "settingsCatalog",
         settingDefinitionId:
           "vendor_msft_firewall_mdmstore_privateprofile_enablefirewall",
+        requirementGroup: "private",
         enforcedWhen: {
           kind: "equals",
           value:
@@ -130,6 +129,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "settingsCatalog",
         settingDefinitionId:
           "vendor_msft_firewall_mdmstore_publicprofile_enablefirewall",
+        requirementGroup: "public",
         enforcedWhen: {
           kind: "equals",
           value:
@@ -147,6 +147,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "graphProperty",
         odataTypes: ["windows10EndpointProtectionConfiguration"],
         propertyPath: "firewallProfileDomain.firewallEnabled",
+        requirementGroup: "domain",
         enforcedWhen: { kind: "equals", value: "allowed" },
         disabledWhen: { kind: "equals", value: "blocked" },
       },
@@ -154,6 +155,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "graphProperty",
         odataTypes: ["windows10EndpointProtectionConfiguration"],
         propertyPath: "firewallProfilePrivate.firewallEnabled",
+        requirementGroup: "private",
         enforcedWhen: { kind: "equals", value: "allowed" },
         disabledWhen: { kind: "equals", value: "blocked" },
       },
@@ -161,6 +163,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         source: "graphProperty",
         odataTypes: ["windows10EndpointProtectionConfiguration"],
         propertyPath: "firewallProfilePublic.firewallEnabled",
+        requirementGroup: "public",
         enforcedWhen: { kind: "equals", value: "allowed" },
         disabledWhen: { kind: "equals", value: "blocked" },
       },
@@ -533,7 +536,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
   {
     id: "ios-jailbreak-block",
     platform: "ios",
-    name: "Jailbroken devices blocked",
+    name: "Jailbreak compliance requirement",
     description: "Jailbroken iOS devices are marked noncompliant.",
     signals: [
       {
@@ -616,13 +619,14 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
     platform: "android",
     name: "Device integrity (Android)",
     description:
-      "Rooted Android devices are blocked or Play Integrity attestation is required.",
+      "Android compliance policy requires an unrooted device or basic integrity attestation.",
     signals: [
       {
         source: "graphProperty",
         odataTypes: [
           "androidCompliancePolicy",
           "androidWorkProfileCompliancePolicy",
+          "androidDeviceOwnerCompliancePolicy",
         ],
         propertyPath: "securityBlockJailbrokenDevices",
         enforcedWhen: { kind: "equals", value: true },
@@ -632,6 +636,7 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
         odataTypes: [
           "androidCompliancePolicy",
           "androidWorkProfileCompliancePolicy",
+          "androidDeviceOwnerCompliancePolicy",
         ],
         propertyPath: "securityRequireSafetyNetAttestationBasicIntegrity",
         enforcedWhen: { kind: "equals", value: true },
@@ -684,4 +689,11 @@ export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] = [
       },
     ],
   },
+  ...ADDITIONAL_CAPABILITIES,
 ];
+
+export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] =
+  CORE_CAPABILITIES.map((capability) => ({
+    ...capability,
+    signals: [...capability.signals, ...(LEGACY_SIGNALS[capability.id] ?? [])],
+  }));

--- a/src/lib/compliance/capabilities.ts
+++ b/src/lib/compliance/capabilities.ts
@@ -1,3 +1,4 @@
+import { ESSENTIAL_EIGHT_CAPABILITIES } from "./essential-eight-capabilities";
 import { LEGACY_SIGNALS } from "./legacy-signals";
 import { ADDITIONAL_CAPABILITIES } from "./additional-capabilities";
 import type { ComplianceCapability } from "./types";
@@ -690,6 +691,7 @@ const CORE_CAPABILITIES: readonly ComplianceCapability[] = [
     ],
   },
   ...ADDITIONAL_CAPABILITIES,
+  ...ESSENTIAL_EIGHT_CAPABILITIES,
 ];
 
 export const COMPLIANCE_CAPABILITIES: readonly ComplianceCapability[] =

--- a/src/lib/compliance/coverage.ts
+++ b/src/lib/compliance/coverage.ts
@@ -1,0 +1,189 @@
+import type { DetailedExportData } from "../configuration-analyzer";
+import type {
+  CapabilityResult,
+  CollectionCoverage,
+  ComplianceCapability,
+} from "./types";
+
+function families(data: Omit<DetailedExportData, "groupNames">) {
+  if (data.sections?.length)
+    return data.sections.map((section) => ({
+      family: section.familyKey,
+      items: section.items,
+      error: section.error?.message,
+    }));
+  return [
+    ...[
+      "settingsCatalog",
+      "deviceConfigurations",
+      "administrativeTemplates",
+      "compliancePolicies",
+      "appProtectionPolicies",
+      "securityBaselines",
+      "appConfigurations",
+      "windowsUpdatePolicies",
+      "enrollmentConfigurations",
+      "conditionalAccessPolicies",
+    ].map((family) => ({
+      family,
+      items: (data as any)[family] ?? [],
+      error: undefined as string | undefined,
+    })),
+    {
+      family: "scripts",
+      items: [...(data.scripts?.windows ?? []), ...(data.scripts?.macOS ?? [])],
+      error: undefined,
+    },
+  ];
+}
+
+export function collectConfigurations(
+  data: Omit<DetailedExportData, "groupNames">,
+): Record<string, any>[] {
+  return families(data).flatMap(({ family, items }) =>
+    items
+      .filter((item: any) => item && typeof item === "object")
+      .map((item: any) => {
+        const errors =
+          data.fetchErrors?.filter(
+            (error) =>
+              error.policyId === item.id &&
+              (!error.familyKey || error.familyKey === family),
+          ) ?? [];
+        const assignmentsIncomplete =
+          (item.hasFetchError && !item.collectionStatus) ||
+          errors.some((error) =>
+            /assignments/i.test(`${error.endpoint ?? ""} ${error.error}`),
+          );
+        return {
+          ...item,
+          ...(family === "conditionalAccessPolicies"
+            ? { "@odata.type": "#microsoft.graph.conditionalAccessPolicy" }
+            : {}),
+          ...(assignmentsIncomplete
+            ? {
+                collectionStatus: {
+                  ...item.collectionStatus,
+                  assignments: "incomplete",
+                },
+              }
+            : {}),
+          __evidenceFamily: family,
+        };
+      }),
+  );
+}
+
+export function buildCollectionCoverage(
+  data: Omit<DetailedExportData, "groupNames">,
+  capabilities: readonly CapabilityResult[],
+): CollectionCoverage[] {
+  const rows = new Map<string, CollectionCoverage>();
+  const evidence = new Set(
+    capabilities.flatMap((result) =>
+      result.evidence.map((item) => `${item.familyKey}:${item.policyId}`),
+    ),
+  );
+  for (const { family, items, error } of families(data)) {
+    const row = rows.get(family) ?? {
+      family,
+      collectedPolicies: 0,
+      recognizedPolicies: 0,
+      unsupportedPolicies: 0,
+      status: data.collectedAt ? "complete" : "unknown",
+      errors: [],
+    };
+    row.collectedPolicies += items.length;
+    const recognized = items.filter((item: any) =>
+      evidence.has(`${family}:${item.id}`),
+    ).length;
+    row.recognizedPolicies += recognized;
+    row.unsupportedPolicies += items.length - recognized;
+    if (error) row.errors.push(error);
+    for (const item of items) {
+      const incompleteParts = Object.entries(item.collectionStatus ?? {})
+        .filter(([, status]) => status === "incomplete")
+        .map(([part]) => part);
+      if (item.hasFetchError || incompleteParts.length)
+        row.errors.push(
+          `${item.displayName ?? item.name ?? item.id}: ${item.fetchErrorMessage ?? `incomplete ${incompleteParts.join(", ") || "policy details"}`}`,
+        );
+    }
+    rows.set(family, row);
+  }
+  for (const error of data.fetchErrors ?? []) {
+    const normalizeFamily = (value: string) =>
+      value
+        .toLowerCase()
+        .replace(/[^a-z]/g, "")
+        .replace(/ies$/, "y")
+        .replace(/s$/, "");
+    const family =
+      error.familyKey ??
+      [...rows.keys()].find(
+        (key) => normalizeFamily(key) === normalizeFamily(error.policyType),
+      ) ??
+      error.policyType;
+    const row = rows.get(family) ?? {
+      family,
+      collectedPolicies: 0,
+      recognizedPolicies: 0,
+      unsupportedPolicies: 0,
+      status: "incomplete",
+      errors: [],
+    };
+    row.errors.push(`${error.policyName}: ${error.error}`);
+    rows.set(family, row);
+  }
+  for (const error of data.permissionErrors ?? []) {
+    const row = [...rows.values()].find(
+      (candidate) =>
+        candidate.family.toLowerCase().replace(/[^a-z]/g, "") ===
+        error.resource.toLowerCase().replace(/[^a-z]/g, ""),
+    );
+    if (row) row.errors.push(error.message);
+    else
+      rows.set(error.resource, {
+        family: error.resource,
+        collectedPolicies: 0,
+        recognizedPolicies: 0,
+        unsupportedPolicies: 0,
+        status: "incomplete",
+        errors: [error.message],
+      });
+  }
+  for (const row of rows.values()) {
+    if (row.errors.length) row.status = "incomplete";
+    else if (data.collectionSkippedFamilies?.includes(row.family))
+      row.status = "notCollected";
+    row.errors = [...new Set(row.errors)];
+  }
+  return [...rows.values()];
+}
+
+export function isCapabilityCollectionIncomplete(
+  data: Omit<DetailedExportData, "groupNames">,
+  capability: ComplianceCapability,
+): boolean {
+  const relevant =
+    capability.platform === "tenant"
+      ? ["conditionalAccessPolicies"]
+      : [
+          "settingsCatalog",
+          "deviceConfigurations",
+          "administrativeTemplates",
+          "securityBaselines",
+          "compliancePolicies",
+          ...(capability.id.includes("update")
+            ? ["windowsUpdatePolicies"]
+            : []),
+          ...(capability.id.includes("app-data")
+            ? ["appProtectionPolicies"]
+            : []),
+        ];
+  return buildCollectionCoverage(data, []).some(
+    (row) =>
+      relevant.includes(row.family) &&
+      ["incomplete", "notCollected"].includes(row.status),
+  );
+}

--- a/src/lib/compliance/coverage.ts
+++ b/src/lib/compliance/coverage.ts
@@ -77,6 +77,7 @@ export function collectConfigurations(
 export function buildCollectionCoverage(
   data: Omit<DetailedExportData, "groupNames">,
   capabilities: readonly CapabilityResult[],
+  evidenceOnly = false,
 ): CollectionCoverage[] {
   const rows = new Map<string, CollectionCoverage>();
   const evidence = new Set(
@@ -102,9 +103,23 @@ export function buildCollectionCoverage(
     if (error) row.errors.push(error);
     for (const item of items) {
       const incompleteParts = Object.entries(item.collectionStatus ?? {})
-        .filter(([, status]) => status === "incomplete")
+        .filter(
+          ([part, status]) =>
+            status === "incomplete" &&
+            (!evidenceOnly ||
+              !["scheduledActionsForRule", "apps"].includes(part)),
+        )
         .map(([part]) => part);
-      if (item.hasFetchError || incompleteParts.length)
+      if (
+        (item.hasFetchError &&
+          (!evidenceOnly ||
+            !Object.entries(item.collectionStatus ?? {}).some(
+              ([part, status]) =>
+                status === "incomplete" &&
+                ["scheduledActionsForRule", "apps"].includes(part),
+            ))) ||
+        incompleteParts.length
+      )
         row.errors.push(
           `${item.displayName ?? item.name ?? item.id}: ${item.fetchErrorMessage ?? `incomplete ${incompleteParts.join(", ") || "policy details"}`}`,
         );
@@ -112,6 +127,15 @@ export function buildCollectionCoverage(
     rows.set(family, row);
   }
   for (const error of data.fetchErrors ?? []) {
+    // Ancillary relation warnings remain visible in the collection report, but
+    // do not invalidate settings or assignment evidence already collected.
+    if (
+      evidenceOnly &&
+      /scheduledActionsForRule|scheduledActionConfigurations|\/apps(?:[/?]|$)/i.test(
+        error.endpoint ?? "",
+      )
+    )
+      continue;
     const normalizeFamily = (value: string) =>
       value
         .toLowerCase()
@@ -181,7 +205,7 @@ export function isCapabilityCollectionIncomplete(
             ? ["appProtectionPolicies"]
             : []),
         ];
-  return buildCollectionCoverage(data, []).some(
+  return buildCollectionCoverage(data, [], true).some(
     (row) =>
       relevant.includes(row.family) &&
       ["incomplete", "notCollected"].includes(row.status),

--- a/src/lib/compliance/coverage.ts
+++ b/src/lib/compliance/coverage.ts
@@ -107,7 +107,9 @@ export function buildCollectionCoverage(
           ([part, status]) =>
             status === "incomplete" &&
             (!evidenceOnly ||
-              !["scheduledActionsForRule", "apps"].includes(part)),
+              !["scheduledActionsForRule", "apps", "categories"].includes(
+                part,
+              )),
         )
         .map(([part]) => part);
       if (
@@ -116,7 +118,9 @@ export function buildCollectionCoverage(
             !Object.entries(item.collectionStatus ?? {}).some(
               ([part, status]) =>
                 status === "incomplete" &&
-                ["scheduledActionsForRule", "apps"].includes(part),
+                ["scheduledActionsForRule", "apps", "categories"].includes(
+                  part,
+                ),
             ))) ||
         incompleteParts.length
       )
@@ -131,7 +135,7 @@ export function buildCollectionCoverage(
     // do not invalidate settings or assignment evidence already collected.
     if (
       evidenceOnly &&
-      /scheduledActionsForRule|scheduledActionConfigurations|\/apps(?:[/?]|$)/i.test(
+      /scheduledActionsForRule|scheduledActionConfigurations|\/(?:apps|categories)(?:[/?]|$)|[?&]\$expand=categories(?:&|$)/i.test(
         error.endpoint ?? "",
       )
     )

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -2,8 +2,11 @@ import type { DetailedExportData } from "../configuration-analyzer";
 import type { ConfigurationSettingInstance } from "../intune-detailed-client";
 import { COMPLIANCE_CAPABILITIES } from "./capabilities";
 import { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
+import { CYBER_ESSENTIALS } from "./frameworks/cyber-essentials";
+import { DEF_STAN_05_138 } from "./frameworks/def-stan-05-138";
 import { ISO_27001 } from "./frameworks/iso-27001";
 import { NIST_800_53 } from "./frameworks/nist-800-53";
+import { NIST_800_171 } from "./frameworks/nist-800-171";
 import { NIST_CSF } from "./frameworks/nist-csf";
 import { SOC_2 } from "./frameworks/soc2";
 import type {
@@ -428,6 +431,9 @@ export function assessCompliance(
       assessFramework(capabilities, BSI_IT_GRUNDSCHUTZ),
       assessFramework(capabilities, ISO_27001),
       assessFramework(capabilities, SOC_2),
+      assessFramework(capabilities, DEF_STAN_05_138),
+      assessFramework(capabilities, CYBER_ESSENTIALS),
+      assessFramework(capabilities, NIST_800_171),
     ],
   };
 }

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -1,5 +1,12 @@
 import type { DetailedExportData } from "../configuration-analyzer";
 import type { ConfigurationSettingInstance } from "../intune-detailed-client";
+import { summarizeAssignments } from "./assignments";
+import { evaluatePolicyCheck } from "./policy-checks";
+import {
+  buildCollectionCoverage,
+  collectConfigurations,
+  isCapabilityCollectionIncomplete,
+} from "./coverage";
 import { COMPLIANCE_CAPABILITIES } from "./capabilities";
 import { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
 import { CYBER_ESSENTIALS } from "./frameworks/cyber-essentials";
@@ -7,10 +14,11 @@ import { DEF_STAN_05_138 } from "./frameworks/def-stan-05-138";
 import { ISO_27001 } from "./frameworks/iso-27001";
 import { NIST_800_53 } from "./frameworks/nist-800-53";
 import { NIST_800_171 } from "./frameworks/nist-800-171";
+import { NIST_800_171_R3 } from "./frameworks/nist-800-171-r3";
 import { NIST_CSF } from "./frameworks/nist-csf";
 import { SOC_2 } from "./frameworks/soc2";
 import type {
-  AssignmentSummary,
+  AssessmentScope,
   CapabilityEvidence,
   CapabilityResult,
   CapabilityStatus,
@@ -22,16 +30,17 @@ import type {
   FrameworkAssessment,
   FrameworkDefinition,
   ValueExpectation,
+  EvidenceKind,
 } from "./types";
 
-type ComplianceExportData = Omit<DetailedExportData, "groupNames"> & {
+export type ComplianceExportData = Omit<DetailedExportData, "groupNames"> & {
   groupNames?: Map<string, string> | Readonly<Record<string, string>>;
 };
 
 export const COMPLIANCE_DISCLAIMER =
   "This assessment reports technical evidence found in the Intune tenant configuration. It is not a compliance certification and does not replace an audit. Absence of evidence means no matching Intune policy was detected, not that a requirement is unmet through other means.";
 
-export const COMPLIANCE_RULESET_VERSION = "2026.08";
+export const COMPLIANCE_RULESET_VERSION = "2026.09.2";
 
 const controlIdCollator = new Intl.Collator("en", {
   numeric: true,
@@ -57,7 +66,7 @@ function satisfies(value: unknown, expectation: ValueExpectation): boolean {
   }
 }
 
-function normalizeOdataType(value: unknown): string {
+export function normalizeOdataType(value: unknown): string {
   if (typeof value !== "string") return "";
   return value
     .replace(/^#/, "")
@@ -76,7 +85,7 @@ function resolvePropertyPath(config: unknown, path: string): unknown {
 
 // Flattens a settings catalog policy into definitionId -> configured primitive
 // values, walking choice/group children so nested settings are evaluated too.
-function collectCatalogValues(
+export function collectCatalogValues(
   settings: unknown,
 ): Map<string, Array<string | number | boolean>> {
   const values = new Map<string, Array<string | number | boolean>>();
@@ -149,41 +158,6 @@ function normalizeGroupNames(value: unknown): Map<string, string> {
   );
 }
 
-function summarizeAssignments(
-  assignments: unknown,
-  groupNames: ReadonlyMap<string, string>,
-): AssignmentSummary {
-  if (!Array.isArray(assignments) || assignments.length === 0) {
-    return { state: "notAssigned", targets: [] };
-  }
-
-  const targets: string[] = [];
-  for (const assignment of assignments) {
-    const target = (assignment as { target?: Record<string, unknown> })?.target;
-    if (!target) continue;
-    const type = normalizeOdataType(target["@odata.type"]);
-
-    if (type.includes("exclusion")) continue;
-    if (type.includes("alldevices")) {
-      targets.push("All Devices");
-    } else if (type.includes("alllicensedusers") || type.includes("allusers")) {
-      targets.push("All Users");
-    } else if (typeof target.groupId === "string" && target.groupId) {
-      const groupName =
-        groupNames.get(target.groupId) ||
-        (typeof target.groupName === "string" && target.groupName) ||
-        target.groupId;
-      targets.push(`Group: ${groupName}`);
-    } else {
-      targets.push("Custom target");
-    }
-  }
-
-  return targets.length > 0
-    ? { state: "assigned", targets }
-    : { state: "notAssigned", targets: [] };
-}
-
 function compliancePolicyNote(
   config: Record<string, unknown>,
 ): string | undefined {
@@ -193,34 +167,66 @@ function compliancePolicyNote(
   const scheduledActions = Array.isArray(config.scheduledActionsForRule)
     ? config.scheduledActionsForRule
     : [];
-  const blocksAccess = scheduledActions.some((rule: any) =>
-    (rule?.scheduledActionConfigurations ?? []).some(
-      (action: any) => action?.actionType === "block",
-    ),
+  const blockActions = scheduledActions
+    .flatMap((rule: any) => rule?.scheduledActionConfigurations ?? [])
+    .filter((action: any) => action?.actionType === "block");
+  const grace = blockActions.map((action: any) =>
+    typeof action.gracePeriodHours === "number"
+      ? `${action.gracePeriodHours} hours`
+      : "unknown grace period",
   );
-
-  return blocksAccess
-    ? "Compliance policy with a block action for noncompliant devices."
-    : "Compliance policy: marks devices noncompliant. Access enforcement depends on Conditional Access.";
+  return `Compliance requirement, not an observed device state. ${grace.length ? `Marks noncompliant after ${grace.join(", ")}. ` : "Noncompliance action timing is unavailable. "}Resource access depends on applicable Conditional Access policies; effective access is unverified.`;
 }
 
-function verdictFor(
+function verdictsFor(
   values: readonly unknown[],
-  signal: DetectionSignal,
-): { verdict: "enforced" | "disabled"; observed: unknown } | undefined {
-  const enforced = values.find((value) =>
-    satisfies(value, signal.enforcedWhen),
-  );
-  if (enforced !== undefined)
-    return { verdict: "enforced", observed: enforced };
-  if (signal.disabledWhen) {
-    const disabled = values.find((value) =>
-      satisfies(value, signal.disabledWhen!),
-    );
-    if (disabled !== undefined)
-      return { verdict: "disabled", observed: disabled };
-  }
-  return undefined;
+  signal: Exclude<DetectionSignal, { source: "policyCheck" }>,
+) {
+  return [...new Set(values)].flatMap<{
+    verdict: "enforced" | "disabled";
+    observed: unknown;
+  }>((value) => {
+    if (satisfies(value, signal.enforcedWhen))
+      return [{ verdict: "enforced" as const, observed: value }];
+    if (signal.disabledWhen && satisfies(value, signal.disabledWhen))
+      return [{ verdict: "disabled" as const, observed: value }];
+    return [];
+  });
+}
+
+function legacyValues(
+  config: Record<string, any>,
+  signal: Extract<DetectionSignal, { settingId: string }>,
+): unknown[] {
+  if (signal.source === "administrativeTemplate")
+    return (config.definitionValues ?? [])
+      .filter((value: any) => value?.definition?.id === signal.settingId)
+      .map((value: any) => value.enabled);
+  if (signal.source === "omaUri")
+    return (config.omaSettings ?? [])
+      .filter((value: any) => value?.omaUri === signal.settingId)
+      .map((value: any) => value.value);
+  const settings = [
+    ...(Array.isArray(config.settings) ? config.settings : []),
+    ...(config.categories ?? []).flatMap(
+      (category: any) => category?.settings ?? [],
+    ),
+  ];
+  return settings
+    .filter((setting: any) => setting?.definitionId === signal.settingId)
+    .flatMap((setting: any) => {
+      if (["boolean", "string", "number"].includes(typeof setting.value))
+        return [setting.value];
+      if (typeof setting.valueJson !== "string") return [];
+      try {
+        const value = JSON.parse(setting.valueJson);
+        return typeof value === "object" && value !== null
+          ? [value.value]
+          : [value];
+      } catch {
+        return [];
+      }
+    });
 }
 
 function evaluateConfiguration(
@@ -231,8 +237,33 @@ function evaluateConfiguration(
   const evidence: CapabilityEvidence[] = [];
   const catalogValues = collectCatalogValues(config.settings);
   const odataType = normalizeOdataType(config["@odata.type"]);
-  const assignment = summarizeAssignments(config.assignments, groupNames);
+  const assignment = summarizeAssignments(
+    config.assignments,
+    groupNames,
+    Boolean(
+      config.collectionStatus &&
+        (config.collectionStatus as any).assignments !== "complete",
+    ),
+  );
+  const kind: EvidenceKind = odataType.endsWith("compliancepolicy")
+    ? "complianceRequirement"
+    : odataType === "conditionalaccesspolicy"
+      ? "accessPolicy"
+      : "configuration";
   const note = compliancePolicyNote(config);
+  if (kind === "accessPolicy") {
+    const ca = config as any;
+    assignment.state = ca.state === "enabled" ? "assigned" : "notAssigned";
+    assignment.targets = [
+      `Users: ${JSON.stringify(ca.conditions?.users ?? {})}`,
+      `Applications: ${JSON.stringify(ca.conditions?.applications ?? {})}`,
+    ];
+    assignment.exclusions = [];
+    // Preserve every condition, including device filters, locations, risk and client types.
+    assignment.targets.push(
+      `Conditions: ${JSON.stringify(ca.conditions ?? {})}`,
+    );
+  }
 
   const policyId = typeof config.id === "string" ? config.id : "";
   const policyName =
@@ -246,99 +277,117 @@ function evaluateConfiguration(
 
   for (const capability of capabilities) {
     for (const signal of capability.signals) {
-      let match:
-        | { verdict: "enforced" | "disabled"; observed: unknown }
-        | undefined;
+      let values: unknown[] = [];
       let settingId: string;
-
-      if (signal.source === "settingsCatalog") {
-        settingId = signal.settingDefinitionId;
-        const values = catalogValues.get(signal.settingDefinitionId);
-        if (!values) continue;
-        match = verdictFor(values, signal);
+      let matches: Array<{
+        verdict: "enforced" | "disabled";
+        observed: unknown;
+      }>;
+      if (signal.source === "policyCheck") {
+        settingId = signal.check;
+        const match = evaluatePolicyCheck(config, signal.check);
+        matches = match ? [match] : [];
       } else {
-        if (
-          !signal.odataTypes.some((type) => type.toLowerCase() === odataType)
-        ) {
-          continue;
+        if (signal.source === "settingsCatalog") {
+          settingId = signal.settingDefinitionId;
+          values = catalogValues.get(settingId) ?? [];
+        } else if (signal.source === "graphProperty") {
+          if (
+            !signal.odataTypes.some((type) => type.toLowerCase() === odataType)
+          )
+            continue;
+          settingId = signal.propertyPath;
+          const value = resolvePropertyPath(config, settingId);
+          if (value === undefined || value === null) continue;
+          values = [value];
+        } else {
+          settingId = signal.settingId;
+          values = legacyValues(config, signal);
         }
-        settingId = signal.propertyPath;
-        const value = resolvePropertyPath(config, signal.propertyPath);
-        if (value === undefined || value === null) continue;
-        match = verdictFor([value], signal);
+        matches = verdictsFor(values, signal);
       }
-
-      // A present value that matches neither expectation is indeterminate and
-      // is deliberately not reported in either direction.
-      if (!match) continue;
-
-      evidence.push({
-        capabilityId: capability.id,
-        policyId,
-        policyName,
-        policyType,
-        source: signal.source,
-        settingId,
-        observedValue: String(match.observed),
-        verdict: match.verdict,
-        assignment,
-        note,
-      });
+      for (const match of matches)
+        evidence.push({
+          capabilityId: capability.id,
+          policyId,
+          policyName,
+          policyType,
+          familyKey:
+            typeof config.__evidenceFamily === "string"
+              ? config.__evidenceFamily
+              : undefined,
+          source: signal.source,
+          settingId,
+          observedValue: String(match.observed),
+          verdict: match.verdict,
+          assignment,
+          kind,
+          note,
+          requirementGroup: signal.requirementGroup,
+          policyVersion:
+            typeof config.version === "number" ||
+            typeof config.version === "string"
+              ? String(config.version)
+              : undefined,
+          policyModifiedAt:
+            typeof config.lastModifiedDateTime === "string"
+              ? config.lastModifiedDateTime
+              : undefined,
+        });
     }
   }
 
   return evidence;
 }
 
-function collectConfigurations(
-  data: ComplianceExportData,
-): Array<Record<string, unknown>> {
-  const configs = data.sections?.length
-    ? data.sections.flatMap((section) => section.items)
-    : [
-        ...data.settingsCatalog,
-        ...data.deviceConfigurations,
-        ...data.administrativeTemplates,
-        ...data.compliancePolicies,
-        ...(data.appProtectionPolicies ?? []),
-        ...data.securityBaselines,
-        ...data.scripts.windows,
-        ...data.scripts.macOS,
-        ...(data.appConfigurations ?? []),
-        ...(data.windowsUpdatePolicies ?? []),
-        ...(data.enrollmentConfigurations ?? []),
-        ...(data.conditionalAccessPolicies ?? []),
-      ];
-
-  return configs.filter(
-    (config): config is Record<string, unknown> =>
-      Boolean(config) && typeof config === "object",
-  );
-}
-
 function capabilityStatus(
   evidence: readonly CapabilityEvidence[],
+  capability: ComplianceCapability,
 ): CapabilityStatus {
-  if (
-    evidence.some(
-      (item) =>
-        item.verdict === "enforced" && item.assignment.state === "assigned",
-    )
-  ) {
-    return "enforced";
+  const assigned = evidence.filter(
+    (item) => item.assignment.state === "assigned",
+  );
+  const positive = assigned.filter((item) => item.verdict === "enforced");
+  if (positive.length && assigned.some((item) => item.verdict === "disabled"))
+    return "conflictingEvidence";
+  if (positive.length) {
+    if (capability.requiredGroups?.length) {
+      // Do not assemble a complete setting from policies with different scopes.
+      const policyKeys = new Set(
+        positive.map((item) => `${item.policyType}:${item.policyId}`),
+      );
+      const complete = [...policyKeys].some((key) =>
+        capability.requiredGroups!.every((group) =>
+          positive.some(
+            (item) =>
+              `${item.policyType}:${item.policyId}` === key &&
+              item.requirementGroup === group,
+          ),
+        ),
+      );
+      if (!complete) return "partialConfiguration";
+    }
+    return positive.some((item) => item.kind !== "complianceRequirement")
+      ? "enforced"
+      : "requirementAssigned";
   }
-  if (evidence.some((item) => item.verdict === "enforced")) {
+  if (evidence.some((item) => item.assignment.state === "unknown"))
+    return "assignmentUnknown";
+  if (evidence.some((item) => item.verdict === "enforced"))
     return "configuredNotAssigned";
-  }
-  if (evidence.some((item) => item.verdict === "disabled")) {
+  if (evidence.some((item) => item.verdict === "disabled"))
     return "disabledByPolicy";
-  }
   return "noEvidence";
+}
+
+export function hasAssignedEvidence(status: CapabilityStatus): boolean {
+  return status === "enforced" || status === "requirementAssigned";
 }
 
 export function assessCapabilities(
   data: ComplianceExportData,
   capabilities: readonly ComplianceCapability[] = COMPLIANCE_CAPABILITIES,
+  scope: AssessmentScope = data.assessmentScope ?? {},
 ): CapabilityResult[] {
   const configurations = collectConfigurations(data);
   const groupNames = normalizeGroupNames(data.groupNames);
@@ -358,13 +407,50 @@ export function assessCapabilities(
 
   return capabilities.map((capability) => {
     const evidence = evidenceByCapability.get(capability.id) ?? [];
-    return { capability, status: capabilityStatus(evidence), evidence };
+    const incomplete = isCapabilityCollectionIncomplete(data, capability);
+    let status = capabilityStatus(evidence, capability);
+    if (status === "noEvidence" && incomplete) status = "collectionIncomplete";
+    if (
+      scope.platforms &&
+      capability.platform !== "tenant" &&
+      !scope.platforms.includes(capability.platform)
+    )
+      status = "notApplicable";
+    return {
+      capability,
+      status,
+      evidence,
+      limitations: [
+        ...(evidence.some((item) => item.assignment.state === "unknown")
+          ? [
+              "Assignment data is unavailable for some matching policies; effective targeting remains unknown.",
+            ]
+          : []),
+        ...(incomplete
+          ? [
+              "Relevant policy collection is incomplete; additional or contradictory evidence may be missing.",
+            ]
+          : []),
+        ...(status === "conflictingEvidence"
+          ? [
+              "Mixed policy evidence. Review profile settings and targeting overlap; a device conflict has not been established.",
+            ]
+          : []),
+        ...(status === "partialConfiguration"
+          ? [
+              "Not all required settings are present together on an assigned policy.",
+            ]
+          : []),
+        ...(capability.caveat ? [capability.caveat.en] : []),
+      ],
+    };
   });
 }
 
 export function assessFramework(
   capabilityResults: readonly CapabilityResult[],
   framework: FrameworkDefinition,
+  scope: AssessmentScope = {},
 ): FrameworkAssessment {
   const capabilitiesByControl = new Map<string, string[]>();
   for (const [capabilityId, controlIds] of Object.entries(framework.mappings)) {
@@ -382,22 +468,76 @@ export function assessFramework(
   const controls: ControlAssessment[] = Object.values(framework.controls)
     .sort((a, b) => compareControlIds(a.id, b.id))
     .map((control) => {
-      const capabilityIds = capabilitiesByControl.get(control.id) ?? [];
-      const enforcedCapabilityIds = capabilityIds.filter(
-        (id) => statusById.get(id) === "enforced",
+      const mappedIds = capabilitiesByControl.get(control.id) ?? [];
+      const excludedCapabilityIds = mappedIds.filter(
+        (id) => statusById.get(id) === "notApplicable",
       );
-
+      const capabilityIds = mappedIds.filter(
+        (id) => !excludedCapabilityIds.includes(id),
+      );
+      const relevant = capabilityResults.filter((result) =>
+        capabilityIds.includes(result.capability.id),
+      );
+      const enforcedCapabilityIds = relevant
+        .filter((result) => hasAssignedEvidence(result.status))
+        .map((result) => result.capability.id);
+      const unassessedAspects = [...(control.unassessedAspects ?? [])];
+      if (control.evidenceStrength !== "direct" && !unassessedAspects.length)
+        unassessedAspects.push(
+          "These settings support part of this control. Remaining technical and organizational requirements need separate assessment.",
+        );
       let status: ControlStatus = "noEvidence";
-      if (
-        enforcedCapabilityIds.length === capabilityIds.length &&
-        capabilityIds.length > 0
+      const outsidePlatformScope =
+        scope.platforms &&
+        control.platforms &&
+        !control.platforms.some((platform) =>
+          scope.platforms!.includes(platform),
+        );
+      const outsideRiskScope =
+        scope.defStanRiskLevel !== undefined &&
+        control.riskLevels &&
+        !control.riskLevels.includes(scope.defStanRiskLevel);
+      if (outsidePlatformScope || outsideRiskScope) status = "notApplicable";
+      else if (!capabilityIds.length) {
+        status = "notAssessed";
+        unassessedAspects.push(
+          "No detector is available for this control in the selected platform scope.",
+        );
+      } else if (
+        relevant.some((result) => result.status === "conflictingEvidence")
+      )
+        status = "conflictingEvidence";
+      else if (
+        enforcedCapabilityIds.length ||
+        relevant.some((result) => result.status === "partialConfiguration")
       ) {
-        status = "evidenceFound";
-      } else if (enforcedCapabilityIds.length > 0) {
-        status = "partialEvidence";
-      }
-
-      return { control, capabilityIds, enforcedCapabilityIds, status };
+        status =
+          enforcedCapabilityIds.length === capabilityIds.length &&
+          control.evidenceStrength === "direct" &&
+          !unassessedAspects.length &&
+          !relevant.some((result) => result.limitations.length)
+            ? "evidenceFound"
+            : "partialEvidence";
+      } else if (
+        relevant.some((result) =>
+          ["collectionIncomplete", "assignmentUnknown"].includes(result.status),
+        )
+      )
+        status = "notAssessed";
+      for (const result of relevant)
+        for (const limitation of result.limitations)
+          if (!unassessedAspects.includes(limitation))
+            unassessedAspects.push(limitation);
+      return {
+        control,
+        capabilityIds: status === "notApplicable" ? [] : capabilityIds,
+        enforcedCapabilityIds:
+          status === "notApplicable" ? [] : enforcedCapabilityIds,
+        status,
+        unassessedAspects,
+        excludedCapabilityIds:
+          status === "notApplicable" ? mappedIds : excludedCapabilityIds,
+      };
     });
 
   return {
@@ -406,6 +546,8 @@ export function assessFramework(
       name: framework.name,
       version: framework.version,
       note: framework.note,
+      source: framework.source,
+      totalRequirements: framework.totalRequirements,
     },
     controls,
     summary: {
@@ -413,27 +555,45 @@ export function assessFramework(
       withEvidence: controls.filter((c) => c.status === "evidenceFound").length,
       partial: controls.filter((c) => c.status === "partialEvidence").length,
       withoutEvidence: controls.filter((c) => c.status === "noEvidence").length,
+      notApplicable: controls.filter((c) => c.status === "notApplicable")
+        .length,
+      notAssessed: controls.filter((c) => c.status === "notAssessed").length,
+      conflicting: controls.filter((c) => c.status === "conflictingEvidence")
+        .length,
+      applicableControls: controls.filter((c) => c.status !== "notApplicable")
+        .length,
     },
   };
 }
 
 export function assessCompliance(
   data: ComplianceExportData,
+  scope: AssessmentScope = data.assessmentScope ?? {},
 ): ComplianceAssessment {
-  const capabilities = assessCapabilities(data);
+  const capabilities = assessCapabilities(data, COMPLIANCE_CAPABILITIES, scope);
   return {
     generatedAt: new Date().toISOString(),
     disclaimer: COMPLIANCE_DISCLAIMER,
     capabilities,
+    scope,
+    collectionCoverage: buildCollectionCoverage(data, capabilities),
+    provenance: {
+      rulesetVersion: COMPLIANCE_RULESET_VERSION,
+      collectedAt: data.collectedAt,
+      collectionStartedAt: data.collectionStartedAt,
+      deviceState: "notCollected",
+      effectiveAccess: "unverified",
+    },
     frameworks: [
-      assessFramework(capabilities, NIST_800_53),
-      assessFramework(capabilities, NIST_CSF),
-      assessFramework(capabilities, BSI_IT_GRUNDSCHUTZ),
-      assessFramework(capabilities, ISO_27001),
-      assessFramework(capabilities, SOC_2),
-      assessFramework(capabilities, DEF_STAN_05_138),
-      assessFramework(capabilities, CYBER_ESSENTIALS),
-      assessFramework(capabilities, NIST_800_171),
+      assessFramework(capabilities, NIST_800_53, scope),
+      assessFramework(capabilities, NIST_CSF, scope),
+      assessFramework(capabilities, BSI_IT_GRUNDSCHUTZ, scope),
+      assessFramework(capabilities, ISO_27001, scope),
+      assessFramework(capabilities, SOC_2, scope),
+      assessFramework(capabilities, DEF_STAN_05_138, scope),
+      assessFramework(capabilities, CYBER_ESSENTIALS, scope),
+      assessFramework(capabilities, NIST_800_171, scope),
+      assessFramework(capabilities, NIST_800_171_R3, scope),
     ],
   };
 }

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -44,7 +44,7 @@ export type ComplianceExportData = Omit<DetailedExportData, "groupNames"> & {
 export const COMPLIANCE_DISCLAIMER =
   "This assessment reports technical evidence found in the Intune tenant configuration. It is not a compliance certification and does not replace an audit. Absence of evidence means no matching Intune policy was detected, not that a requirement is unmet through other means.";
 
-export const COMPLIANCE_RULESET_VERSION = "2026.09.3";
+export const COMPLIANCE_RULESET_VERSION = "2026.09.4";
 
 const controlIdCollator = new Intl.Collator("en", {
   numeric: true,
@@ -369,7 +369,18 @@ function capabilityStatus(
           ),
         ),
       );
-      if (!complete) return "partialConfiguration";
+      if (!complete) {
+        // A compliance requirement is supporting evidence for the capability,
+        // not a partial attempt to configure all firewall profile settings.
+        if (
+          positive.some(
+            (item) =>
+              item.kind === "complianceRequirement" && !item.requirementGroup,
+          )
+        )
+          return "requirementAssigned";
+        return "partialConfiguration";
+      }
     }
     return positive.some((item) => item.kind !== "complianceRequirement")
       ? "enforced"

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -44,7 +44,7 @@ export type ComplianceExportData = Omit<DetailedExportData, "groupNames"> & {
 export const COMPLIANCE_DISCLAIMER =
   "This assessment reports technical evidence found in the Intune tenant configuration. It is not a compliance certification and does not replace an audit. Absence of evidence means no matching Intune policy was detected, not that a requirement is unmet through other means.";
 
-export const COMPLIANCE_RULESET_VERSION = "2026.09.4";
+export const COMPLIANCE_RULESET_VERSION = "2026.09.5";
 
 const controlIdCollator = new Intl.Collator("en", {
   numeric: true,

--- a/src/lib/compliance/engine.ts
+++ b/src/lib/compliance/engine.ts
@@ -1,3 +1,7 @@
+import {
+  essentialEightFramework,
+  essentialEightLevel,
+} from "./frameworks/essential-eight";
 import type { DetailedExportData } from "../configuration-analyzer";
 import type { ConfigurationSettingInstance } from "../intune-detailed-client";
 import { summarizeAssignments } from "./assignments";
@@ -40,7 +44,7 @@ export type ComplianceExportData = Omit<DetailedExportData, "groupNames"> & {
 export const COMPLIANCE_DISCLAIMER =
   "This assessment reports technical evidence found in the Intune tenant configuration. It is not a compliance certification and does not replace an audit. Absence of evidence means no matching Intune policy was detected, not that a requirement is unmet through other means.";
 
-export const COMPLIANCE_RULESET_VERSION = "2026.09.2";
+export const COMPLIANCE_RULESET_VERSION = "2026.09.3";
 
 const controlIdCollator = new Intl.Collator("en", {
   numeric: true,
@@ -570,6 +574,12 @@ export function assessCompliance(
   data: ComplianceExportData,
   scope: AssessmentScope = data.assessmentScope ?? {},
 ): ComplianceAssessment {
+  scope = {
+    ...scope,
+    essentialEightMaturityLevel: essentialEightLevel(
+      scope.essentialEightMaturityLevel,
+    ),
+  };
   const capabilities = assessCapabilities(data, COMPLIANCE_CAPABILITIES, scope);
   return {
     generatedAt: new Date().toISOString(),
@@ -594,6 +604,11 @@ export function assessCompliance(
       assessFramework(capabilities, CYBER_ESSENTIALS, scope),
       assessFramework(capabilities, NIST_800_171, scope),
       assessFramework(capabilities, NIST_800_171_R3, scope),
+      assessFramework(
+        capabilities,
+        essentialEightFramework(scope.essentialEightMaturityLevel),
+        scope,
+      ),
     ],
   };
 }

--- a/src/lib/compliance/essential-eight-capabilities.ts
+++ b/src/lib/compliance/essential-eight-capabilities.ts
@@ -1,0 +1,53 @@
+import type { ComplianceCapability } from "./types";
+
+// Graph endpoint-protection enums verified against Microsoft documentation, 2026-09-06.
+// Audit, warn and userDefined values never count as blocking evidence.
+export const ESSENTIAL_EIGHT_CAPABILITIES: readonly ComplianceCapability[] = [
+  [
+    "windows-office-macro-win32-block",
+    "Office macro Win32 calls blocked",
+    "defenderOfficeMacroCodeAllowWin32ImportsType",
+    "block",
+  ],
+  [
+    "windows-office-child-process-block",
+    "Office child processes blocked",
+    "defenderOfficeAppsLaunchChildProcessType",
+    "block",
+  ],
+  [
+    "windows-office-executable-block",
+    "Office executable content blocked",
+    "defenderOfficeAppsExecutableContentCreationOrLaunchType",
+    "block",
+  ],
+  [
+    "windows-office-injection-block",
+    "Office process injection blocked",
+    "defenderOfficeAppsOtherProcessInjectionType",
+    "block",
+  ],
+  [
+    "windows-adobe-child-process-block",
+    "Adobe Reader child processes blocked",
+    "defenderAdobeReaderLaunchChildProcess",
+    "enable",
+  ],
+].map(([id, name, propertyPath, blockingValue]) => ({
+  id: id!,
+  name: name!,
+  platform: "windows",
+  description:
+    "An explicit endpoint-protection rule blocks this behaviour. ASR exclusions, effective deployment and execution remain unverified.",
+  documentationUrl:
+    "https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10endpointprotectionconfiguration?view=graph-rest-beta",
+  signals: [
+    {
+      source: "graphProperty",
+      odataTypes: ["windows10EndpointProtectionConfiguration"],
+      propertyPath: propertyPath!,
+      enforcedWhen: { kind: "equals", value: blockingValue! },
+      disabledWhen: { kind: "oneOf", values: ["auditMode", "warn", "disable"] },
+    },
+  ],
+}));

--- a/src/lib/compliance/frameworks/bsi-it-grundschutz.ts
+++ b/src/lib/compliance/frameworks/bsi-it-grundschutz.ts
@@ -13,44 +13,63 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
   name: "BSI IT-Grundschutz",
   version: "Kompendium Edition 2023",
   note: "Client Bausteine (SYS.2.2.3, SYS.2.4, SYS.3.2.1, SYS.3.2.2) are mapped at requirement level; other Bausteine at building-block level. Only requirements with technical device-management evidence are listed. Organizational requirements must be assessed separately.",
+  source: {
+    url: "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Grundschutz/IT-GS-Kompendium/IT_Grundschutz_Kompendium_Edition2023.pdf?__blob=publicationFile&v=4",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "CON.1": {
       id: "CON.1",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Kryptokonzept",
       summary:
         "Cryptographic protection of stored data, including full-disk and device encryption.",
     },
     "OPS.1.1.3": {
       id: "OPS.1.1.3",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Patch- und Änderungsmanagement",
       summary:
         "Managed, timely installation of patches and updates across managed systems.",
     },
     "OPS.1.1.4": {
       id: "OPS.1.1.4",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Schutz vor Schadprogrammen",
       summary: "Protection of endpoints against malware with current tooling.",
     },
     "ORP.4": {
       id: "ORP.4",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Identitäts- und Berechtigungsmanagement",
       summary:
         "Management of identities and access, including device unlock credentials.",
     },
     "NET.3.2": {
       id: "NET.3.2",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Firewall",
       summary:
         "Firewall protection controlling network traffic to and from systems.",
     },
     "SYS.2.1": {
       id: "SYS.2.1",
+      evidenceStrength: "supporting",
+      granularity: "buildingBlock",
       title: "Allgemeiner Client",
       summary:
         "General security requirements for all client systems regardless of operating system.",
     },
     "SYS.2.2.3.A4": {
       id: "SYS.2.2.3.A4",
+      evidenceStrength: "direct",
+      granularity: "requirement",
+      platforms: ["windows"],
       title: "Telemetrie und Datenschutzeinstellungen unter Windows",
       tier: "Basis-Anforderung",
       summary:
@@ -58,6 +77,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.2.3.A5": {
       id: "SYS.2.2.3.A5",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["windows"],
       title: "Schutz vor Schadsoftware unter Windows",
       tier: "Basis-Anforderung",
       summary:
@@ -65,6 +87,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.2.3.A6": {
       id: "SYS.2.2.3.A6",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["windows"],
       title: "Integration von Online-Konten in das Betriebssystem",
       tier: "Basis-Anforderung",
       summary:
@@ -72,12 +97,21 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.2.3.A14": {
       id: "SYS.2.2.3.A14",
+      evidenceStrength: "direct",
+      granularity: "requirement",
+      platforms: ["windows"],
       title: "Einsatz des Sprachassistenten Cortana",
       tier: "Standard-Anforderung",
       summary: "Cortana should be disabled on managed Windows clients.",
     },
     "SYS.2.2.3.A23": {
       id: "SYS.2.2.3.A23",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "LSA protected-mode monitoring and applicable RDP restrictions are unassessed.",
+      ],
+      granularity: "requirement",
+      platforms: ["windows"],
       title: "Erweiterter Schutz der Anmeldeinformationen unter Windows",
       tier: "Anforderung bei erhöhtem Schutzbedarf",
       summary:
@@ -85,6 +119,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.4.A2": {
       id: "SYS.2.4.A2",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "XProtect status, installed software and actual activation of macOS protections are unassessed.",
+      ],
+      granularity: "requirement",
+      platforms: ["macos"],
       title: "Nutzung der integrierten Sicherheitsfunktionen von macOS",
       tier: "Basis-Anforderung",
       summary:
@@ -92,6 +132,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.4.A4": {
       id: "SYS.2.4.A4",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "FileVault recovery key custody and storage location are unassessed.",
+      ],
+      granularity: "requirement",
+      platforms: ["macos"],
       title: "Verwendung einer Festplattenverschlüsselung",
       tier: "Standard-Anforderung",
       summary:
@@ -99,6 +145,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.4.A6": {
       id: "SYS.2.4.A6",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Hardware support and installed OS security-update support are not verified. A configured minimum version does not establish currency.",
+      ],
+      granularity: "requirement",
+      platforms: ["macos"],
       title: "Verwendung aktueller Mac-Hardware",
       tier: "Standard-Anforderung",
       summary:
@@ -106,6 +158,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.2.4.A10": {
       id: "SYS.2.4.A10",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["macos"],
       title: "Aktivierung der Personal Firewall unter macOS",
       tier: "Standard-Anforderung",
       summary:
@@ -113,6 +168,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.1.A4": {
       id: "SYS.3.2.1.A4",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Passcode complexity, lock timeout and effective device enforcement require separate review.",
+      ],
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Verwendung eines Zugriffsschutzes",
       tier: "Basis-Anforderung",
       summary:
@@ -120,6 +181,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.1.A5": {
       id: "SYS.3.2.1.A5",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Installed OS and app support, actual patch installation and replacement of unsupported devices are unassessed.",
+      ],
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Updates von Betriebssystem und Apps",
       tier: "Basis-Anforderung",
       summary:
@@ -127,6 +194,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.1.A8": {
       id: "SYS.3.2.1.A8",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Installation von Apps",
       tier: "Basis-Anforderung",
       summary:
@@ -134,6 +204,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.1.A11": {
       id: "SYS.3.2.1.A11",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Verschlüsselung des Speichers",
       tier: "Standard-Anforderung",
       summary:
@@ -141,6 +214,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.2.A2": {
       id: "SYS.3.2.2.A2",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Approved device models and organizational authorization are unassessed.",
+      ],
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Festlegung erlaubter mobiler Endgeräte",
       tier: "Basis-Anforderung",
       summary:
@@ -148,6 +227,9 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.2.A17": {
       id: "SYS.3.2.2.A17",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Kontrolle der Nutzung von mobilen Endgeräten",
       tier: "Anforderung bei erhöhtem Schutzbedarf",
       summary:
@@ -155,6 +237,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
     "SYS.3.2.2.A23": {
       id: "SYS.3.2.2.A23",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Alerts, wipe and lock actions, grace periods and effective Conditional Access coverage require separate review.",
+      ],
+      granularity: "requirement",
+      platforms: ["ios", "android"],
       title: "Durchsetzung von Compliance-Anforderungen",
       tier: "Anforderung bei erhöhtem Schutzbedarf",
       summary:
@@ -162,6 +250,22 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-network-inspection": [],
+    "windows-virtualization-security": [],
+    "windows-credential-theft-protection": [],
+    "tenant-mfa-required": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "windows-antivirus-required": ["OPS.1.1.4", "SYS.2.2.3.A5"],
+    "windows-periodic-antimalware-scan": ["OPS.1.1.4"],
+    "windows-quality-update-deadline": ["OPS.1.1.3"],
+    "windows-application-control": ["SYS.2.1"],
+    "windows-behavior-monitoring": ["OPS.1.1.4"],
+    "windows-memory-integrity": ["SYS.2.1"],
+    "windows-credential-guard": ["SYS.2.2.3.A23"],
+    "tenant-compliant-device-required": ["SYS.3.2.2.A23"],
+
     "windows-disk-encryption": ["CON.1", "SYS.2.1"],
     "macos-disk-encryption": ["CON.1", "SYS.2.4.A4"],
     "android-storage-encryption": ["CON.1", "SYS.3.2.1.A11"],

--- a/src/lib/compliance/frameworks/bsi-it-grundschutz.ts
+++ b/src/lib/compliance/frameworks/bsi-it-grundschutz.ts
@@ -250,6 +250,12 @@ export const BSI_IT_GRUNDSCHUTZ: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-network-inspection": [],
     "windows-virtualization-security": [],
     "windows-credential-theft-protection": [],

--- a/src/lib/compliance/frameworks/cyber-essentials.ts
+++ b/src/lib/compliance/frameworks/cyber-essentials.ts
@@ -9,41 +9,83 @@ import type { FrameworkDefinition } from "../types";
 export const CYBER_ESSENTIALS: FrameworkDefinition = {
   id: "cyber-essentials-v3",
   name: "NCSC Cyber Essentials",
-  version: "Requirements for IT infrastructure v3.2/v3.3",
+  version: "Requirements for IT infrastructure v3.3 (April 2026)",
   note: "Device-management evidence for the five Cyber Essentials control themes. Contains public sector information licensed under the Open Government Licence v3.0. Evidence here does not indicate Cyber Essentials certification.",
+  source: {
+    url: "https://www.ncsc.gov.uk/sites/default/files/documents/cyber-essentials-requirements-for-it-infrastructure-v3-3.pdf",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     Firewalls: {
       id: "Firewalls",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Network boundaries, allowed traffic, default-deny rules and effective device coverage require review.",
+      ],
+      granularity: "theme",
       title: "Firewalls",
       summary:
         "Every in-scope device is protected by a firewall that blocks unauthenticated inbound connections by default.",
     },
     "Secure configuration": {
       id: "Secure configuration",
+      evidenceStrength: "supporting",
+      granularity: "theme",
       title: "Secure configuration",
       summary:
         "Devices are configured to reduce unnecessary functionality, keep platform integrity and require a credential to unlock.",
     },
     "Security update management": {
       id: "Security update management",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Actual release-to-install timing, supported software and application updates are unassessed. A configured version floor does not prove support.",
+      ],
+      granularity: "theme",
       title: "Security update management",
       summary:
         "Software is supported and updated automatically, with minimum operating system versions enforced.",
     },
     "User access control": {
       id: "User access control",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "MFA coverage for all in-scope cloud services, exclusions, account approvals, privileges and account removal require review.",
+      ],
+      granularity: "theme",
       title: "User access control",
       summary:
         "Users authenticate with a credential before gaining access to devices and the data on them.",
     },
     "Malware protection": {
       id: "Malware protection",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Protection effectiveness, signature currency, scan exclusions and approved application lists require review.",
+      ],
+      granularity: "theme",
       title: "Malware protection",
       summary:
         "Anti-malware protection is active on in-scope devices, or application installation is restricted to trusted sources.",
     },
   },
   mappings: {
+    "windows-behavior-monitoring": [],
+    "windows-network-inspection": [],
+    "windows-memory-integrity": [],
+    "windows-virtualization-security": [],
+    "windows-credential-guard": [],
+    "windows-credential-theft-protection": [],
+    "tenant-compliant-device-required": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "windows-antivirus-required": ["Malware protection"],
+    "windows-periodic-antimalware-scan": ["Malware protection"],
+    "windows-quality-update-deadline": ["Security update management"],
+    "windows-application-control": ["Malware protection"],
+    "tenant-mfa-required": ["User access control"],
+
     // Cyber Essentials does not require encryption of data at rest.
     "windows-disk-encryption": [],
     "macos-disk-encryption": [],

--- a/src/lib/compliance/frameworks/cyber-essentials.ts
+++ b/src/lib/compliance/frameworks/cyber-essentials.ts
@@ -1,0 +1,80 @@
+import type { FrameworkDefinition } from "../types";
+
+// The NCSC "Cyber Essentials: Requirements for IT infrastructure" document is
+// Crown copyright, published under the Open Government Licence v3.0. It has no
+// control identifiers, so the five control themes are used as identifiers.
+// Summaries are original descriptions written for this device-management
+// evidence mapping. The Cyber Essentials logo is not part of the licence and
+// evidence here never indicates certification.
+export const CYBER_ESSENTIALS: FrameworkDefinition = {
+  id: "cyber-essentials-v3",
+  name: "NCSC Cyber Essentials",
+  version: "Requirements for IT infrastructure v3.2/v3.3",
+  note: "Device-management evidence for the five Cyber Essentials control themes. Contains public sector information licensed under the Open Government Licence v3.0. Evidence here does not indicate Cyber Essentials certification.",
+  controls: {
+    Firewalls: {
+      id: "Firewalls",
+      title: "Firewalls",
+      summary:
+        "Every in-scope device is protected by a firewall that blocks unauthenticated inbound connections by default.",
+    },
+    "Secure configuration": {
+      id: "Secure configuration",
+      title: "Secure configuration",
+      summary:
+        "Devices are configured to reduce unnecessary functionality, keep platform integrity and require a credential to unlock.",
+    },
+    "Security update management": {
+      id: "Security update management",
+      title: "Security update management",
+      summary:
+        "Software is supported and updated automatically, with minimum operating system versions enforced.",
+    },
+    "User access control": {
+      id: "User access control",
+      title: "User access control",
+      summary:
+        "Users authenticate with a credential before gaining access to devices and the data on them.",
+    },
+    "Malware protection": {
+      id: "Malware protection",
+      title: "Malware protection",
+      summary:
+        "Anti-malware protection is active on in-scope devices, or application installation is restricted to trusted sources.",
+    },
+  },
+  mappings: {
+    // Cyber Essentials does not require encryption of data at rest.
+    "windows-disk-encryption": [],
+    "macos-disk-encryption": [],
+    "android-storage-encryption": [],
+    "windows-realtime-antimalware": ["Malware protection"],
+    "windows-firewall": ["Firewalls"],
+    "macos-firewall": ["Firewalls"],
+    "windows-password-required": [
+      "Secure configuration",
+      "User access control",
+    ],
+    "macos-password-required": ["Secure configuration", "User access control"],
+    "ios-passcode-required": ["Secure configuration", "User access control"],
+    "android-password-required": [
+      "Secure configuration",
+      "User access control",
+    ],
+    "windows-automatic-updates": ["Security update management"],
+    "windows-minimum-os-version": ["Security update management"],
+    "macos-minimum-os-version": ["Security update management"],
+    "ios-minimum-os-version": ["Security update management"],
+    "android-minimum-os-version": ["Security update management"],
+    "windows-secure-boot": ["Secure configuration"],
+    "windows-code-integrity": ["Secure configuration"],
+    "macos-system-integrity": ["Secure configuration"],
+    "windows-telemetry-minimized": ["Secure configuration"],
+    "windows-cortana-disabled": ["Secure configuration"],
+    "windows-microsoft-account-blocked": ["Secure configuration"],
+    "ios-jailbreak-block": ["Secure configuration"],
+    "android-device-integrity": ["Secure configuration"],
+    "macos-gatekeeper": ["Malware protection"],
+    "android-app-source-restriction": ["Malware protection"],
+  },
+};

--- a/src/lib/compliance/frameworks/cyber-essentials.ts
+++ b/src/lib/compliance/frameworks/cyber-essentials.ts
@@ -70,6 +70,12 @@ export const CYBER_ESSENTIALS: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-behavior-monitoring": [],
     "windows-network-inspection": [],
     "windows-memory-integrity": [],

--- a/src/lib/compliance/frameworks/def-stan-05-138.ts
+++ b/src/lib/compliance/frameworks/def-stan-05-138.ts
@@ -7,6 +7,10 @@ import type { FrameworkDefinition } from "../types";
 // Cyber Risk Profile levels (Level 0 to Level 3) at which the control applies.
 // Only controls with technical Intune evidence are listed; governance,
 // personnel, physical and incident-response controls are intentionally absent.
+// Also omitted until dedicated detectors exist: credential quality (2213),
+// executable allow lists (2409), and default-deny traffic rules (2429, 2507).
+// Password presence, app-source restrictions and firewall activation do not
+// demonstrate those controls.
 
 /** Control family labels keyed by the first two digits of the control id. */
 export const DEF_STAN_FAMILIES: Readonly<Record<string, string>> = {
@@ -30,13 +34,6 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
       summary:
         "Devices that access the network are known and trusted through integrity checks on managed platforms.",
       tier: "Level 2 to Level 3",
-    },
-    "2213": {
-      id: "2213",
-      title: "Credential quality controls",
-      summary:
-        "Technical controls require a credential before a managed device can be used.",
-      tier: "Level 1 to Level 3",
     },
     "2309": {
       id: "2309",
@@ -72,13 +69,6 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
         "Operating system updates are applied automatically and minimum supported versions are enforced.",
       tier: "Level 1 to Level 3",
     },
-    "2409": {
-      id: "2409",
-      title: "Authorised software",
-      summary:
-        "Software installation is restricted to trusted sources on managed platforms.",
-      tier: "Level 1 to Level 3",
-    },
     "2418": {
       id: "2418",
       title: "Managed hardening baselines",
@@ -93,32 +83,18 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
         "Real-time anti-malware protection is enforced on managed endpoints.",
       tier: "Level 1 to Level 3",
     },
-    "2429": {
-      id: "2429",
-      title: "Inbound connections blocked by default",
-      summary:
-        "Host firewalls block unauthorised inbound connections on managed devices.",
-      tier: "Level 1 to Level 3",
-    },
-    "2507": {
-      id: "2507",
-      title: "Default-deny host firewall rules",
-      summary:
-        "Host firewalls deny network traffic that is not explicitly allowed.",
-      tier: "Level 1 to Level 3",
-    },
   },
   mappings: {
     "windows-disk-encryption": ["2317"],
     "macos-disk-encryption": ["2317"],
     "android-storage-encryption": ["2317", "2309"],
     "windows-realtime-antimalware": ["2426"],
-    "windows-firewall": ["2429", "2507"],
-    "macos-firewall": ["2429", "2507"],
-    "windows-password-required": ["2213"],
-    "macos-password-required": ["2213"],
-    "ios-passcode-required": ["2213", "2309", "2322"],
-    "android-password-required": ["2213", "2322"],
+    "windows-firewall": [],
+    "macos-firewall": [],
+    "windows-password-required": [],
+    "macos-password-required": [],
+    "ios-passcode-required": ["2309", "2322"],
+    "android-password-required": ["2322"],
     "windows-automatic-updates": ["2405"],
     "windows-minimum-os-version": ["2405"],
     "macos-minimum-os-version": ["2405"],
@@ -132,7 +108,7 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     "windows-microsoft-account-blocked": ["2418"],
     "ios-jailbreak-block": ["2202", "2322"],
     "android-device-integrity": ["2202", "2322"],
-    "macos-gatekeeper": ["2409"],
-    "android-app-source-restriction": ["2409", "2322"],
+    "macos-gatekeeper": [],
+    "android-app-source-restriction": ["2322"],
   },
 };

--- a/src/lib/compliance/frameworks/def-stan-05-138.ts
+++ b/src/lib/compliance/frameworks/def-stan-05-138.ts
@@ -10,12 +10,12 @@ import type { FrameworkDefinition } from "../types";
 
 /** Control family labels keyed by the first two digits of the control id. */
 export const DEF_STAN_FAMILIES: Readonly<Record<string, string>> = {
-  "22": "Identity and access control (22xx)",
-  "23": "Data security (23xx)",
-  "24": "System security (24xx)",
-  "25": "Resilient networks and systems (25xx)",
-  "31": "Security monitoring (31xx)",
-  "32": "Proactive security event discovery (32xx)",
+  "22": "Accounts, identities and access (22xx)",
+  "23": "Protecting stored and transmitted data (23xx)",
+  "24": "Hardening and system protection (24xx)",
+  "25": "Network and service resilience (25xx)",
+  "31": "Monitoring for security events (31xx)",
+  "32": "Finding threats proactively (32xx)",
 };
 
 export const DEF_STAN_05_138: FrameworkDefinition = {
@@ -26,7 +26,7 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
   controls: {
     "2202": {
       id: "2202",
-      title: "Device management",
+      title: "Trusted managed devices",
       summary:
         "Devices that access the network are known and trusted through integrity checks on managed platforms.",
       tier: "Level 2 to Level 3",
@@ -47,7 +47,7 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     },
     "2317": {
       id: "2317",
-      title: "Endpoint encryption",
+      title: "Full disk encryption on endpoints",
       summary: "Full disk encryption is enforced on managed endpoints.",
       tier: "Level 1 to Level 3",
     },
@@ -60,14 +60,14 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     },
     "2401": {
       id: "2401",
-      title: "Secure configuration",
+      title: "Platform integrity protections",
       summary:
         "Platform integrity protections such as Secure Boot, code integrity and System Integrity Protection are enforced.",
       tier: "Level 1 to Level 3",
     },
     "2405": {
       id: "2405",
-      title: "Patch management",
+      title: "Operating system update enforcement",
       summary:
         "Operating system updates are applied automatically and minimum supported versions are enforced.",
       tier: "Level 1 to Level 3",
@@ -81,14 +81,14 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     },
     "2418": {
       id: "2418",
-      title: "Baseline configuration and hardening",
+      title: "Managed hardening baselines",
       summary:
         "Hardening settings that reduce unnecessary functionality are applied through managed baselines.",
       tier: "Level 1 to Level 3",
     },
     "2426": {
       id: "2426",
-      title: "Anti-malware capabilities",
+      title: "Real-time anti-malware protection",
       summary:
         "Real-time anti-malware protection is enforced on managed endpoints.",
       tier: "Level 1 to Level 3",
@@ -102,7 +102,7 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     },
     "2507": {
       id: "2507",
-      title: "Deny traffic by default",
+      title: "Default-deny host firewall rules",
       summary:
         "Host firewalls deny network traffic that is not explicitly allowed.",
       tier: "Level 1 to Level 3",

--- a/src/lib/compliance/frameworks/def-stan-05-138.ts
+++ b/src/lib/compliance/frameworks/def-stan-05-138.ts
@@ -1,0 +1,138 @@
+import type { FrameworkDefinition } from "../types";
+
+// Def Stan 05-138 Issue 4 (14 May 2024) is Crown copyright and marked
+// "Copying Only as Agreed with DStan". Controls are referenced by their
+// four-digit identifier only; titles and summaries are original descriptions
+// written for this device-management evidence mapping. The tier records the
+// Cyber Risk Profile levels (Level 0 to Level 3) at which the control applies.
+// Only controls with technical Intune evidence are listed; governance,
+// personnel, physical and incident-response controls are intentionally absent.
+
+/** Control family labels keyed by the first two digits of the control id. */
+export const DEF_STAN_FAMILIES: Readonly<Record<string, string>> = {
+  "22": "Identity and access control (22xx)",
+  "23": "Data security (23xx)",
+  "24": "System security (24xx)",
+  "25": "Resilient networks and systems (25xx)",
+  "31": "Security monitoring (31xx)",
+  "32": "Proactive security event discovery (32xx)",
+};
+
+export const DEF_STAN_05_138: FrameworkDefinition = {
+  id: "def-stan-05-138-i4",
+  name: "UK MOD Def Stan 05-138",
+  version: "Issue 4",
+  note: "Device-management evidence for selected Objective B controls of Def Stan 05-138 Issue 4, referenced by control identifier with original summaries and the Cyber Risk Profile levels at which each applies. Cyber Essentials certification (control 0001) is required at every level and cannot be evidenced from device configuration.",
+  controls: {
+    "2202": {
+      id: "2202",
+      title: "Device management",
+      summary:
+        "Devices that access the network are known and trusted through integrity checks on managed platforms.",
+      tier: "Level 2 to Level 3",
+    },
+    "2213": {
+      id: "2213",
+      title: "Credential quality controls",
+      summary:
+        "Technical controls require a credential before a managed device can be used.",
+      tier: "Level 1 to Level 3",
+    },
+    "2309": {
+      id: "2309",
+      title: "Data on mobile devices",
+      summary:
+        "Information held on mobile devices is protected through enforced storage encryption and device unlock credentials.",
+      tier: "Level 2 to Level 3",
+    },
+    "2317": {
+      id: "2317",
+      title: "Endpoint encryption",
+      summary: "Full disk encryption is enforced on managed endpoints.",
+      tier: "Level 1 to Level 3",
+    },
+    "2322": {
+      id: "2322",
+      title: "Mobile device management",
+      summary:
+        "Mobile devices that access organisational data are configured and controlled through the management platform.",
+      tier: "Level 1 to Level 3",
+    },
+    "2401": {
+      id: "2401",
+      title: "Secure configuration",
+      summary:
+        "Platform integrity protections such as Secure Boot, code integrity and System Integrity Protection are enforced.",
+      tier: "Level 1 to Level 3",
+    },
+    "2405": {
+      id: "2405",
+      title: "Patch management",
+      summary:
+        "Operating system updates are applied automatically and minimum supported versions are enforced.",
+      tier: "Level 1 to Level 3",
+    },
+    "2409": {
+      id: "2409",
+      title: "Authorised software",
+      summary:
+        "Software installation is restricted to trusted sources on managed platforms.",
+      tier: "Level 1 to Level 3",
+    },
+    "2418": {
+      id: "2418",
+      title: "Baseline configuration and hardening",
+      summary:
+        "Hardening settings that reduce unnecessary functionality are applied through managed baselines.",
+      tier: "Level 1 to Level 3",
+    },
+    "2426": {
+      id: "2426",
+      title: "Anti-malware capabilities",
+      summary:
+        "Real-time anti-malware protection is enforced on managed endpoints.",
+      tier: "Level 1 to Level 3",
+    },
+    "2429": {
+      id: "2429",
+      title: "Inbound connections blocked by default",
+      summary:
+        "Host firewalls block unauthorised inbound connections on managed devices.",
+      tier: "Level 1 to Level 3",
+    },
+    "2507": {
+      id: "2507",
+      title: "Deny traffic by default",
+      summary:
+        "Host firewalls deny network traffic that is not explicitly allowed.",
+      tier: "Level 1 to Level 3",
+    },
+  },
+  mappings: {
+    "windows-disk-encryption": ["2317"],
+    "macos-disk-encryption": ["2317"],
+    "android-storage-encryption": ["2317", "2309"],
+    "windows-realtime-antimalware": ["2426"],
+    "windows-firewall": ["2429", "2507"],
+    "macos-firewall": ["2429", "2507"],
+    "windows-password-required": ["2213"],
+    "macos-password-required": ["2213"],
+    "ios-passcode-required": ["2213", "2309", "2322"],
+    "android-password-required": ["2213", "2322"],
+    "windows-automatic-updates": ["2405"],
+    "windows-minimum-os-version": ["2405"],
+    "macos-minimum-os-version": ["2405"],
+    "ios-minimum-os-version": ["2405", "2322"],
+    "android-minimum-os-version": ["2405", "2322"],
+    "windows-secure-boot": ["2202", "2401"],
+    "windows-code-integrity": ["2202", "2401"],
+    "macos-system-integrity": ["2202", "2401"],
+    "windows-telemetry-minimized": ["2418"],
+    "windows-cortana-disabled": ["2418"],
+    "windows-microsoft-account-blocked": ["2418"],
+    "ios-jailbreak-block": ["2202", "2322"],
+    "android-device-integrity": ["2202", "2322"],
+    "macos-gatekeeper": ["2409"],
+    "android-app-source-restriction": ["2409", "2322"],
+  },
+};

--- a/src/lib/compliance/frameworks/def-stan-05-138.ts
+++ b/src/lib/compliance/frameworks/def-stan-05-138.ts
@@ -27,64 +27,108 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
   name: "UK MOD Def Stan 05-138",
   version: "Issue 4",
   note: "Device-management evidence for selected Objective B controls of Def Stan 05-138 Issue 4, referenced by control identifier with original summaries and the Cyber Risk Profile levels at which each applies. Cyber Essentials certification (control 0001) is required at every level and cannot be evidenced from device configuration.",
+  source: {
+    url: "https://www.gov.uk/government/publications/cyber-security-for-defence-suppliers-def-stan-05-138-issue-4",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "2202": {
       id: "2202",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Trusted managed devices",
       summary:
         "Devices that access the network are known and trusted through integrity checks on managed platforms.",
       tier: "Level 2 to Level 3",
+      riskLevels: [2, 3],
     },
     "2309": {
       id: "2309",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Data on mobile devices",
       summary:
         "Information held on mobile devices is protected through enforced storage encryption and device unlock credentials.",
       tier: "Level 2 to Level 3",
+      riskLevels: [2, 3],
     },
     "2317": {
       id: "2317",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Full disk encryption on endpoints",
       summary: "Full disk encryption is enforced on managed endpoints.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
     "2322": {
       id: "2322",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Mobile device management",
       summary:
         "Mobile devices that access organisational data are configured and controlled through the management platform.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
     "2401": {
       id: "2401",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Platform integrity protections",
       summary:
         "Platform integrity protections such as Secure Boot, code integrity and System Integrity Protection are enforced.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
     "2405": {
       id: "2405",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Operating system update enforcement",
       summary:
         "Operating system updates are applied automatically and minimum supported versions are enforced.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
     "2418": {
       id: "2418",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Managed hardening baselines",
       summary:
         "Hardening settings that reduce unnecessary functionality are applied through managed baselines.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
     "2426": {
       id: "2426",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Real-time anti-malware protection",
       summary:
         "Real-time anti-malware protection is enforced on managed endpoints.",
       tier: "Level 1 to Level 3",
+      riskLevels: [1, 2, 3],
     },
   },
   mappings: {
+    "windows-antivirus-required": [],
+    "windows-periodic-antimalware-scan": [],
+    "windows-quality-update-deadline": [],
+    "windows-application-control": [],
+    "windows-behavior-monitoring": [],
+    "windows-network-inspection": [],
+    "windows-virtualization-security": [],
+    "windows-credential-guard": [],
+    "windows-credential-theft-protection": [],
+    "tenant-mfa-required": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "tenant-compliant-device-required": ["2202"],
+    "windows-memory-integrity": ["2202"],
+
     "windows-disk-encryption": ["2317"],
     "macos-disk-encryption": ["2317"],
     "android-storage-encryption": ["2317", "2309"],

--- a/src/lib/compliance/frameworks/def-stan-05-138.ts
+++ b/src/lib/compliance/frameworks/def-stan-05-138.ts
@@ -113,6 +113,12 @@ export const DEF_STAN_05_138: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-antivirus-required": [],
     "windows-periodic-antimalware-scan": [],
     "windows-quality-update-deadline": [],

--- a/src/lib/compliance/frameworks/essential-eight-requirements.json
+++ b/src/lib/compliance/frameworks/essential-eight-requirements.json
@@ -1,0 +1,1833 @@
+{
+  "source": "https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-maturity-model",
+  "version": "November 2023",
+  "verifiedAt": "2026-09-06",
+  "attribution": "Australian Signals Directorate, © Commonwealth of Australia 2026. CC BY 4.0. Requirement text reproduced from Appendices A–C; local identifiers added by IntuneDocumentation and are not official ISM identifiers.",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "requirements": [
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in online services."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-04",
+      "requirement": "A vulnerability scanner is used at least weekly to identify missing patches or updates for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-05",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-06",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within two weeks of release."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-08",
+      "requirement": "Online services that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch applications",
+      "id": "ML1-PA-09",
+      "requirement": "Office productivity suites, web browsers and their extensions, email clients, PDF software, Adobe Flash Player, and security products that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-04",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-05",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-06",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within one month of release."
+    },
+    {
+      "level": 1,
+      "strategy": "Patch operating systems",
+      "id": "ML1-PO-08",
+      "requirement": "Operating systems that are no longer supported by vendors are replaced."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-01",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-02",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-03",
+      "requirement": "Multi-factor authentication (where available) is used to authenticate users to third-party online services that process, store or communicate their organisation’s non-sensitive data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-04",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-05",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-06",
+      "requirement": "Multi-factor authentication is used to authenticate customers to online customer services that process, store or communicate sensitive customer data."
+    },
+    {
+      "level": 1,
+      "strategy": "Multi-factor authentication",
+      "id": "ML1-MFA-07",
+      "requirement": "Multi-factor authentication uses either: something users have and something users know, or something users have that is unlocked by something users know or are."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-01",
+      "requirement": "Requests for privileged access to systems, applications and data repositories are validated when first requested."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-02",
+      "requirement": "Privileged users are assigned a dedicated privileged user account to be used solely for duties requiring privileged access."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-03",
+      "requirement": "Privileged user accounts (excluding those explicitly authorised to access online services) are prevented from accessing the internet, email and web services."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-04",
+      "requirement": "Privileged user accounts explicitly authorised to access online services are strictly limited to only what is required for users and services to undertake their duties."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-05",
+      "requirement": "Privileged users use separate privileged and unprivileged operating environments."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-06",
+      "requirement": "Unprivileged user accounts cannot logon to privileged operating environments."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML1-RAP-07",
+      "requirement": "Privileged user accounts (excluding local administrator accounts) cannot logon to unprivileged operating environments."
+    },
+    {
+      "level": 1,
+      "strategy": "Application control",
+      "id": "ML1-AC-01",
+      "requirement": "Application control is implemented on workstations."
+    },
+    {
+      "level": 1,
+      "strategy": "Application control",
+      "id": "ML1-AC-02",
+      "requirement": "Application control is applied to user profiles and temporary folders used by operating systems, web browsers and email clients."
+    },
+    {
+      "level": 1,
+      "strategy": "Application control",
+      "id": "ML1-AC-03",
+      "requirement": "Application control restricts the execution of executables, software libraries, scripts, installers, compiled HTML, HTML applications and control panel applets to an organisation-approved set."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML1-MAC-01",
+      "requirement": "Microsoft Office macros are disabled for users that do not have a demonstrated business requirement."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML1-MAC-02",
+      "requirement": "Microsoft Office macros in files originating from the internet are blocked."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML1-MAC-03",
+      "requirement": "Microsoft Office macro antivirus scanning is enabled."
+    },
+    {
+      "level": 1,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML1-MAC-04",
+      "requirement": "Microsoft Office macro security settings cannot be changed by users."
+    },
+    {
+      "level": 1,
+      "strategy": "User application hardening",
+      "id": "ML1-UAH-01",
+      "requirement": "Internet Explorer 11 is disabled or removed."
+    },
+    {
+      "level": 1,
+      "strategy": "User application hardening",
+      "id": "ML1-UAH-02",
+      "requirement": "Web browsers do not process Java from the internet."
+    },
+    {
+      "level": 1,
+      "strategy": "User application hardening",
+      "id": "ML1-UAH-03",
+      "requirement": "Web browsers do not process web advertisements from the internet."
+    },
+    {
+      "level": 1,
+      "strategy": "User application hardening",
+      "id": "ML1-UAH-04",
+      "requirement": "Web browser security settings cannot be changed by users."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-01",
+      "requirement": "Backups of data, applications and settings are performed and retained in accordance with business criticality and business continuity requirements."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-02",
+      "requirement": "Backups of data, applications and settings are synchronised to enable restoration to a common point in time."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-03",
+      "requirement": "Backups of data, applications and settings are retained in a secure and resilient manner."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-04",
+      "requirement": "Restoration of data, applications and settings from backups to a common point in time is tested as part of disaster recovery exercises."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-05",
+      "requirement": "Unprivileged user accounts cannot access backups belonging to other user accounts."
+    },
+    {
+      "level": 1,
+      "strategy": "Regular backups",
+      "id": "ML1-BK-06",
+      "requirement": "Unprivileged user accounts are prevented from modifying and deleting backups."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in online services."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-04",
+      "requirement": "A vulnerability scanner is used at least weekly to identify missing patches or updates for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-05",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in applications other than office productivity suites, web browsers and their extensions, email clients, PDF software, and security products."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-06",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-08",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within two weeks of release."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-09",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in applications other than office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within one month of release."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-10",
+      "requirement": "Online services that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch applications",
+      "id": "ML2-PA-11",
+      "requirement": "Office productivity suites, web browsers and their extensions, email clients, PDF software, Adobe Flash Player, and security products that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-04",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-05",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-06",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within one month of release."
+    },
+    {
+      "level": 2,
+      "strategy": "Patch operating systems",
+      "id": "ML2-PO-08",
+      "requirement": "Operating systems that are no longer supported by vendors are replaced."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-01",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-02",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-03",
+      "requirement": "Multi-factor authentication (where available) is used to authenticate users to third-party online services that process, store or communicate their organisation’s non-sensitive data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-04",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-05",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-06",
+      "requirement": "Multi-factor authentication is used to authenticate customers to online customer services that process, store or communicate sensitive customer data."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-07",
+      "requirement": "Multi-factor authentication is used to authenticate privileged users of systems."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-08",
+      "requirement": "Multi-factor authentication is used to authenticate unprivileged users of systems."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-09",
+      "requirement": "Multi-factor authentication uses either: something users have and something users know, or something users have that is unlocked by something users know or are."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-10",
+      "requirement": "Multi-factor authentication used for authenticating users of online services is phishing-resistant."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-11",
+      "requirement": "Multi-factor authentication used for authenticating customers of online customer services provides a phishing-resistant option."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-12",
+      "requirement": "Multi-factor authentication used for authenticating users of systems is phishing-resistant."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-13",
+      "requirement": "Successful and unsuccessful multi-factor authentication events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-14",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-15",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-16",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-17",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-18",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Multi-factor authentication",
+      "id": "ML2-MFA-19",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-01",
+      "requirement": "Requests for privileged access to systems, applications and data repositories are validated when first requested."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-02",
+      "requirement": "Privileged access to systems, applications and data repositories is disabled after 12 months unless revalidated."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-03",
+      "requirement": "Privileged access to systems and applications is disabled after 45 days of inactivity."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-04",
+      "requirement": "Privileged users are assigned a dedicated privileged user account to be used solely for duties requiring privileged access."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-05",
+      "requirement": "Privileged user accounts (excluding those explicitly authorised to access online services) are prevented from accessing the internet, email and web services."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-06",
+      "requirement": "Privileged user accounts explicitly authorised to access online services are strictly limited to only what is required for users and services to undertake their duties."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-07",
+      "requirement": "Privileged users use separate privileged and unprivileged operating environments."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-08",
+      "requirement": "Privileged operating environments are not virtualised within unprivileged operating environments."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-09",
+      "requirement": "Unprivileged user accounts cannot logon to privileged operating environments."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-10",
+      "requirement": "Privileged user accounts (excluding local administrator accounts) cannot logon to unprivileged operating environments."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-11",
+      "requirement": "Administrative activities are conducted through jump servers."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-12",
+      "requirement": "Credentials for break glass accounts, local administrator accounts and service accounts are long, unique, unpredictable and managed."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-13",
+      "requirement": "Privileged access events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-14",
+      "requirement": "Privileged user account and security group management events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-15",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-16",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-17",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-18",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-19",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML2-RAP-20",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-01",
+      "requirement": "Application control is implemented on workstations."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-02",
+      "requirement": "Application control is implemented on internet-facing servers."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-03",
+      "requirement": "Application control is applied to user profiles and temporary folders used by operating systems, web browsers and email clients."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-04",
+      "requirement": "Application control is applied to all locations other than user profiles and temporary folders used by operating systems, web browsers and email clients."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-05",
+      "requirement": "Application control restricts the execution of executables, software libraries, scripts, installers, compiled HTML, HTML applications and control panel applets to an organisation-approved set."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-06",
+      "requirement": "Microsoft’s recommended application blocklist is implemented."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-07",
+      "requirement": "Application control rulesets are validated on an annual or more frequent basis."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-08",
+      "requirement": "Allowed and blocked application control events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-09",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-10",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-11",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-12",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-13",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "Application control",
+      "id": "ML2-AC-14",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML2-MAC-01",
+      "requirement": "Microsoft Office macros are disabled for users that do not have a demonstrated business requirement."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML2-MAC-02",
+      "requirement": "Microsoft Office macros in files originating from the internet are blocked."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML2-MAC-03",
+      "requirement": "Microsoft Office macro antivirus scanning is enabled."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML2-MAC-04",
+      "requirement": "Microsoft Office macros are blocked from making Win32 API calls."
+    },
+    {
+      "level": 2,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML2-MAC-05",
+      "requirement": "Microsoft Office macro security settings cannot be changed by users."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-01",
+      "requirement": "Internet Explorer 11 is disabled or removed."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-02",
+      "requirement": "Web browsers do not process Java from the internet."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-03",
+      "requirement": "Web browsers do not process web advertisements from the internet."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-04",
+      "requirement": "Web browsers are hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-05",
+      "requirement": "Web browser security settings cannot be changed by users."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-06",
+      "requirement": "Microsoft Office is blocked from creating child processes."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-07",
+      "requirement": "Microsoft Office is blocked from creating executable content."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-08",
+      "requirement": "Microsoft Office is blocked from injecting code into other processes."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-09",
+      "requirement": "Microsoft Office is configured to prevent activation of Object Linking and Embedding packages."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-10",
+      "requirement": "Office productivity suites are hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-11",
+      "requirement": "Office productivity suite security settings cannot be changed by users."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-12",
+      "requirement": "PDF software is blocked from creating child processes."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-13",
+      "requirement": "PDF software is hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-14",
+      "requirement": "PDF software security settings cannot be changed by users."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-15",
+      "requirement": "PowerShell module logging, script block logging and transcription events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-16",
+      "requirement": "Command line process creation events are centrally logged."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-17",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-18",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-19",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-20",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-21",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 2,
+      "strategy": "User application hardening",
+      "id": "ML2-UAH-22",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-01",
+      "requirement": "Backups of data, applications and settings are performed and retained in accordance with business criticality and business continuity requirements."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-02",
+      "requirement": "Backups of data, applications and settings are synchronised to enable restoration to a common point in time."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-03",
+      "requirement": "Backups of data, applications and settings are retained in a secure and resilient manner."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-04",
+      "requirement": "Restoration of data, applications and settings from backups to a common point in time is tested as part of disaster recovery exercises."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-05",
+      "requirement": "Unprivileged user accounts cannot access backups belonging to other user accounts."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-06",
+      "requirement": "Privileged user accounts (excluding backup administrator accounts) cannot access backups belonging to other user accounts."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-07",
+      "requirement": "Unprivileged user accounts are prevented from modifying and deleting backups."
+    },
+    {
+      "level": 2,
+      "strategy": "Regular backups",
+      "id": "ML2-BK-08",
+      "requirement": "Privileged user accounts (excluding backup administrator accounts) are prevented from modifying and deleting backups."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in online services."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-04",
+      "requirement": "A vulnerability scanner is used at least weekly to identify missing patches or updates for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-05",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in applications other than office productivity suites, web browsers and their extensions, email clients, PDF software, and security products."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-06",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in online services are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-08",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-09",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-10",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in applications other than office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are applied within one month of release."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-11",
+      "requirement": "Online services that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-12",
+      "requirement": "Office productivity suites, web browsers and their extensions, email clients, PDF software, Adobe Flash Player, and security products that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch applications",
+      "id": "ML3-PA-13",
+      "requirement": "Applications other than office productivity suites, web browsers and their extensions, email clients, PDF software, Adobe Flash Player, and security products that are no longer supported by vendors are removed."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-01",
+      "requirement": "An automated method of asset discovery is used at least fortnightly to support the detection of assets for subsequent vulnerability scanning activities."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-02",
+      "requirement": "A vulnerability scanner with an up-to-date vulnerability database is used for vulnerability scanning activities."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-03",
+      "requirement": "A vulnerability scanner is used at least daily to identify missing patches or updates for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-04",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-05",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in drivers."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-06",
+      "requirement": "A vulnerability scanner is used at least fortnightly to identify missing patches or updates for vulnerabilities in firmware."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-07",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-08",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of internet-facing servers and internet-facing network devices are applied within two weeks of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-09",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-10",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within one month of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-11",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in drivers are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-12",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in drivers are applied within one month of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-13",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in firmware are applied within 48 hours of release when vulnerabilities are assessed as critical by vendors or when working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-14",
+      "requirement": "Patches, updates or other vendor mitigations for vulnerabilities in firmware are applied within one month of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-15",
+      "requirement": "The latest release, or the previous release, of operating systems are used."
+    },
+    {
+      "level": 3,
+      "strategy": "Patch operating systems",
+      "id": "ML3-PO-16",
+      "requirement": "Operating systems that are no longer supported by vendors are replaced."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-01",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-02",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online services that process, store or communicate their organisation’s sensitive data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-03",
+      "requirement": "Multi-factor authentication (where available) is used to authenticate users to third-party online services that process, store or communicate their organisation’s non-sensitive data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-04",
+      "requirement": "Multi-factor authentication is used to authenticate users to their organisation’s online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-05",
+      "requirement": "Multi-factor authentication is used to authenticate users to third-party online customer services that process, store or communicate their organisation’s sensitive customer data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-06",
+      "requirement": "Multi-factor authentication is used to authenticate customers to online customer services that process, store or communicate sensitive customer data."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-07",
+      "requirement": "Multi-factor authentication is used to authenticate privileged users of systems."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-08",
+      "requirement": "Multi-factor authentication is used to authenticate unprivileged users of systems."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-09",
+      "requirement": "Multi-factor authentication is used to authenticate users of data repositories."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-10",
+      "requirement": "Multi-factor authentication uses either: something users have and something users know, or something users have that is unlocked by something users know or are."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-11",
+      "requirement": "Multi-factor authentication used for authenticating users of online services is phishing-resistant."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-12",
+      "requirement": "Multi-factor authentication used for authenticating customers of online customer services is phishing-resistant."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-13",
+      "requirement": "Multi-factor authentication used for authenticating users of systems is phishing-resistant."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-14",
+      "requirement": "Multi-factor authentication used for authenticating users of data repositories is phishing-resistant."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-15",
+      "requirement": "Successful and unsuccessful multi-factor authentication events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-16",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-17",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-18",
+      "requirement": "Event logs from non-internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-19",
+      "requirement": "Event logs from workstations are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-20",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-21",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-22",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Multi-factor authentication",
+      "id": "ML3-MFA-23",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-01",
+      "requirement": "Requests for privileged access to systems, applications and data repositories are validated when first requested."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-02",
+      "requirement": "Privileged access to systems, applications and data repositories is disabled after 12 months unless revalidated."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-03",
+      "requirement": "Privileged access to systems and applications is disabled after 45 days of inactivity."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-04",
+      "requirement": "Privileged users are assigned a dedicated privileged user account to be used solely for duties requiring privileged access."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-05",
+      "requirement": "Privileged access to systems, applications and data repositories is limited to only what is required for users and services to undertake their duties."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-06",
+      "requirement": "Privileged user accounts (excluding those explicitly authorised to access online services) are prevented from accessing the internet, email and web services."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-07",
+      "requirement": "Privileged user accounts explicitly authorised to access online services are strictly limited to only what is required for users and services to undertake their duties."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-08",
+      "requirement": "Secure Admin Workstations are used in the performance of administrative activities."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-09",
+      "requirement": "Privileged users use separate privileged and unprivileged operating environments."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-10",
+      "requirement": "Privileged operating environments are not virtualised within unprivileged operating environments."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-11",
+      "requirement": "Unprivileged user accounts cannot logon to privileged operating environments."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-12",
+      "requirement": "Privileged user accounts (excluding local administrator accounts) cannot logon to unprivileged operating environments."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-13",
+      "requirement": "Just-in-time administration is used for administering systems and applications."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-14",
+      "requirement": "Administrative activities are conducted through jump servers."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-15",
+      "requirement": "Credentials for break glass accounts, local administrator accounts and service accounts are long, unique, unpredictable and managed."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-16",
+      "requirement": "Memory integrity functionality is enabled."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-17",
+      "requirement": "Local Security Authority protection functionality is enabled."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-18",
+      "requirement": "Credential Guard functionality is enabled."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-19",
+      "requirement": "Remote Credential Guard functionality is enabled."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-20",
+      "requirement": "Privileged access events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-21",
+      "requirement": "Privileged user account and security group management events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-22",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-23",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-24",
+      "requirement": "Event logs from non-internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-25",
+      "requirement": "Event logs from workstations are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-26",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-27",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-28",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict administrative privileges",
+      "id": "ML3-RAP-29",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-01",
+      "requirement": "Application control is implemented on workstations."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-02",
+      "requirement": "Application control is implemented on internet-facing servers."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-03",
+      "requirement": "Application control is implemented on non-internet-facing servers."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-04",
+      "requirement": "Application control is applied to user profiles and temporary folders used by operating systems, web browsers and email clients."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-05",
+      "requirement": "Application control is applied to all locations other than user profiles and temporary folders used by operating systems, web browsers and email clients."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-06",
+      "requirement": "Application control restricts the execution of executables, software libraries, scripts, installers, compiled HTML, HTML applications and control panel applets to an organisation-approved set."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-07",
+      "requirement": "Application control restricts the execution of drivers to an organisation-approved set."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-08",
+      "requirement": "Microsoft’s recommended application blocklist is implemented."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-09",
+      "requirement": "Microsoft’s vulnerable driver blocklist is implemented."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-10",
+      "requirement": "Application control rulesets are validated on an annual or more frequent basis."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-11",
+      "requirement": "Allowed and blocked application control events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-12",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-13",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-14",
+      "requirement": "Event logs from non-internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-15",
+      "requirement": "Event logs from workstations are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-16",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-17",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-18",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "Application control",
+      "id": "ML3-AC-19",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-01",
+      "requirement": "Microsoft Office macros are disabled for users that do not have a demonstrated business requirement."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-02",
+      "requirement": "Only Microsoft Office macros running from within a sandboxed environment, a Trusted Location or that are digitally signed by a trusted publisher are allowed to execute."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-03",
+      "requirement": "Microsoft Office macros are checked to ensure they are free of malicious code before being digitally signed or placed within Trusted Locations."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-04",
+      "requirement": "Only privileged users responsible for checking that Microsoft Office macros are free of malicious code can write to and modify content within Trusted Locations."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-05",
+      "requirement": "Microsoft Office macros digitally signed by an untrusted publisher cannot be enabled via the Message Bar or Backstage View."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-06",
+      "requirement": "Microsoft Office macros digitally signed by signatures other than V3 signatures cannot be enabled via the Message Bar or Backstage View."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-07",
+      "requirement": "Microsoft Office’s list of trusted publishers is validated on an annual or more frequent basis."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-08",
+      "requirement": "Microsoft Office macros in files originating from the internet are blocked."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-09",
+      "requirement": "Microsoft Office macro antivirus scanning is enabled."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-10",
+      "requirement": "Microsoft Office macros are blocked from making Win32 API calls."
+    },
+    {
+      "level": 3,
+      "strategy": "Restrict Microsoft Office macros",
+      "id": "ML3-MAC-11",
+      "requirement": "Microsoft Office macro security settings cannot be changed by users."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-01",
+      "requirement": "Internet Explorer 11 is disabled or removed."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-02",
+      "requirement": "Web browsers do not process Java from the internet."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-03",
+      "requirement": "Web browsers do not process web advertisements from the internet."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-04",
+      "requirement": "Web browsers are hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-05",
+      "requirement": "Web browser security settings cannot be changed by users."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-06",
+      "requirement": "Microsoft Office is blocked from creating child processes."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-07",
+      "requirement": "Microsoft Office is blocked from creating executable content."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-08",
+      "requirement": "Microsoft Office is blocked from injecting code into other processes."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-09",
+      "requirement": "Microsoft Office is configured to prevent activation of Object Linking and Embedding packages."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-10",
+      "requirement": "Office productivity suites are hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-11",
+      "requirement": "Office productivity suite security settings cannot be changed by users."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-12",
+      "requirement": "PDF software is blocked from creating child processes."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-13",
+      "requirement": "PDF software is hardened using ASD and vendor hardening guidance, with the most restrictive guidance taking precedence when conflicts occur."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-14",
+      "requirement": "PDF software security settings cannot be changed by users."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-15",
+      "requirement": ".NET Framework 3.5 (includes .NET 2.0 and 3.0) is disabled or removed."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-16",
+      "requirement": "Windows PowerShell 2.0 is disabled or removed."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-17",
+      "requirement": "PowerShell is configured to use Constrained Language Mode."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-18",
+      "requirement": "PowerShell module logging, script block logging and transcription events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-19",
+      "requirement": "Command line process creation events are centrally logged."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-20",
+      "requirement": "Event logs are protected from unauthorised modification and deletion."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-21",
+      "requirement": "Event logs from internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-22",
+      "requirement": "Event logs from non-internet-facing servers are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-23",
+      "requirement": "Event logs from workstations are analysed in a timely manner to detect cyber security events."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-24",
+      "requirement": "Cyber security events are analysed in a timely manner to identify cyber security incidents."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-25",
+      "requirement": "Cyber security incidents are reported to the chief information security officer, or one of their delegates, as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-26",
+      "requirement": "Cyber security incidents are reported to ASD as soon as possible after they occur or are discovered."
+    },
+    {
+      "level": 3,
+      "strategy": "User application hardening",
+      "id": "ML3-UAH-27",
+      "requirement": "Following the identification of a cyber security incident, the cyber security incident response plan is enacted."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-01",
+      "requirement": "Backups of data, applications and settings are performed and retained in accordance with business criticality and business continuity requirements."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-02",
+      "requirement": "Backups of data, applications and settings are synchronised to enable restoration to a common point in time."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-03",
+      "requirement": "Backups of data, applications and settings are retained in a secure and resilient manner."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-04",
+      "requirement": "Restoration of data, applications and settings from backups to a common point in time is tested as part of disaster recovery exercises."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-05",
+      "requirement": "Unprivileged user accounts cannot access backups belonging to other user accounts."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-06",
+      "requirement": "Unprivileged user accounts cannot access their own backups."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-07",
+      "requirement": "Privileged user accounts (excluding backup administrator accounts) cannot access backups belonging to other user accounts."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-08",
+      "requirement": "Privileged user accounts (excluding backup administrator accounts) cannot access their own backups."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-09",
+      "requirement": "Unprivileged user accounts are prevented from modifying and deleting backups."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-10",
+      "requirement": "Privileged user accounts (excluding backup administrator accounts) are prevented from modifying and deleting backups."
+    },
+    {
+      "level": 3,
+      "strategy": "Regular backups",
+      "id": "ML3-BK-11",
+      "requirement": "Backup administrator accounts are prevented from modifying and deleting backups during their retention period."
+    }
+  ]
+}

--- a/src/lib/compliance/frameworks/essential-eight-requirements.json
+++ b/src/lib/compliance/frameworks/essential-eight-requirements.json
@@ -2,7 +2,7 @@
   "source": "https://www.cyber.gov.au/business-government/asds-cyber-security-frameworks/essential-eight/essential-eight-maturity-model",
   "version": "November 2023",
   "verifiedAt": "2026-09-06",
-  "attribution": "Australian Signals Directorate, © Commonwealth of Australia 2026. CC BY 4.0. Requirement text reproduced from Appendices A–C; local identifiers added by IntuneDocumentation and are not official ISM identifiers.",
+  "attribution": "Australian Signals Directorate, © Commonwealth of Australia 2026. CC BY 4.0. Requirement text reproduced from Appendices A to C; local identifiers added by IntuneDocumentation and are not official ISM identifiers.",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "requirements": [
     {

--- a/src/lib/compliance/frameworks/essential-eight.ts
+++ b/src/lib/compliance/frameworks/essential-eight.ts
@@ -1,0 +1,114 @@
+import source from "./essential-eight-requirements.json";
+import type { FrameworkDefinition } from "../types";
+
+export type EssentialEightMaturityLevel = 1 | 2 | 3;
+export function essentialEightLevel(
+  value: unknown,
+): EssentialEightMaturityLevel {
+  if (value === undefined) return 1;
+  if (value === 1 || value === 2 || value === 3) return value;
+  throw new Error("Essential Eight target maturity level must be 1, 2 or 3");
+}
+
+// Exact requirement text from the versioned ASD snapshot. No keyword-based evidence detection.
+const bindings: ReadonlyArray<readonly [string, string, string]> = [
+  [
+    "Application control is implemented on workstations.",
+    "windows-application-control",
+    "Approved executables, rule coverage, exceptions and actual workstation enforcement require verification.",
+  ],
+  [
+    "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within one month of release.",
+    "windows-quality-update-deadline",
+    "Windows update settings support scheduling only. Release-to-install timing, vulnerability scans, servers and network devices are unassessed.",
+  ],
+  [
+    "Patches, updates or other vendor mitigations for vulnerabilities in operating systems of workstations, non-internet-facing servers and non-internet-facing network devices are applied within one month of release when vulnerabilities are assessed as non-critical by vendors and no working exploits exist.",
+    "windows-quality-update-deadline",
+    "A Windows update deadline does not verify installation or vulnerability classification. Critical and exploited vulnerabilities have separate requirements; servers and network devices are unassessed.",
+  ],
+  [
+    "Multi-factor authentication is used to authenticate users to their organisation’s online services that process, store or communicate their organisation’s sensitive data.",
+    "tenant-mfa-required",
+    "Conditional Access configuration does not establish coverage of every service, actual authentication, exclusions or phishing resistance. Review those separately.",
+  ],
+  [
+    "Memory integrity functionality is enabled.",
+    "windows-memory-integrity",
+    "An assigned compliance requirement does not prove HVCI is enabled on devices. Device attestation and effective coverage require review.",
+  ],
+  [
+    "Credential Guard functionality is enabled.",
+    "windows-credential-guard",
+    "Device activation, hardware prerequisites and effective coverage require verification. This does not establish Remote Credential Guard or LSA protection.",
+  ],
+  [
+    "Microsoft Office macros are blocked from making Win32 API calls.",
+    "windows-office-macro-win32-block",
+    "ASR exclusions, software coverage and effective device enforcement require verification. This does not prove all macro restrictions.",
+  ],
+  [
+    "Microsoft Office is blocked from creating child processes.",
+    "windows-office-child-process-block",
+    "ASR exclusions and effective device enforcement require verification.",
+  ],
+  [
+    "Microsoft Office is blocked from creating executable content.",
+    "windows-office-executable-block",
+    "ASR exclusions and effective device enforcement require verification.",
+  ],
+  [
+    "Microsoft Office is blocked from injecting code into other processes.",
+    "windows-office-injection-block",
+    "ASR exclusions and effective device enforcement require verification.",
+  ],
+  [
+    "PDF software is blocked from creating child processes.",
+    "windows-adobe-child-process-block",
+    "The detector covers Adobe Reader only. Other PDF software, exclusions and effective enforcement remain unassessed.",
+  ],
+];
+
+export function essentialEightFramework(
+  target: EssentialEightMaturityLevel = 1,
+): FrameworkDefinition {
+  const level = essentialEightLevel(target);
+  const requirements = source.requirements.filter((row) => row.level === level);
+  const mappings: Record<string, string[]> = {};
+  const controls = Object.fromEntries(
+    requirements.map((row) => {
+      const binding = bindings.find(
+        ([requirement]) => requirement === row.requirement,
+      );
+      if (binding) (mappings[binding[1]] ??= []).push(row.id);
+      return [
+        row.id,
+        {
+          id: row.id,
+          title: row.strategy,
+          summary: row.requirement,
+          tier: `Target Maturity Level ${level}`,
+          granularity: "requirement" as const,
+          evidenceStrength: "supporting" as const,
+          ...(binding && binding[1].startsWith("windows-")
+            ? { platforms: ["windows" as const] }
+            : {}),
+          unassessedAspects: [
+            binding?.[2] ??
+              "This requirement needs separate technical or operational assessment; no verified detector is available in this export.",
+          ],
+        },
+      ];
+    }),
+  );
+  return {
+    id: "essential-eight",
+    name: "ASD Essential Eight",
+    version: `November 2023; target Maturity Level ${level}`,
+    totalRequirements: requirements.length,
+    note: `Evidence against target Maturity Level ${level}; no achieved maturity level is calculated. All eight strategies are included. Local ML identifiers identify rows within the published appendix and are not official ISM control IDs. ${source.attribution} Licence: ${source.license} Configuration evidence does not prove implementation effectiveness, patch installation, backup recovery or operational processes. The model targets enterprise IT; mobile and operational technology coverage must be assessed separately.`,
+    source: { url: source.source, verifiedAt: source.verifiedAt },
+    controls,
+    mappings,
+  };
+}

--- a/src/lib/compliance/frameworks/iso-27001.ts
+++ b/src/lib/compliance/frameworks/iso-27001.ts
@@ -7,57 +7,93 @@ export const ISO_27001: FrameworkDefinition = {
   name: "ISO/IEC 27001",
   version: "2022, Annex A",
   note: "Device-management evidence for selected technological (Annex A clause 8) controls, referenced by control number with original summaries. Organizational, people, and physical controls are out of scope for an Intune tenant export.",
+  source: {
+    url: "https://www.iso.org/standard/27001",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "8.1": {
       id: "8.1",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "User endpoint devices",
       summary:
         "Endpoint devices that handle organizational information are secured through managed protections.",
     },
     "8.5": {
       id: "8.5",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Secure authentication",
       summary:
         "Authentication is required before users can access managed devices, including through device-unlock controls.",
     },
     "8.7": {
       id: "8.7",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Protection against malware",
       summary:
         "Antimalware protections are implemented and maintained on managed endpoints.",
     },
     "8.8": {
       id: "8.8",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Technical vulnerability management",
       summary:
         "Technical vulnerabilities are addressed through timely operating system updates and enforced minimum versions.",
     },
     "8.9": {
       id: "8.9",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Configuration management",
       summary:
         "Secure device configurations are defined and enforced across managed platforms.",
     },
     "8.19": {
       id: "8.19",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Software installation control",
       summary:
         "Software installation on managed systems is limited to approved sources and trusted applications.",
     },
     "8.20": {
       id: "8.20",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Network security",
       summary:
         "Managed device network connections are protected with enforced host firewall controls.",
     },
     "8.24": {
       id: "8.24",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Use of cryptography",
       summary:
         "Cryptographic safeguards protect information stored on managed devices.",
     },
   },
   mappings: {
+    "windows-virtualization-security": [],
+    "windows-credential-theft-protection": [],
+
+    "windows-antivirus-required": ["8.7"],
+    "windows-periodic-antimalware-scan": ["8.7"],
+    "windows-quality-update-deadline": ["8.8"],
+    "windows-application-control": ["8.19"],
+    "windows-behavior-monitoring": ["8.7"],
+    "windows-network-inspection": ["8.7"],
+    "windows-memory-integrity": ["8.9"],
+    "windows-credential-guard": ["8.5"],
+    "tenant-mfa-required": ["8.5"],
+    "tenant-compliant-device-required": ["8.1"],
+    "ios-app-data-transfer": ["8.1"],
+    "android-app-data-transfer": ["8.1"],
+
     "windows-disk-encryption": ["8.1", "8.24"],
     "macos-disk-encryption": ["8.1", "8.24"],
     "android-storage-encryption": ["8.1", "8.24"],

--- a/src/lib/compliance/frameworks/iso-27001.ts
+++ b/src/lib/compliance/frameworks/iso-27001.ts
@@ -78,6 +78,12 @@ export const ISO_27001: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-virtualization-security": [],
     "windows-credential-theft-protection": [],
 

--- a/src/lib/compliance/frameworks/nist-800-171-r3.ts
+++ b/src/lib/compliance/frameworks/nist-800-171-r3.ts
@@ -1,0 +1,182 @@
+import type { FrameworkDefinition } from "../types";
+
+// Independently reviewed against NIST SP 800-171r3 (May 2024), section 3.
+// This is not a renumbered Rev. 2 mapping. Withdrawn requirements are omitted:
+// 03.01.19 -> 03.01.18; 03.13.16 -> 03.13.08; 03.14.05 -> 03.14.02.
+// App-source restrictions alone do not establish 03.04.08 allow-by-exception.
+// Organization-defined parameters and effective device state remain unassessed.
+export const NIST_800_171_R3: FrameworkDefinition = {
+  id: "nist-800-171-r3",
+  name: "NIST SP 800-171",
+  version: "Rev. 3 (May 2024)",
+  totalRequirements: 97,
+  note: "Selected technical requirements from NIST SP 800-171 Revision 3. These mappings provide supporting Intune configuration evidence, not a complete assessment. Organization-defined parameters, CUI scope and operational evidence require separate review. For CMMC Level 2 assessments, select Revision 2.",
+  source: {
+    url: "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
+    verifiedAt: "2026-09-05",
+  },
+  controls: {
+    "03.01.18": {
+      id: "03.01.18",
+      title: "Access Control for Mobile Devices",
+      summary:
+        "Managed-device encryption and restrictions can support the protection of CUI on mobile endpoints.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Mobile-device authorization, connection approval, CUI scope and effective encryption require separate assessment.",
+      ],
+    },
+    "03.04.01": {
+      id: "03.04.01",
+      title: "Baseline Configuration",
+      summary:
+        "Documented hardening settings provide evidence of a device configuration baseline.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Approved baseline completeness, change control and the organization-defined review frequency are unassessed.",
+      ],
+    },
+    "03.04.02": {
+      id: "03.04.02",
+      title: "Configuration Settings",
+      summary:
+        "Platform integrity and hardening settings support the implementation of security configuration requirements.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Organization-defined configuration settings, operational requirements and approval of deviations need separate review.",
+      ],
+    },
+    "03.04.06": {
+      id: "03.04.06",
+      title: "Least Functionality",
+      summary:
+        "Restrictions on optional endpoint features provide supporting evidence for reducing unnecessary functionality.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Mission-essential functions, prohibited ports and services, periodic reviews and actual removal of unnecessary components are unassessed.",
+      ],
+    },
+    "03.04.08": {
+      id: "03.04.08",
+      title: "Authorized Software: Allow by Exception",
+      summary:
+        "Application control in enforcement mode provides supporting evidence for restricting executable software.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "The approved software list, deny-all coverage, policy exceptions and organization-defined list review frequency require separate assessment.",
+      ],
+    },
+    "03.05.01": {
+      id: "03.05.01",
+      title: "User Identification and Authentication",
+      summary:
+        "Endpoint credential requirements support user authentication before device access.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Unique user identification, attribution of processes and organization-defined re-authentication circumstances are unassessed.",
+      ],
+    },
+    "03.05.03": {
+      id: "03.05.03",
+      title: "Multi-Factor Authentication",
+      summary:
+        "Enabled Conditional Access policies that require MFA provide evidence for the users and applications they target.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "MFA coverage of all privileged and non-privileged accounts, exclusions, non-cloud access and effective sign-ins are unassessed.",
+      ],
+    },
+    "03.13.01": {
+      id: "03.13.01",
+      title: "Boundary Protection",
+      summary:
+        "Host firewall configuration supports endpoint communication controls.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Network boundary architecture, managed interfaces, public-system separation and communication monitoring require separate assessment.",
+      ],
+    },
+    "03.13.08": {
+      id: "03.13.08",
+      title: "Transmission and Storage Confidentiality",
+      summary:
+        "Device storage encryption provides evidence for the storage portion of CUI confidentiality protection.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Encryption during transmission, cryptographic suitability, key management and actual protection of all CUI storage are unassessed.",
+      ],
+    },
+    "03.14.01": {
+      id: "03.14.01",
+      title: "Flaw Remediation",
+      summary:
+        "Update policies provide supporting evidence for operating-system flaw remediation.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Flaw identification and reporting, firmware and application updates, actual installation dates and the organization-defined remediation period are unassessed. A 14-day configuration does not establish that the required period is met.",
+      ],
+    },
+    "03.14.02": {
+      id: "03.14.02",
+      title: "Malicious Code Protection",
+      summary:
+        "Antimalware requirements, real-time protection and scheduled scans provide supporting endpoint protection evidence.",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      unassessedAspects: [
+        "Protection updates, organization-defined scan frequency, scan execution, external-file coverage and block or quarantine responses require separate assessment.",
+      ],
+    },
+  },
+  mappings: {
+    "windows-disk-encryption": ["03.01.18", "03.13.08"],
+    "macos-disk-encryption": ["03.01.18", "03.13.08"],
+    "android-storage-encryption": ["03.01.18", "03.13.08"],
+    "windows-realtime-antimalware": ["03.14.02"],
+    "windows-antivirus-required": ["03.14.02"],
+    "windows-periodic-antimalware-scan": ["03.14.02"],
+    "windows-behavior-monitoring": ["03.14.02"],
+    "windows-firewall": ["03.13.01"],
+    "macos-firewall": ["03.13.01"],
+    "windows-password-required": ["03.05.01"],
+    "macos-password-required": ["03.05.01"],
+    "ios-passcode-required": ["03.05.01"],
+    "android-password-required": ["03.05.01"],
+    "tenant-mfa-required": ["03.05.03"],
+    "windows-automatic-updates": ["03.14.01"],
+    "windows-quality-update-deadline": ["03.14.01"],
+    "windows-minimum-os-version": ["03.14.01"],
+    "macos-minimum-os-version": ["03.14.01"],
+    "ios-minimum-os-version": ["03.14.01"],
+    "android-minimum-os-version": ["03.14.01"],
+    "windows-secure-boot": ["03.04.02"],
+    "windows-code-integrity": ["03.04.02"],
+    "windows-memory-integrity": ["03.04.02"],
+    "windows-virtualization-security": ["03.04.02"],
+    "windows-credential-guard": ["03.04.02"],
+    "windows-credential-theft-protection": ["03.04.02"],
+    "macos-system-integrity": ["03.04.02"],
+    "ios-jailbreak-block": ["03.04.02"],
+    "android-device-integrity": ["03.04.02"],
+    "windows-telemetry-minimized": ["03.04.01", "03.04.06"],
+    "windows-cortana-disabled": ["03.04.01", "03.04.06"],
+    "windows-microsoft-account-blocked": ["03.04.01"],
+    "windows-application-control": ["03.04.08"],
+    "windows-network-inspection": [],
+    "tenant-compliant-device-required": [],
+    "macos-gatekeeper": [],
+    "android-app-source-restriction": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+  },
+};

--- a/src/lib/compliance/frameworks/nist-800-171-r3.ts
+++ b/src/lib/compliance/frameworks/nist-800-171-r3.ts
@@ -139,6 +139,12 @@ export const NIST_800_171_R3: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-disk-encryption": ["03.01.18", "03.13.08"],
     "macos-disk-encryption": ["03.01.18", "03.13.08"],
     "android-storage-encryption": ["03.01.18", "03.13.08"],

--- a/src/lib/compliance/frameworks/nist-800-171.ts
+++ b/src/lib/compliance/frameworks/nist-800-171.ts
@@ -1,0 +1,113 @@
+import type { FrameworkDefinition } from "../types";
+
+// NIST SP 800-171 is published by the US government and is in the public
+// domain. Revision 2 is used because CMMC 2.0 Level 2 (32 CFR 170.14) and
+// DFARS 252.204-7012 reference that revision. Revision 2 requirements carry
+// no titles, so short titles and summaries are original descriptions written
+// for this device-management evidence mapping.
+export const NIST_800_171: FrameworkDefinition = {
+  id: "nist-800-171-r2",
+  name: "NIST SP 800-171",
+  version: "Rev. 2 (CMMC 2.0 Level 2)",
+  note: "Device-management evidence for selected NIST SP 800-171 Revision 2 requirements, the revision incorporated into CMMC 2.0 Level 2. Requirements without technical Intune evidence are out of scope.",
+  controls: {
+    "3.1.19": {
+      id: "3.1.19",
+      title: "Encrypt CUI on mobile devices",
+      summary:
+        "Storage on laptops and mobile devices that may hold controlled unclassified information is encrypted.",
+    },
+    "3.4.1": {
+      id: "3.4.1",
+      title: "Baseline configurations",
+      summary:
+        "Baseline hardening settings are established and enforced on managed devices.",
+    },
+    "3.4.2": {
+      id: "3.4.2",
+      title: "Security configuration settings",
+      summary:
+        "Platform integrity protections are enforced as part of the security configuration.",
+    },
+    "3.4.6": {
+      id: "3.4.6",
+      title: "Least functionality",
+      summary:
+        "Non-essential functions and data collection are restricted on managed devices.",
+    },
+    "3.4.8": {
+      id: "3.4.8",
+      title: "Software execution policy",
+      summary:
+        "Software installation is restricted to trusted sources on managed platforms.",
+    },
+    "3.5.2": {
+      id: "3.5.2",
+      title: "Authenticate users and devices",
+      summary:
+        "A credential is required before a user can access a managed device.",
+    },
+    "3.13.1": {
+      id: "3.13.1",
+      title: "Boundary protection",
+      summary:
+        "Host firewalls monitor and control communications at the device boundary.",
+    },
+    "3.13.6": {
+      id: "3.13.6",
+      title: "Deny by default, allow by exception",
+      summary:
+        "Host firewalls deny network traffic that is not explicitly allowed.",
+    },
+    "3.13.16": {
+      id: "3.13.16",
+      title: "Protect CUI at rest",
+      summary:
+        "Information stored on managed devices is protected through enforced encryption.",
+    },
+    "3.14.1": {
+      id: "3.14.1",
+      title: "Flaw remediation",
+      summary:
+        "Operating system flaws are remediated through automatic updates and enforced minimum versions.",
+    },
+    "3.14.2": {
+      id: "3.14.2",
+      title: "Malicious code protection",
+      summary: "Anti-malware protection is enforced on managed endpoints.",
+    },
+    "3.14.5": {
+      id: "3.14.5",
+      title: "Real-time and periodic scanning",
+      summary:
+        "Real-time anti-malware scanning is enforced on managed endpoints.",
+    },
+  },
+  mappings: {
+    "windows-disk-encryption": ["3.1.19", "3.13.16"],
+    "macos-disk-encryption": ["3.1.19", "3.13.16"],
+    "android-storage-encryption": ["3.1.19", "3.13.16"],
+    "windows-realtime-antimalware": ["3.14.2", "3.14.5"],
+    "windows-firewall": ["3.13.1", "3.13.6"],
+    "macos-firewall": ["3.13.1", "3.13.6"],
+    "windows-password-required": ["3.5.2"],
+    "macos-password-required": ["3.5.2"],
+    "ios-passcode-required": ["3.5.2"],
+    "android-password-required": ["3.5.2"],
+    "windows-automatic-updates": ["3.14.1"],
+    "windows-minimum-os-version": ["3.14.1"],
+    "macos-minimum-os-version": ["3.14.1"],
+    "ios-minimum-os-version": ["3.14.1"],
+    "android-minimum-os-version": ["3.14.1"],
+    "windows-secure-boot": ["3.4.2"],
+    "windows-code-integrity": ["3.4.2"],
+    "macos-system-integrity": ["3.4.2"],
+    "windows-telemetry-minimized": ["3.4.1", "3.4.6"],
+    "windows-cortana-disabled": ["3.4.1", "3.4.6"],
+    "windows-microsoft-account-blocked": ["3.4.1"],
+    "ios-jailbreak-block": ["3.4.2"],
+    "android-device-integrity": ["3.4.2"],
+    "macos-gatekeeper": ["3.4.8"],
+    "android-app-source-restriction": ["3.4.8"],
+  },
+};

--- a/src/lib/compliance/frameworks/nist-800-171.ts
+++ b/src/lib/compliance/frameworks/nist-800-171.ts
@@ -12,75 +12,121 @@ export const NIST_800_171: FrameworkDefinition = {
   id: "nist-800-171-r2",
   name: "NIST SP 800-171",
   version: "Rev. 2 (CMMC 2.0 Level 2)",
-  note: "Device-management evidence for selected NIST SP 800-171 Revision 2 requirements, the revision incorporated into CMMC 2.0 Level 2. Requirements without technical Intune evidence are out of scope.",
+  totalRequirements: 110,
+  note: "Supporting device-management evidence for selected NIST SP 800-171 Revision 2 requirements, the revision incorporated into CMMC 2.0 Level 2. Requirements without technical Intune evidence are not assessed. This report is not a complete CMMC assessment or an SPRS score.",
+  source: {
+    url: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "3.1.19": {
       id: "3.1.19",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Encrypt CUI on mobile devices",
       summary:
         "Storage on laptops and mobile devices that may hold controlled unclassified information is encrypted.",
     },
     "3.4.1": {
       id: "3.4.1",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Baseline configurations",
       summary:
         "Baseline hardening settings are established and enforced on managed devices.",
     },
     "3.4.2": {
       id: "3.4.2",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Security configuration settings",
       summary:
         "Platform integrity protections are enforced as part of the security configuration.",
     },
     "3.4.6": {
       id: "3.4.6",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Least functionality",
       summary:
         "Non-essential functions and data collection are restricted on managed devices.",
     },
     "3.4.9": {
       id: "3.4.9",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "User-installed software restrictions",
       summary:
         "Software installation is restricted to trusted sources on managed platforms.",
     },
     "3.5.2": {
       id: "3.5.2",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Authenticate users and devices",
       summary:
         "A credential is required before a user can access a managed device.",
     },
     "3.13.1": {
       id: "3.13.1",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Boundary protection",
       summary:
         "Host firewalls monitor and control communications at the device boundary.",
     },
     "3.13.16": {
       id: "3.13.16",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Protect CUI at rest",
       summary:
         "Information stored on managed devices is protected through enforced encryption.",
     },
     "3.14.1": {
       id: "3.14.1",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Flaw remediation",
       summary:
         "Operating system flaws are remediated through automatic updates and enforced minimum versions.",
     },
     "3.14.2": {
       id: "3.14.2",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Malicious code protection",
       summary: "Anti-malware protection is enforced on managed endpoints.",
     },
     "3.14.5": {
       id: "3.14.5",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Actual periodic scan execution, files from external sources and scan exclusions are unassessed.",
+      ],
+      granularity: "requirement",
       title: "Real-time and periodic scanning",
       summary:
-        "Real-time anti-malware scanning is enforced on managed endpoints.",
+        "Real-time protection and periodic scans are configured on managed endpoints; scan execution is assessed separately.",
     },
   },
   mappings: {
+    "windows-network-inspection": [],
+    "windows-virtualization-security": [],
+    "windows-credential-theft-protection": [],
+    "tenant-compliant-device-required": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "windows-antivirus-required": ["3.14.2"],
+    "windows-periodic-antimalware-scan": ["3.14.5"],
+    "windows-quality-update-deadline": ["3.14.1"],
+    "windows-application-control": ["3.4.9"],
+    "windows-behavior-monitoring": ["3.14.2"],
+    "windows-memory-integrity": ["3.4.2"],
+    "windows-credential-guard": ["3.5.2"],
+    "tenant-mfa-required": ["3.5.2"],
+
     "windows-disk-encryption": ["3.1.19", "3.13.16"],
     "macos-disk-encryption": ["3.1.19", "3.13.16"],
     "android-storage-encryption": ["3.1.19", "3.13.16"],

--- a/src/lib/compliance/frameworks/nist-800-171.ts
+++ b/src/lib/compliance/frameworks/nist-800-171.ts
@@ -5,6 +5,9 @@ import type { FrameworkDefinition } from "../types";
 // DFARS 252.204-7012 reference that revision. Revision 2 requirements carry
 // no titles, so short titles and summaries are original descriptions written
 // for this device-management evidence mapping.
+// Firewall activation does not establish default-deny traffic rules (3.13.6).
+// App-source restrictions support user-installed software controls (3.4.9),
+// not executable allow/block lists (3.4.8).
 export const NIST_800_171: FrameworkDefinition = {
   id: "nist-800-171-r2",
   name: "NIST SP 800-171",
@@ -35,9 +38,9 @@ export const NIST_800_171: FrameworkDefinition = {
       summary:
         "Non-essential functions and data collection are restricted on managed devices.",
     },
-    "3.4.8": {
-      id: "3.4.8",
-      title: "Software execution policy",
+    "3.4.9": {
+      id: "3.4.9",
+      title: "User-installed software restrictions",
       summary:
         "Software installation is restricted to trusted sources on managed platforms.",
     },
@@ -52,12 +55,6 @@ export const NIST_800_171: FrameworkDefinition = {
       title: "Boundary protection",
       summary:
         "Host firewalls monitor and control communications at the device boundary.",
-    },
-    "3.13.6": {
-      id: "3.13.6",
-      title: "Deny by default, allow by exception",
-      summary:
-        "Host firewalls deny network traffic that is not explicitly allowed.",
     },
     "3.13.16": {
       id: "3.13.16",
@@ -88,8 +85,8 @@ export const NIST_800_171: FrameworkDefinition = {
     "macos-disk-encryption": ["3.1.19", "3.13.16"],
     "android-storage-encryption": ["3.1.19", "3.13.16"],
     "windows-realtime-antimalware": ["3.14.2", "3.14.5"],
-    "windows-firewall": ["3.13.1", "3.13.6"],
-    "macos-firewall": ["3.13.1", "3.13.6"],
+    "windows-firewall": ["3.13.1"],
+    "macos-firewall": ["3.13.1"],
     "windows-password-required": ["3.5.2"],
     "macos-password-required": ["3.5.2"],
     "ios-passcode-required": ["3.5.2"],
@@ -107,7 +104,7 @@ export const NIST_800_171: FrameworkDefinition = {
     "windows-microsoft-account-blocked": ["3.4.1"],
     "ios-jailbreak-block": ["3.4.2"],
     "android-device-integrity": ["3.4.2"],
-    "macos-gatekeeper": ["3.4.8"],
-    "android-app-source-restriction": ["3.4.8"],
+    "macos-gatekeeper": ["3.4.9"],
+    "android-app-source-restriction": ["3.4.9"],
   },
 };

--- a/src/lib/compliance/frameworks/nist-800-171.ts
+++ b/src/lib/compliance/frameworks/nist-800-171.ts
@@ -67,6 +67,17 @@ export const NIST_800_171: FrameworkDefinition = {
       summary:
         "A credential is required before a user can access a managed device.",
     },
+    "3.5.3": {
+      id: "3.5.3",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
+      title: "Multi-factor authentication",
+      summary:
+        "Multi-factor authentication is required for access under the configured Conditional Access policy conditions.",
+      unassessedAspects: [
+        "Local privileged access, all required accounts, exclusions and effective sign-in behavior are assessed separately.",
+      ],
+    },
     "3.13.1": {
       id: "3.13.1",
       evidenceStrength: "supporting",
@@ -130,8 +141,8 @@ export const NIST_800_171: FrameworkDefinition = {
     "windows-application-control": ["3.4.9"],
     "windows-behavior-monitoring": ["3.14.2"],
     "windows-memory-integrity": ["3.4.2"],
-    "windows-credential-guard": ["3.5.2"],
-    "tenant-mfa-required": ["3.5.2"],
+    "windows-credential-guard": ["3.4.2"],
+    "tenant-mfa-required": ["3.5.3"],
 
     "windows-disk-encryption": ["3.1.19", "3.13.16"],
     "macos-disk-encryption": ["3.1.19", "3.13.16"],

--- a/src/lib/compliance/frameworks/nist-800-171.ts
+++ b/src/lib/compliance/frameworks/nist-800-171.ts
@@ -111,6 +111,12 @@ export const NIST_800_171: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-network-inspection": [],
     "windows-virtualization-security": [],
     "windows-credential-theft-protection": [],

--- a/src/lib/compliance/frameworks/nist-800-53.ts
+++ b/src/lib/compliance/frameworks/nist-800-53.ts
@@ -6,69 +6,109 @@ export const NIST_800_53: FrameworkDefinition = {
   name: "NIST SP 800-53",
   version: "Revision 5",
   note: "Device-management evidence for a subset of technical controls. Organizational and procedural aspects of each control are out of scope for an Intune tenant export.",
+  source: {
+    url: "https://doi.org/10.6028/NIST.SP.800-53r5",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "SC-28": {
       id: "SC-28",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Protection of Information at Rest",
       summary:
         "Protect the confidentiality and integrity of information stored on devices, typically through encryption at rest.",
     },
     "SI-3": {
       id: "SI-3",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Malicious Code Protection",
       summary:
         "Employ malicious code protection mechanisms at system entry and exit points and keep them current.",
     },
     "SC-7": {
       id: "SC-7",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Boundary Protection",
       summary:
         "Monitor and control communications at managed interfaces, including host-based firewall protections.",
     },
     "IA-5": {
       id: "IA-5",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Authenticator Management",
       summary:
         "Manage system authenticators, including requiring and maintaining device unlock credentials.",
     },
     "SI-2": {
       id: "SI-2",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Flaw Remediation",
       summary:
         "Identify, report, and correct system flaws, including timely installation of security-relevant updates.",
     },
     "AC-2": {
       id: "AC-2",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Account Management",
       summary:
         "Manage system accounts, including restricting sign-in to organization-managed identities.",
     },
     "CM-6": {
       id: "CM-6",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Configuration Settings",
       summary:
         "Establish and enforce secure configuration settings, including restricting data flows to external providers.",
     },
     "CM-7": {
       id: "CM-7",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Least Functionality",
       summary:
         "Configure systems to provide only essential capabilities and disable functions that are not required.",
     },
     "CM-11": {
       id: "CM-11",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "User-Installed Software",
       summary:
         "Govern and restrict the installation of software by users, including blocking untrusted installation sources.",
     },
     "SI-7": {
       id: "SI-7",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Software, Firmware, and Information Integrity",
       summary:
         "Employ integrity verification for software, firmware, and boot processes, and respond to integrity violations.",
     },
   },
   mappings: {
+    "tenant-mfa-required": [],
+    "tenant-compliant-device-required": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "windows-antivirus-required": ["SI-3"],
+    "windows-periodic-antimalware-scan": ["SI-3"],
+    "windows-quality-update-deadline": ["SI-2"],
+    "windows-application-control": ["CM-11"],
+    "windows-behavior-monitoring": ["SI-3"],
+    "windows-network-inspection": ["SI-3"],
+    "windows-memory-integrity": ["SI-7"],
+    "windows-virtualization-security": ["SI-7"],
+    "windows-credential-guard": ["IA-5"],
+    "windows-credential-theft-protection": ["IA-5"],
+
     "windows-disk-encryption": ["SC-28"],
     "macos-disk-encryption": ["SC-28"],
     "android-storage-encryption": ["SC-28"],

--- a/src/lib/compliance/frameworks/nist-800-53.ts
+++ b/src/lib/compliance/frameworks/nist-800-53.ts
@@ -93,6 +93,12 @@ export const NIST_800_53: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "tenant-mfa-required": [],
     "tenant-compliant-device-required": [],
     "ios-app-data-transfer": [],

--- a/src/lib/compliance/frameworks/nist-csf.ts
+++ b/src/lib/compliance/frameworks/nist-csf.ts
@@ -7,57 +7,96 @@ export const NIST_CSF: FrameworkDefinition = {
   name: "NIST Cybersecurity Framework",
   version: "2.0",
   note: "Device-management evidence for a subset of Protect and Detect subcategories. Governance, process, and organizational aspects are out of scope for an Intune tenant export.",
+  source: {
+    url: "https://doi.org/10.6028/NIST.CSWP.29",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "PR.DS-01": {
       id: "PR.DS-01",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Data-at-rest is protected",
       summary:
         "The confidentiality, integrity, and availability of data at rest are protected, typically through device and storage encryption.",
     },
     "PR.AA-01": {
       id: "PR.AA-01",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Identities and credentials are managed",
       summary:
         "Identities and credentials for authorized users, services, and hardware are managed, including device unlock credentials.",
     },
     "PR.AA-03": {
       id: "PR.AA-03",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Users, services, and hardware are authenticated",
       summary:
         "Access to devices requires authentication, such as a required password, PIN, or passcode.",
     },
     "PR.PS-01": {
       id: "PR.PS-01",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Configuration management practices are applied",
       summary:
         "Platforms are managed with secure configuration baselines, including platform and boot integrity requirements.",
     },
     "PR.PS-02": {
       id: "PR.PS-02",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Software is maintained commensurate with risk",
       summary:
         "Operating systems and software are kept current through managed updates and minimum version requirements.",
     },
     "PR.PS-05": {
       id: "PR.PS-05",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Unauthorized software is prevented",
       summary:
         "Installation and execution of unauthorized software are prevented, including blocking untrusted app sources.",
     },
     "PR.IR-01": {
       id: "PR.IR-01",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Networks and environments are protected",
       summary:
         "Networks and environments are protected from unauthorized logical access, including host-based firewalls.",
     },
     "DE.CM-09": {
       id: "DE.CM-09",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Actual detection events, monitoring coverage and response processes are unassessed.",
+      ],
+      granularity: "requirement",
       title: "Computing hardware and software are monitored",
       summary:
         "Endpoints and their runtime environments are monitored for potentially adverse events, including malware.",
     },
   },
   mappings: {
+    "windows-credential-guard": [],
+    "windows-credential-theft-protection": [],
+    "ios-app-data-transfer": [],
+    "android-app-data-transfer": [],
+
+    "windows-antivirus-required": ["DE.CM-09"],
+    "windows-periodic-antimalware-scan": ["DE.CM-09"],
+    "windows-quality-update-deadline": ["PR.PS-02"],
+    "windows-application-control": ["PR.PS-05"],
+    "windows-behavior-monitoring": ["DE.CM-09"],
+    "windows-network-inspection": ["DE.CM-09"],
+    "windows-memory-integrity": ["PR.PS-01"],
+    "windows-virtualization-security": ["PR.PS-01"],
+    "tenant-mfa-required": ["PR.AA-03"],
+    "tenant-compliant-device-required": ["PR.AA-03"],
+
     "windows-disk-encryption": ["PR.DS-01"],
     "macos-disk-encryption": ["PR.DS-01"],
     "android-storage-encryption": ["PR.DS-01"],

--- a/src/lib/compliance/frameworks/nist-csf.ts
+++ b/src/lib/compliance/frameworks/nist-csf.ts
@@ -81,6 +81,12 @@ export const NIST_CSF: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-credential-guard": [],
     "windows-credential-theft-protection": [],
     "ios-app-data-transfer": [],

--- a/src/lib/compliance/frameworks/soc2.ts
+++ b/src/lib/compliance/frameworks/soc2.ts
@@ -7,39 +7,75 @@ export const SOC_2: FrameworkDefinition = {
   name: "SOC 2",
   version: "Trust Services Criteria",
   note: "Device-management evidence for selected Common Criteria, referenced by criterion ID with original summaries. A SOC 2 examination covers far more than device configuration; this mapping supports evidence collection only.",
+  source: {
+    url: "https://www.aicpa-cima.com/resources/download/2017-trust-services-criteria-with-revised-points-of-focus-2022",
+    verifiedAt: "2026-09-04",
+  },
   controls: {
     "CC6.1": {
       id: "CC6.1",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Logical access controls",
       summary:
         "Managed systems use logical access measures, including device authentication and encryption of stored data.",
     },
     "CC6.6": {
       id: "CC6.6",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Protection against external threats",
       summary:
         "Boundary protections, including host firewalls, defend managed devices against external threats.",
     },
     "CC6.7": {
       id: "CC6.7",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Data classification, all transfer channels, managed app scope and data-loss prevention effectiveness are unassessed.",
+      ],
+      granularity: "requirement",
       title: "Restricted data movement",
       summary:
         "Information movement and transmission are limited by controls that reduce external data sharing.",
     },
     "CC6.8": {
       id: "CC6.8",
+      evidenceStrength: "supporting",
+      granularity: "requirement",
       title: "Unauthorized software prevention",
       summary:
         "Controls prevent or detect unauthorized and malicious software on managed devices.",
     },
     "CC7.1": {
       id: "CC7.1",
+      evidenceStrength: "supporting",
+      unassessedAspects: [
+        "Actual vulnerability findings, detection events, alert handling and remediation outcomes are unassessed.",
+      ],
+      granularity: "requirement",
       title: "Vulnerability and configuration monitoring",
       summary:
         "Managed endpoint configurations and software versions are monitored and maintained to address vulnerabilities.",
     },
   },
   mappings: {
+    "windows-memory-integrity": [],
+    "windows-virtualization-security": [],
+    "windows-credential-guard": [],
+    "windows-credential-theft-protection": [],
+
+    "windows-antivirus-required": ["CC6.8"],
+    "windows-periodic-antimalware-scan": ["CC6.8"],
+    "windows-quality-update-deadline": ["CC7.1"],
+    "windows-application-control": ["CC6.8"],
+    "windows-behavior-monitoring": ["CC7.1"],
+    "windows-network-inspection": ["CC7.1"],
+    "tenant-mfa-required": ["CC6.1"],
+    "tenant-compliant-device-required": ["CC6.1"],
+    "ios-app-data-transfer": ["CC6.7"],
+    "android-app-data-transfer": ["CC6.7"],
+
     "windows-disk-encryption": ["CC6.1"],
     "macos-disk-encryption": ["CC6.1"],
     "android-storage-encryption": ["CC6.1"],

--- a/src/lib/compliance/frameworks/soc2.ts
+++ b/src/lib/compliance/frameworks/soc2.ts
@@ -60,6 +60,12 @@ export const SOC_2: FrameworkDefinition = {
     },
   },
   mappings: {
+    "windows-office-macro-win32-block": [],
+    "windows-office-child-process-block": [],
+    "windows-office-executable-block": [],
+    "windows-office-injection-block": [],
+    "windows-adobe-child-process-block": [],
+
     "windows-memory-integrity": [],
     "windows-virtualization-security": [],
     "windows-credential-guard": [],

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -12,6 +12,12 @@ export { NIST_CSF } from "./frameworks/nist-csf";
 export { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
 export { ISO_27001 } from "./frameworks/iso-27001";
 export { SOC_2 } from "./frameworks/soc2";
+export {
+  DEF_STAN_05_138,
+  DEF_STAN_FAMILIES,
+} from "./frameworks/def-stan-05-138";
+export { CYBER_ESSENTIALS } from "./frameworks/cyber-essentials";
+export { NIST_800_171 } from "./frameworks/nist-800-171";
 export type {
   CapabilityEvidence,
   CapabilityResult,

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -7,6 +7,7 @@ export {
   COMPLIANCE_RULESET_VERSION,
 } from "./engine";
 export { COMPLIANCE_CAPABILITIES } from "./capabilities";
+export { createEvidenceManifest } from "./manifest";
 export { NIST_800_53 } from "./frameworks/nist-800-53";
 export { NIST_CSF } from "./frameworks/nist-csf";
 export { BSI_IT_GRUNDSCHUTZ } from "./frameworks/bsi-it-grundschutz";
@@ -18,7 +19,11 @@ export {
 } from "./frameworks/def-stan-05-138";
 export { CYBER_ESSENTIALS } from "./frameworks/cyber-essentials";
 export { NIST_800_171 } from "./frameworks/nist-800-171";
+export { NIST_800_171_R3 } from "./frameworks/nist-800-171-r3";
 export type {
+  AssessmentScope,
+  CollectionCoverage,
+  CompliancePlatform,
   CapabilityEvidence,
   CapabilityResult,
   CapabilityStatus,

--- a/src/lib/compliance/index.ts
+++ b/src/lib/compliance/index.ts
@@ -36,3 +36,5 @@ export type {
   FrameworkControl,
   FrameworkDefinition,
 } from "./types";
+
+export { essentialEightFramework } from "./frameworks/essential-eight";

--- a/src/lib/compliance/legacy-signals.ts
+++ b/src/lib/compliance/legacy-signals.ts
@@ -1,0 +1,61 @@
+import type { LegacySettingSignal } from "./types";
+
+// Microsoft Policy/BitLocker/Firewall CSP identifiers. Keep the value types:
+// OMA-URI integers and booleans are not Settings Catalog choice suffixes.
+// https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-defender
+// https://learn.microsoft.com/en-us/windows/client-management/mdm/bitlocker-csp
+// https://learn.microsoft.com/en-us/windows/client-management/mdm/firewall-csp
+const integer = (
+  settingId: string,
+  enabled: number,
+  disabled: number,
+): LegacySettingSignal => ({
+  source: "omaUri",
+  settingId,
+  enforcedWhen: { kind: "equals", value: enabled },
+  disabledWhen: { kind: "equals", value: disabled },
+});
+export const LEGACY_SIGNALS: Readonly<
+  Record<string, readonly LegacySettingSignal[]>
+> = {
+  "windows-disk-encryption": [
+    integer("./Device/Vendor/MSFT/BitLocker/RequireDeviceEncryption", 1, 0),
+  ],
+  "windows-realtime-antimalware": [
+    integer(
+      "./Device/Vendor/MSFT/Policy/Config/Defender/AllowRealtimeMonitoring",
+      1,
+      0,
+    ),
+  ],
+  "windows-password-required": [
+    integer(
+      "./Device/Vendor/MSFT/Policy/Config/DeviceLock/DevicePasswordEnabled",
+      0,
+      1,
+    ),
+  ],
+  "windows-telemetry-minimized": [
+    integer("./Device/Vendor/MSFT/Policy/Config/System/AllowTelemetry", 0, 1),
+  ],
+  "windows-cortana-disabled": [
+    integer("./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana", 0, 1),
+  ],
+  "windows-automatic-updates": [
+    {
+      source: "omaUri",
+      settingId: "./Device/Vendor/MSFT/Policy/Config/Update/AllowAutoUpdate",
+      enforcedWhen: { kind: "oneOf", values: [1, 2, 3, 4] },
+      disabledWhen: { kind: "equals", value: 5 },
+    },
+  ],
+  "windows-firewall": (["Domain", "Private", "Public"] as const).map(
+    (profile) => ({
+      source: "omaUri",
+      settingId: `./Vendor/MSFT/Firewall/MdmStore/${profile}Profile/EnableFirewall`,
+      requirementGroup: profile.toLowerCase(),
+      enforcedWhen: { kind: "equals", value: true },
+      disabledWhen: { kind: "equals", value: false },
+    }),
+  ),
+};

--- a/src/lib/compliance/manifest.ts
+++ b/src/lib/compliance/manifest.ts
@@ -1,0 +1,60 @@
+import {
+  assessCompliance,
+  COMPLIANCE_RULESET_VERSION,
+  type ComplianceExportData,
+} from "./engine";
+import { COMPLIANCE_CAPABILITIES } from "./capabilities";
+import type { AssessmentScope } from "./types";
+
+export function canonicalJson(value: unknown): string {
+  const normalize = (item: any): any => {
+    if (item instanceof Map) return normalize(Object.fromEntries(item));
+    if (Array.isArray(item)) return item.map(normalize);
+    if (item && typeof item === "object")
+      return Object.fromEntries(
+        Object.keys(item)
+          .sort()
+          .filter((key) => item[key] !== undefined)
+          .map((key) => [key, normalize(item[key])]),
+      );
+    return item;
+  };
+  return JSON.stringify(normalize(value));
+}
+
+async function sha256(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalJson(value));
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function createEvidenceManifest(
+  data: ComplianceExportData,
+  scope: AssessmentScope = data.assessmentScope ?? {},
+) {
+  const assessment = assessCompliance(data, scope);
+  // Branding and report generation time do not alter the source snapshot fingerprint.
+  const snapshot = { ...data };
+  delete snapshot.branding;
+  delete snapshot.assessmentScope;
+  const [snapshotSha256, rulesetSha256] = await Promise.all([
+    sha256(snapshot),
+    sha256({
+      version: COMPLIANCE_RULESET_VERSION,
+      capabilities: COMPLIANCE_CAPABILITIES,
+      frameworks: assessment.frameworks.map((framework) => ({
+        ...framework.framework,
+        controls: framework.controls.map((control) => ({
+          control: control.control,
+          capabilityIds: [
+            ...control.capabilityIds,
+            ...control.excludedCapabilityIds,
+          ].sort(),
+        })),
+      })),
+    }),
+  ]);
+  return { schemaVersion: 1, snapshotSha256, rulesetSha256, assessment };
+}

--- a/src/lib/compliance/policy-checks.ts
+++ b/src/lib/compliance/policy-checks.ts
@@ -1,0 +1,121 @@
+import type { PolicyCheckSignal } from "./types";
+
+export interface PolicyCheckResult {
+  verdict: "enforced" | "disabled";
+  observed: string;
+}
+
+/** Compound checks must be satisfied by one policy, never unrelated policies. */
+export function evaluatePolicyCheck(
+  config: Record<string, any>,
+  check: PolicyCheckSignal["check"],
+): PolicyCheckResult | undefined {
+  const type = String(config["@odata.type"] ?? "")
+    .replace(/^#?(microsoft\.graph\.)?/, "")
+    .toLowerCase();
+  if (check === "scheduledAntivirusScan") {
+    if (
+      ![
+        "windows10generalconfiguration",
+        "windows10endpointprotectionconfiguration",
+      ].includes(type)
+    )
+      return;
+    const day =
+      config.defenderSystemScanSchedule ?? config.defenderScheduledScanDay;
+    const scan = config.defenderScanType;
+    if (scan === "disabled" || day === "noScheduledScan")
+      return {
+        verdict: "disabled",
+        observed: `Scan: ${scan ?? "unspecified"}; schedule: ${day ?? "unspecified"}`,
+      };
+    if (
+      !["quick", "full"].includes(scan) ||
+      ![
+        "everyday",
+        "sunday",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+      ].includes(day)
+    )
+      return;
+    if (
+      typeof config.defenderScheduledScanTime !== "string" ||
+      !/^\d{2}:\d{2}:\d{2}/.test(config.defenderScheduledScanTime)
+    )
+      return;
+    return {
+      verdict: "enforced",
+      observed: `${scan}; ${day}; ${config.defenderScheduledScanTime}`,
+    };
+  }
+  if (check === "qualityUpdateDeadline") {
+    if (type !== "windowsupdateforbusinessconfiguration") return;
+    const {
+      qualityUpdatesDeferralPeriodInDays: deferral,
+      deadlineForQualityUpdatesInDays: deadline,
+      deadlineGracePeriodInDays: grace,
+    } = config;
+    if (
+      ![deferral, deadline, grace].every(
+        (value) =>
+          typeof value === "number" && Number.isInteger(value) && value >= 0,
+      )
+    )
+      return;
+    const days = deferral + deadline + grace;
+    // Policy timing is supporting evidence. Release-to-device installation still requires observations.
+    const paused = config.qualityUpdatesPaused;
+    if (typeof paused !== "boolean") return;
+    const automatic = [
+      "autoInstallAtMaintenanceTime",
+      "autoInstallAndRebootAtMaintenanceTime",
+      "autoInstallAndRebootAtScheduledTime",
+      "autoInstallAndRebootWithoutEndUserControl",
+    ].includes(config.automaticUpdateMode);
+    if (!automatic) return;
+    return {
+      verdict: !paused && days <= 14 ? "enforced" : "disabled",
+      observed: `Quality update deferral ${deferral}d + deadline ${deadline}d + grace ${grace}d = ${days}d; paused: ${paused}`,
+    };
+  }
+  if (type !== "conditionalaccesspolicy") return;
+  const controls = config.grantControls;
+  const required = check === "conditionalAccessMfa" ? "mfa" : "compliantDevice";
+  if (
+    !Array.isArray(controls?.builtInControls) ||
+    !controls.builtInControls.includes(required) ||
+    controls.builtInControls.includes("block")
+  )
+    return;
+  const alternatives =
+    controls.builtInControls.length +
+    (controls.customAuthenticationFactors?.length ?? 0) +
+    (controls.termsOfUse?.length ?? 0) +
+    (controls.authenticationStrength ? 1 : 0);
+  // OR with another grant does not require this particular control.
+  if (
+    controls.operator !== "AND" &&
+    !(controls.operator === "OR" && alternatives === 1)
+  )
+    return;
+  if (config.state !== "enabled") return;
+  const users = config.conditions?.users;
+  const apps = config.conditions?.applications;
+  if (
+    ![users?.includeUsers, users?.includeGroups, users?.includeRoles].some(
+      (value) => Array.isArray(value) && value.length > 0,
+    ) ||
+    !Array.isArray(apps?.includeApplications) ||
+    apps.includeApplications.length === 0
+  )
+    return;
+  return {
+    verdict: "enforced",
+    observed: `${required} required; enabled; configured conditions apply`,
+  };
+}

--- a/src/lib/compliance/policy-checks.ts
+++ b/src/lib/compliance/policy-checks.ts
@@ -78,8 +78,11 @@ export function evaluatePolicyCheck(
       "autoInstallAndRebootWithoutEndUserControl",
     ].includes(config.automaticUpdateMode);
     if (!automatic) return;
+    // This shared signal supports frameworks with different remediation periods.
+    // Exceeding its 14-day evidence threshold is not a framework deviation.
+    if (!paused && days > 14) return;
     return {
-      verdict: !paused && days <= 14 ? "enforced" : "disabled",
+      verdict: paused ? "disabled" : "enforced",
       observed: `Quality update deferral ${deferral}d + deadline ${deadline}d + grace ${grace}d = ${days}d; paused: ${paused}`,
     };
   }

--- a/src/lib/compliance/presentation.ts
+++ b/src/lib/compliance/presentation.ts
@@ -1,0 +1,72 @@
+import type {
+  CapabilityStatus,
+  ControlStatus,
+  FrameworkAssessment,
+} from "./types";
+
+export function frameworkCoverageLabel(
+  assessment: FrameworkAssessment,
+): string | undefined {
+  const total = assessment.framework.totalRequirements;
+  if (total === undefined) return undefined;
+  return `${assessment.summary.totalControls} of ${total} published requirements have Intune evidence mappings. Supporting evidence only; this is not a full assessment or compliance score.`;
+}
+
+export const CONTROL_STATUS_LABELS: Record<ControlStatus, string> = {
+  evidenceFound: "Configuration evidence",
+  partialEvidence: "Supporting or partial evidence",
+  noEvidence: "No recognized evidence",
+  notApplicable: "Outside selected scope",
+  notAssessed: "Not assessed",
+  conflictingEvidence: "Mixed policy evidence",
+};
+
+export const CAPABILITY_STATUS_LABELS: Record<CapabilityStatus, string> = {
+  enforced: "Setting configured and assigned",
+  requirementAssigned: "Compliance requirement assigned",
+  configuredNotAssigned: "Configured, not assigned",
+  disabledByPolicy: "Non-enforcing setting detected",
+  noEvidence: "No recognized evidence",
+  assignmentUnknown: "Assignment unknown",
+  conflictingEvidence: "Mixed policy evidence",
+  partialConfiguration: "Some required settings missing",
+  collectionIncomplete: "Collection incomplete",
+  notApplicable: "Outside selected scope",
+};
+
+export const CONTROL_STATUS_ORDER: Record<ControlStatus, number> = {
+  conflictingEvidence: 0,
+  notAssessed: 1,
+  noEvidence: 2,
+  partialEvidence: 3,
+  evidenceFound: 4,
+  notApplicable: 5,
+};
+
+export const CONTROL_STATUS_COLORS: Record<
+  ControlStatus,
+  [number, number, number]
+> = {
+  evidenceFound: [31, 133, 83],
+  partialEvidence: [196, 113, 31],
+  noEvidence: [100, 116, 139],
+  notApplicable: [100, 116, 139],
+  notAssessed: [196, 113, 31],
+  conflictingEvidence: [185, 28, 28],
+};
+
+export const CAPABILITY_STATUS_COLORS: Record<
+  CapabilityStatus,
+  [number, number, number]
+> = {
+  enforced: [31, 133, 83],
+  requirementAssigned: [37, 99, 235],
+  configuredNotAssigned: [196, 113, 31],
+  disabledByPolicy: [185, 28, 28],
+  noEvidence: [100, 116, 139],
+  assignmentUnknown: [196, 113, 31],
+  conflictingEvidence: [185, 28, 28],
+  partialConfiguration: [196, 113, 31],
+  collectionIncomplete: [196, 113, 31],
+  notApplicable: [100, 116, 139],
+};

--- a/src/lib/compliance/presentation.ts
+++ b/src/lib/compliance/presentation.ts
@@ -7,6 +7,12 @@ import type {
 export function frameworkCoverageLabel(
   assessment: FrameworkAssessment,
 ): string | undefined {
+  if (assessment.framework.id === "essential-eight") {
+    const mapped = assessment.controls.filter(
+      (row) => row.capabilityIds.length || row.excludedCapabilityIds.length,
+    ).length;
+    return `${assessment.summary.totalControls} published requirement entries across all eight strategies; ${mapped} have supporting Intune evidence mappings. Target level only; achieved maturity is not assessed.`;
+  }
   const total = assessment.framework.totalRequirements;
   if (total === undefined) return undefined;
   return `${assessment.summary.totalControls} of ${total} published requirements have Intune evidence mappings. Supporting evidence only; this is not a full assessment or compliance score.`;

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -6,6 +6,7 @@ import {
   compareControlIds,
   COMPLIANCE_RULESET_VERSION,
 } from "./engine";
+import { DEF_STAN_FAMILIES } from "./frameworks/def-stan-05-138";
 import type {
   CapabilityEvidence,
   CapabilityResult,
@@ -20,7 +21,10 @@ export type ComplianceFrameworkId =
   | "nist-csf-2"
   | "bsi-it-grundschutz"
   | "iso-27001-2022"
-  | "soc2-tsc";
+  | "soc2-tsc"
+  | "def-stan-05-138-i4"
+  | "cyber-essentials-v3"
+  | "nist-800-171-r2";
 
 type Locale = "en" | "de";
 type RgbColor = [number, number, number];
@@ -200,6 +204,9 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "bsi-it-grundschutz": "BSI-IT-Grundschutz",
       "iso-27001-2022": "ISO-27001",
       "soc2-tsc": "SOC-2",
+      "def-stan-05-138-i4": "Def-Stan-05-138",
+      "cyber-essentials-v3": "Cyber-Essentials",
+      "nist-800-171-r2": "NIST-800-171-R2",
     },
   },
   de: {
@@ -325,6 +332,9 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "bsi-it-grundschutz": "BSI-IT-Grundschutz",
       "iso-27001-2022": "ISO-27001",
       "soc2-tsc": "SOC-2",
+      "def-stan-05-138-i4": "Def-Stan-05-138",
+      "cyber-essentials-v3": "Cyber-Essentials",
+      "nist-800-171-r2": "NIST-800-171-R2",
     },
   },
 };
@@ -455,6 +465,9 @@ const FRAMEWORK_REPORT_CODES: Record<ComplianceFrameworkId, string> = {
   "bsi-it-grundschutz": "BSI",
   "iso-27001-2022": "ISO",
   "soc2-tsc": "SOC",
+  "def-stan-05-138-i4": "DEF",
+  "cyber-essentials-v3": "CE",
+  "nist-800-171-r2": "N171",
 };
 
 function frameworkReportCode(frameworkId: ComplianceFrameworkId): string {
@@ -568,7 +581,12 @@ function buildOverviewRows(
     const prefix =
       frameworkId === "nist-800-53-r5"
         ? control.control.id.split("-")[0]
-        : control.control.id.split(".")[0];
+        : frameworkId === "nist-800-171-r2"
+          ? control.control.id.split(".").slice(0, 2).join(".")
+          : frameworkId === "def-stan-05-138-i4"
+            ? (DEF_STAN_FAMILIES[control.control.id.slice(0, 2)] ??
+              control.control.id.slice(0, 2))
+            : control.control.id.split(".")[0];
     if (!prefix) continue;
     const existing = controlsByPrefix.get(prefix);
     if (existing) existing.push(control);

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -1,11 +1,16 @@
+import { assignmentDetails, summarizeAssignments } from "./assignments";
+import {
+  CONTROL_STATUS_LABELS,
+  CAPABILITY_STATUS_LABELS,
+  CONTROL_STATUS_COLORS,
+  CAPABILITY_STATUS_COLORS,
+  frameworkCoverageLabel,
+} from "./presentation";
+import { createEvidenceManifest } from "./manifest";
 import jsPDF from "jspdf";
 import type { BrandingOptions } from "~/types/branding";
 import type { DetailedExportData } from "../configuration-analyzer";
-import {
-  assessCompliance,
-  compareControlIds,
-  COMPLIANCE_RULESET_VERSION,
-} from "./engine";
+import { compareControlIds, COMPLIANCE_RULESET_VERSION } from "./engine";
 import { DEF_STAN_FAMILIES } from "./frameworks/def-stan-05-138";
 import type {
   CapabilityEvidence,
@@ -24,7 +29,8 @@ export type ComplianceFrameworkId =
   | "soc2-tsc"
   | "def-stan-05-138-i4"
   | "cyber-essentials-v3"
-  | "nist-800-171-r2";
+  | "nist-800-171-r2"
+  | "nist-800-171-r3";
 
 type Locale = "en" | "de";
 type RgbColor = [number, number, number];
@@ -68,7 +74,10 @@ interface ReportStrings {
   platformScope: string;
   controlStatuses: Record<ControlStatus, string>;
   capabilityStatuses: Record<CapabilityStatus, string>;
-  counterEvidenceStatuses: Record<"assigned" | "notAssigned", string>;
+  counterEvidenceStatuses: Record<
+    "assigned" | "notAssigned" | "unknown",
+    string
+  >;
   notAssigned: string;
   assigned: string;
   evidenceRefs: string;
@@ -126,7 +135,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     assignedDeviations: "Assigned deviating configurations",
     assignedDeviationsExplanation:
       "At least one assigned policy explicitly contradicts the target configuration.",
-    unassignedCompliant: "Compliant configurations without assignment",
+    unassignedCompliant: "Configured settings without assignment",
     unassignedCompliantExplanation:
       "The detected target configuration is not effective until it is assigned.",
     findingsHeading: "Key findings",
@@ -147,20 +156,22 @@ const STRINGS: Record<Locale, ReportStrings> = {
     incompleteCollection:
       "Data collection was incomplete. Assessment points without evidence may be caused by missing data.",
     noCollectionErrors: "No collection errors were provided.",
-    platformScope: "Platforms in scope",
+    platformScope: "Platforms observed in export",
     controlStatuses: {
+      ...CONTROL_STATUS_LABELS,
       evidenceFound: "Technical configuration evidence detected",
       partialEvidence: "Technical configuration evidence partially detected",
       noEvidence: "No supported technical configuration evidence detected",
     },
     capabilityStatuses: {
-      enforced: "Compliant configuration detected and assigned",
-      configuredNotAssigned:
-        "Compliant configuration detected, but not assigned",
+      ...CAPABILITY_STATUS_LABELS,
+      enforced: "Setting configured and assigned",
+      configuredNotAssigned: "Setting configured, but not assigned",
       disabledByPolicy: "Deviating configuration detected",
       noEvidence: "No evidence",
     },
     counterEvidenceStatuses: {
+      unknown: "Assignment unknown; effective scope unverified",
       assigned: "Deviating configuration detected and assigned (risk)",
       notAssigned: "Deviating configuration detected, but not assigned",
     },
@@ -170,7 +181,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     gapIntro:
       "No technical evidence was found. Possible implementation through these Intune settings:",
     disclaimer:
-      "This report documents technical evidence from the tenant's Microsoft Intune configuration. It is not a compliance certification or an IT Grundschutz check and does not replace an audit. Missing evidence means that no supported and effectively assigned configuration was detected in the evaluated dataset.",
+      "This report documents technical evidence from the tenant's Microsoft Intune configuration. It is not a compliance certification or an IT Grundschutz check and does not replace an audit. Missing evidence means that no supported configuration with a known assignment was detected in the evaluated dataset.",
     appendixHeading: "Appendix A: Evidence Register",
     appendixContinuation: "Appendix A (continued)",
     appendixHeaders: [
@@ -184,7 +195,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     appendixNote:
       "Referenced assessment points for each item of evidence are listed in the relevant sections.",
     methodology:
-      "Evidence is determined exclusively from concrete Intune settings: An assessment point is considered technically evidenced only when a recognized setting is configured with a value defined as compliant and the policy is assigned. Configurations that explicitly contradict the target state are reported separately. Unsupported settings or settings that cannot be mapped unambiguously remain unassessed. Organizational requirements are not part of this automated technical assessment and must be assessed separately.",
+      "Evidence is determined exclusively from concrete Intune settings: An assessment point is considered technically evidenced only when a recognized setting is configured with a recognized value and the policy is assigned. Configurations that explicitly contradict the target state are reported separately. Unsupported settings or settings that cannot be mapped unambiguously remain unassessed. Organizational requirements are not part of this automated technical assessment and must be assessed separately.",
     footer: "Generated with Intune Documentation (intunedocumentation.com)",
     methodologyHeading: "Methodology",
     notePrefix: "Note: ",
@@ -207,6 +218,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "def-stan-05-138-i4": "Def-Stan-05-138",
       "cyber-essentials-v3": "Cyber-Essentials",
       "nist-800-171-r2": "NIST-800-171-R2",
+      "nist-800-171-r3": "NIST-800-171-R3",
     },
   },
   de: {
@@ -253,7 +265,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     assignedDeviations: "Abweichende Konfigurationen (zugewiesen)",
     assignedDeviationsExplanation:
       "Mindestens eine zugewiesene Richtlinie widerspricht der Sollkonfiguration.",
-    unassignedCompliant: "Konforme Konfigurationen ohne Zuweisung",
+    unassignedCompliant: "Konfigurierte Einstellungen ohne Zuweisung",
     unassignedCompliantExplanation:
       "Die erkannte Sollkonfiguration ist ohne Zuweisung nicht wirksam.",
     findingsHeading: "Wesentliche Feststellungen",
@@ -274,21 +286,33 @@ const STRINGS: Record<Locale, ReportStrings> = {
     incompleteCollection:
       "Die Datenerhebung war unvollständig. Prüfpunkte ohne Nachweis können auf fehlende Daten zurückgehen.",
     noCollectionErrors: "Keine Erhebungsfehler übermittelt.",
-    platformScope: "Plattformen im Geltungsbereich",
+    platformScope: "Im Export erkannte Plattformen",
     controlStatuses: {
+      ...CONTROL_STATUS_LABELS,
+      notApplicable: "Außerhalb des gewählten Geltungsbereichs",
+      notAssessed: "Nicht bewertet",
+      conflictingEvidence: "Widersprüchliche Richtliniennachweise",
       evidenceFound: "Technischer Konfigurationsnachweis erkannt",
       partialEvidence: "Technischer Konfigurationsnachweis teilweise erkannt",
       noEvidence:
         "Kein unterstützter technischer Konfigurationsnachweis erkannt",
     },
     capabilityStatuses: {
-      enforced: "Konforme Konfiguration erkannt und zugewiesen",
+      ...CAPABILITY_STATUS_LABELS,
+      requirementAssigned: "Konformitätsanforderung zugewiesen",
+      assignmentUnknown: "Zuweisung unbekannt",
+      conflictingEvidence: "Widersprüchliche Richtliniennachweise",
+      partialConfiguration: "Erforderliche Einstellungen teilweise vorhanden",
+      collectionIncomplete: "Datenerhebung unvollständig",
+      notApplicable: "Außerhalb des Geltungsbereichs",
+      enforced: "Einstellung konfiguriert und zugewiesen",
       configuredNotAssigned:
-        "Konforme Konfiguration erkannt, jedoch nicht zugewiesen",
+        "Einstellung konfiguriert, jedoch nicht zugewiesen",
       disabledByPolicy: "Abweichende Konfiguration erkannt",
       noEvidence: "Kein Nachweis",
     },
     counterEvidenceStatuses: {
+      unknown: "Assignment unknown; effective scope unverified",
       assigned: "Abweichende Konfiguration erkannt und zugewiesen (Risiko)",
       notAssigned: "Abweichende Konfiguration erkannt, jedoch nicht zugewiesen",
     },
@@ -312,7 +336,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
     appendixNote:
       "Referenzierte Prüfpunkte je Nachweis sind den Abschnitten zu entnehmen.",
     methodology:
-      "Nachweise werden ausschließlich anhand konkreter Intune-Einstellungen ermittelt: Ein Prüfpunkt gilt nur dann als technisch nachgewiesen, wenn eine erkannte Einstellung mit einem als konform definierten Wert konfiguriert und die Richtlinie zugewiesen ist. Konfigurationen, die der Sollvorgabe ausdrücklich widersprechen, werden gesondert ausgewiesen. Nicht unterstützte oder nicht eindeutig zuordenbare Einstellungen bleiben unbewertet. Organisatorische Anforderungen sind nicht Teil dieser automatisierten technischen Prüfung und müssen separat bewertet werden.",
+      "Nachweise werden ausschließlich anhand konkreter Intune-Einstellungen ermittelt: Ein Prüfpunkt gilt nur dann als technisch nachgewiesen, wenn eine erkannte Einstellung mit einem erkannten Sollwert konfiguriert und die Richtlinie zugewiesen ist. Konfigurationen, die der Sollvorgabe ausdrücklich widersprechen, werden gesondert ausgewiesen. Nicht unterstützte oder nicht eindeutig zuordenbare Einstellungen bleiben unbewertet. Organisatorische Anforderungen sind nicht Teil dieser automatisierten technischen Prüfung und müssen separat bewertet werden.",
     footer: "Erstellt mit Intune Documentation (intunedocumentation.com)",
     methodologyHeading: "Methodik",
     notePrefix: "Hinweis: ",
@@ -335,11 +359,30 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "def-stan-05-138-i4": "Def-Stan-05-138",
       "cyber-essentials-v3": "Cyber-Essentials",
       "nist-800-171-r2": "NIST-800-171-R2",
+      "nist-800-171-r3": "NIST-800-171-R3",
     },
   },
 };
 
 export const GERMAN_CAPABILITY_NAMES: Readonly<Record<string, string>> = {
+  "windows-antivirus-required": "Antivirenschutz als Konformitätsanforderung",
+  "windows-periodic-antimalware-scan": "Regelmäßige Schadsoftwareprüfungen",
+  "windows-quality-update-deadline": "Qualitätsupdate-Frist bis 14 Tage",
+  "windows-application-control": "Anwendungssteuerung im Erzwingungsmodus",
+  "windows-behavior-monitoring": "Verhaltensüberwachung",
+  "windows-network-inspection": "Netzwerkprüfung gegen Schadsoftware",
+  "windows-memory-integrity": "Speicherintegrität (HVCI)",
+  "windows-virtualization-security": "Virtualisierungsbasierte Sicherheit",
+  "windows-credential-guard": "Credential Guard konfiguriert",
+  "windows-credential-theft-protection":
+    "Schutz vor Diebstahl von Anmeldeinformationen",
+  "tenant-mfa-required": "MFA-Anforderung durch bedingten Zugriff",
+  "tenant-compliant-device-required":
+    "Gerätekonformität durch bedingten Zugriff",
+  "ios-app-data-transfer":
+    "Datentransferbeschränkungen für verwaltete iOS-Apps",
+  "android-app-data-transfer":
+    "Datentransferbeschränkungen für verwaltete Android-Apps",
   "windows-disk-encryption": "Festplattenverschlüsselung (BitLocker)",
   "windows-realtime-antimalware":
     "Echtzeitschutz durch Microsoft Defender Antivirus",
@@ -367,19 +410,6 @@ export const GERMAN_CAPABILITY_NAMES: Readonly<Record<string, string>> = {
   "android-app-source-restriction":
     "Blockierung unbekannter App-Quellen (Android)",
   "android-minimum-os-version": "Mindestversion des Betriebssystems (Android)",
-};
-
-const CONTROL_STATUS_COLORS: Record<ControlStatus, RgbColor> = {
-  evidenceFound: [31, 133, 83],
-  partialEvidence: [196, 113, 31],
-  noEvidence: [105, 112, 119],
-};
-
-const CAPABILITY_STATUS_COLORS: Record<CapabilityStatus, RgbColor> = {
-  enforced: [31, 133, 83],
-  configuredNotAssigned: [196, 113, 31],
-  disabledByPolicy: [190, 45, 45],
-  noEvidence: [105, 112, 119],
 };
 
 const ASSIGNED_COUNTER_EVIDENCE_COLOR: RgbColor = [190, 45, 45];
@@ -415,6 +445,42 @@ function translateEvidenceValue(value: string, locale: Locale): string {
 function translateEvidenceNote(value: string, locale: Locale): string {
   if (locale !== "de") return value;
   return GERMAN_COMPLIANCE_NOTE_TRANSLATIONS[value] ?? value;
+}
+
+function translateAssessmentLimitation(text: string): string {
+  const translations: Record<string, string> = {
+    "Assignment data is unavailable for some matching policies; effective targeting remains unknown.":
+      "Für einige passende Richtlinien fehlen Zuweisungsdaten; der tatsächliche Zielumfang bleibt unbekannt.",
+    "These settings support part of this control. Remaining technical and organizational requirements need separate assessment.":
+      "Diese Einstellungen liefern Teilnachweise. Weitere technische und organisatorische Anforderungen sind separat zu bewerten.",
+    "Relevant policy collection is incomplete; additional or contradictory evidence may be missing.":
+      "Die relevante Datenerhebung ist unvollständig. Weitere oder widersprüchliche Nachweise können fehlen.",
+    "Mixed policy evidence. Review profile settings and targeting overlap; a device conflict has not been established.":
+      "Widersprüchliche Richtliniennachweise. Profileinstellungen und überlappende Zuweisungen prüfen; ein Gerätekonflikt wurde nicht nachgewiesen.",
+    "Not all required settings are present together on an assigned policy.":
+      "Nicht alle erforderlichen Einstellungen sind gemeinsam in einer zugewiesenen Richtlinie vorhanden.",
+    "A minimum version is configured; whether it is current is not assessed.":
+      "Eine Mindestversion ist konfiguriert; ob sie aktuell ist, wird nicht bewertet.",
+    "No detector is available for this control in the selected platform scope.":
+      "Für diesen Prüfpunkt ist im gewählten Plattformumfang keine Erkennungsregel verfügbar.",
+    "Hardware support and installed OS security-update support are not verified. A configured minimum version does not establish currency.":
+      "Hardware-Unterstützung und Sicherheitsupdates für das installierte Betriebssystem sind nicht geprüft. Eine Mindestversion belegt keine Aktualität.",
+    "XProtect status, installed software and actual activation of macOS protections are unassessed.":
+      "XProtect-Status, installierte Software und tatsächliche Aktivierung der macOS-Schutzfunktionen sind unbewertet.",
+    "FileVault recovery key custody and storage location are unassessed.":
+      "Verwahrung und Speicherort der FileVault-Wiederherstellungsschlüssel sind unbewertet.",
+    "LSA protected-mode monitoring and applicable RDP restrictions are unassessed.":
+      "Überwachung des geschützten LSA-Modus und erforderliche RDP-Beschränkungen sind unbewertet.",
+    "Passcode complexity, lock timeout and effective device enforcement require separate review.":
+      "Code-Komplexität, Sperrfrist und tatsächliche Durchsetzung am Gerät sind separat zu prüfen.",
+    "Installed OS and app support, actual patch installation and replacement of unsupported devices are unassessed.":
+      "Support für Betriebssystem und Apps, tatsächliche Update-Installation und Ersatz nicht mehr unterstützter Geräte sind unbewertet.",
+    "Approved device models and organizational authorization are unassessed.":
+      "Freigegebene Gerätemodelle und organisatorische Genehmigungen sind unbewertet.",
+    "Alerts, wipe and lock actions, grace periods and effective Conditional Access coverage require separate review.":
+      "Warnungen, Lösch- und Sperraktionen, Karenzfristen und tatsächlicher Geltungsbereich des bedingten Zugriffs sind separat zu prüfen.",
+  };
+  return translations[text] ?? text;
 }
 
 function formatReportDate(date: Date, locale: Locale): string {
@@ -468,6 +534,7 @@ const FRAMEWORK_REPORT_CODES: Record<ComplianceFrameworkId, string> = {
   "def-stan-05-138-i4": "DEF",
   "cyber-essentials-v3": "CE",
   "nist-800-171-r2": "N171",
+  "nist-800-171-r3": "N171R3",
 };
 
 function frameworkReportCode(frameworkId: ComplianceFrameworkId): string {
@@ -533,11 +600,18 @@ interface OverviewRow {
   evidenceFound: number;
   partialEvidence: number;
   noEvidence: number;
+  notAssessed: number;
+  conflictingEvidence: number;
+  notApplicable: number;
 }
 
 function evidenceRegistryKey(evidence: CapabilityEvidence): string {
   return JSON.stringify([
     evidence.policyId,
+    evidence.policyType,
+    evidence.familyKey,
+    evidence.kind,
+    evidence.source,
     evidence.settingId,
     evidence.observedValue,
     evidence.verdict,
@@ -554,6 +628,13 @@ function controlStatusCounts(
       (item) => item.status === "partialEvidence",
     ).length,
     noEvidence: controls.filter((item) => item.status === "noEvidence").length,
+    notAssessed: controls.filter((item) => item.status === "notAssessed")
+      .length,
+    conflictingEvidence: controls.filter(
+      (item) => item.status === "conflictingEvidence",
+    ).length,
+    notApplicable: controls.filter((item) => item.status === "notApplicable")
+      .length,
   };
 }
 
@@ -581,7 +662,7 @@ function buildOverviewRows(
     const prefix =
       frameworkId === "nist-800-53-r5"
         ? control.control.id.split("-")[0]
-        : frameworkId === "nist-800-171-r2"
+        : frameworkId === "nist-800-171-r2" || frameworkId === "nist-800-171-r3"
           ? control.control.id.split(".").slice(0, 2).join(".")
           : frameworkId === "def-stan-05-138-i4"
             ? (DEF_STAN_FAMILIES[control.control.id.slice(0, 2)] ??
@@ -658,9 +739,13 @@ function implementationSignals(results: readonly CapabilityResult[]): string[] {
     for (const signal of result.capability.signals) {
       if (signal.source === "settingsCatalog") {
         signals.add(signal.settingDefinitionId);
-      } else {
+      } else if (signal.source === "graphProperty") {
         const odataType = signal.odataTypes[0];
         if (odataType) signals.add(`${odataType}.${signal.propertyPath}`);
+      } else if (signal.source === "policyCheck") {
+        signals.add(signal.check);
+      } else {
+        signals.add(signal.settingId);
       }
     }
   }
@@ -692,7 +777,8 @@ export async function generateComplianceReportPDF(
   const accentColor = hexToRgb(branding?.colors?.accent, [0, 166, 82]);
   const textColor = hexToRgb(branding?.colors?.text, [30, 30, 30]);
 
-  const assessment = assessCompliance(data);
+  const manifest = await createEvidenceManifest(data);
+  const assessment = manifest.assessment;
   const framework = assessment.frameworks.find(
     (item) => item.framework.id === options.frameworkId,
   );
@@ -957,7 +1043,13 @@ export async function generateComplianceReportPDF(
   const markerForCapabilityStatus = (status: CapabilityStatus): MarkerKind =>
     status === "enforced"
       ? "filled"
-      : status === "configuredNotAssigned"
+      : [
+            "configuredNotAssigned",
+            "requirementAssigned",
+            "assignmentUnknown",
+            "collectionIncomplete",
+            "partialConfiguration",
+          ].includes(status)
         ? "half"
         : status === "disabledByPolicy"
           ? "triangle"
@@ -967,6 +1059,7 @@ export async function generateComplianceReportPDF(
     headers: readonly string[],
     rows: readonly (readonly string[])[],
     widths: readonly number[],
+    heading?: string,
   ) => {
     const headerHeight = 8;
     const rowLayouts = rows.map((row) => {
@@ -983,7 +1076,15 @@ export async function generateComplianceReportPDF(
     });
     const totalHeight =
       headerHeight + rowLayouts.reduce((sum, row) => sum + row.height, 0) + 5;
-    ensureSpace(totalHeight);
+    ensureSpace(totalHeight + (heading ? 12 : 0));
+    if (heading)
+      drawWrappedText(heading, {
+        fontSize: 10,
+        style: "bold",
+        color: primaryColor,
+        lineHeight: 4.5,
+        after: 1,
+      });
 
     doc.setFillColor(...primaryColor);
     doc.rect(margin, yPosition, contentWidth, headerHeight, "F");
@@ -1098,7 +1199,11 @@ export async function generateComplianceReportPDF(
       : UNASSIGNED_COUNTER_EVIDENCE_COLOR;
     const assignment = assigned
       ? strings.assigned.toLowerCase()
-      : strings.notAssigned.toLowerCase();
+      : evidence.assignment.state === "unknown"
+        ? locale === "de"
+          ? "Zuweisung unbekannt"
+          : "assignment unknown"
+        : strings.notAssigned.toLowerCase();
     const refPrefix =
       locale === "de"
         ? assigned
@@ -1183,23 +1288,13 @@ export async function generateComplianceReportPDF(
 
     const buildRow = (entry: EvidenceRegistryEntry) => {
       const { evidence } = entry;
-      const maxTargets = 6;
-      const targetLabels = evidence.assignment.targets.map((target) =>
-        translateEvidenceValue(target, locale),
+
+      const targetLabels = assignmentDetails(evidence.assignment).map(
+        (target) => translateEvidenceValue(target, locale),
       );
-      const shownTargets =
-        targetLabels.length > maxTargets
-          ? [
-              ...targetLabels.slice(0, maxTargets),
-              locale === "de"
-                ? `+${targetLabels.length - maxTargets} weitere`
-                : `+${targetLabels.length - maxTargets} more`,
-            ]
-          : targetLabels;
+      const shownTargets = targetLabels;
       const assignment =
-        evidence.assignment.state === "assigned" && shownTargets.length > 0
-          ? shownTargets.join(", ")
-          : strings.notAssigned;
+        shownTargets.length > 0 ? shownTargets.join(", ") : strings.notAssigned;
       const cells = [
         [entry.ref],
         wrap(evidence.policyName, widths[1] - 3, 7),
@@ -1213,7 +1308,7 @@ export async function generateComplianceReportPDF(
         wrap(assignment, widths[5] - 3, 7),
       ];
       const policyIdLines = wrapTechnicalId(
-        evidence.policyId || "-",
+        `${evidence.policyId || "-"}; ${evidence.kind}; version ${evidence.policyVersion ?? "unknown"}; modified ${evidence.policyModifiedAt ?? "unknown"}`,
         widths[1] - 3,
       );
       const mainLineCount = Math.max(...cells.map((cell) => cell.length));
@@ -1364,7 +1459,7 @@ export async function generateComplianceReportPDF(
       ? "BSI IT-Grundschutz-Kompendium, Edition 2023"
       : options.frameworkId === "iso-27001-2022"
         ? "ISO/IEC 27001:2022, Annex A"
-      : `${framework.framework.name} ${framework.framework.version}`;
+        : `${framework.framework.name} ${framework.framework.version}`;
   doc.text(frameworkDisplay, pageWidth / 2, frameworkY, { align: "center" });
 
   const subtitleLines = wrap(
@@ -1486,6 +1581,19 @@ export async function generateComplianceReportPDF(
   addContentPage();
 
   drawRecordedSectionHeading(strings.summaryHeading);
+  const coverageLabel = frameworkCoverageLabel(framework);
+  if (coverageLabel)
+    drawWrappedText(coverageLabel, {
+      fontSize: 9,
+      style: "bold",
+      after: 4,
+    });
+  drawWrappedText(
+    locale === "de"
+      ? `${framework.summary.applicableControls} im Geltungsbereich; ${framework.summary.notApplicable} außerhalb; ${framework.summary.notAssessed} unbewertet; ${framework.summary.conflicting} mit widersprüchlichen Nachweisen. Ausgewählte Zuordnungen, keine vollständige Rahmenwerksbewertung.`
+      : `${framework.summary.applicableControls} in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed policy evidence. Entries are selected mappings, not full framework coverage.`,
+    { fontSize: 8, after: 4 },
+  );
   drawWrappedText(strings.summaryCounts(framework), {
     fontSize: 10,
     style: "bold",
@@ -1534,14 +1642,22 @@ export async function generateComplianceReportPDF(
   drawRecordedSectionHeading(strings.resultsHeading);
   const overviewRows = buildOverviewRows(options.frameworkId, controls);
   drawGridTable(
-    strings.resultsHeaders,
+    [
+      ...strings.resultsHeaders,
+      locale === "de" ? "Unbewertet" : "Unassessed",
+      locale === "de" ? "Gemischt" : "Mixed",
+      locale === "de" ? "Außerhalb" : "Out of scope",
+    ],
     overviewRows.map((row) => [
       row.label,
       String(row.evidenceFound),
       String(row.partialEvidence),
       String(row.noEvidence),
+      String(row.notAssessed),
+      String(row.conflictingEvidence),
+      String(row.notApplicable),
     ]),
-    [96, 28, 28, 28],
+    [60, 20, 20, 20, 20, 20, 20],
   );
 
   const controlIdsByCapability = new Map<string, string[]>();
@@ -1637,8 +1753,8 @@ export async function generateComplianceReportPDF(
     if (ids.length === 0) continue;
     findings.push(
       locale === "de"
-        ? `${capabilityName(result)}: Konforme Konfiguration ohne Zuweisung für ${ids.join(", ")}.`
-        : `${capabilityName(result)}: Compliant configuration without assignment affects ${ids.join(", ")}.`,
+        ? `${capabilityName(result)}: Konfigurierte Einstellung ohne Zuweisung für ${ids.join(", ")}.`
+        : `${capabilityName(result)}: Configured setting without assignment affects ${ids.join(", ")}.`,
     );
   }
   const prioritizedFindings = findings.slice(0, 5);
@@ -1676,13 +1792,6 @@ export async function generateComplianceReportPDF(
     { fontSize: 8.5, style: "bold", after: 4 },
   );
 
-  drawWrappedText(strings.inventoryHeading, {
-    fontSize: 10,
-    style: "bold",
-    color: primaryColor,
-    lineHeight: 4.5,
-    after: 1,
-  });
   const inventoryKeys = [
     "settingsCatalog",
     "deviceConfigurations",
@@ -1690,7 +1799,12 @@ export async function generateComplianceReportPDF(
   ] as const;
   const countAssigned = (items: Array<Record<string, unknown>>): number =>
     items.filter(
-      (item) => Array.isArray(item.assignments) && item.assignments.length > 0,
+      (item) =>
+        summarizeAssignments(
+          item.assignments,
+          undefined,
+          (item.collectionStatus as any)?.assignments === "incomplete",
+        ).state === "assigned",
     ).length;
   const familyCounts = inventoryKeys.map((key) => familyItems(data, key));
   const inventoryRows = inventoryKeys.map((key, index) => {
@@ -1704,7 +1818,10 @@ export async function generateComplianceReportPDF(
   // The engine assesses every collected policy family; list the remainder so
   // the provenance section never understates the assessed inventory.
   const allItems = allPolicyItems(data);
-  const familyTotal = familyCounts.reduce((sum, items) => sum + items.length, 0);
+  const familyTotal = familyCounts.reduce(
+    (sum, items) => sum + items.length,
+    0,
+  );
   const otherCount = allItems.length - familyTotal;
   if (otherCount > 0) {
     const otherAssigned =
@@ -1716,7 +1833,12 @@ export async function generateComplianceReportPDF(
       String(Math.max(otherAssigned, 0)),
     ]);
   }
-  drawGridTable(strings.inventoryHeaders, inventoryRows, [108, 30, 42]);
+  drawGridTable(
+    strings.inventoryHeaders,
+    inventoryRows,
+    [108, 30, 42],
+    strings.inventoryHeading,
+  );
 
   drawWrappedText(strings.collectionHeading, {
     fontSize: 10,
@@ -1725,6 +1847,52 @@ export async function generateComplianceReportPDF(
     lineHeight: 4.5,
     after: 1,
   });
+  drawWrappedText(
+    locale === "de"
+      ? `Erhoben: ${assessment.provenance.collectedAt ?? "unbekannt"}; Regelwerk ${assessment.provenance.rulesetVersion}. Gerätezustand nicht erhoben; tatsächlicher Zugriff nicht geprüft.`
+      : `Collected: ${assessment.provenance.collectedAt ?? "unknown"}; ruleset ${assessment.provenance.rulesetVersion}. Device state not collected; effective access unverified.`,
+    { fontSize: 8, after: 3 },
+  );
+  drawWrappedText(
+    `${locale === "de" ? "Geltungsbereich" : "Scope"}: ${(assessment.scope.platforms ?? ["windows", "macos", "ios", "android"]).join(", ")}${options.frameworkId === "def-stan-05-138-i4" ? `; Cyber Risk Profile: ${assessment.scope.defStanRiskLevel ?? "all levels"}` : ""}.`,
+    { fontSize: 8, after: 3 },
+  );
+  drawWrappedText(
+    `${locale === "de" ? "Datenstand" : "Snapshot"} SHA-256: ${manifest.snapshotSha256}`,
+    {
+      fontSize: 7,
+      after: 2,
+    },
+  );
+  drawWrappedText(
+    `${locale === "de" ? "Regelwerk" : "Ruleset"} SHA-256: ${manifest.rulesetSha256}`,
+    {
+      fontSize: 7,
+      after: 3,
+    },
+  );
+  if (framework.framework.source)
+    drawWrappedText(
+      `${locale === "de" ? "Herausgeberquelle" : "Publisher reference"}: ${framework.framework.source.url}`,
+      {
+        fontSize: 7,
+        after: 3,
+      },
+    );
+  for (const row of assessment.collectionCoverage)
+    drawWrappedText(
+      (locale === "de"
+        ? `${row.family}: Erhebung ${{ complete: "vollständig", incomplete: "unvollständig", unknown: "unbekannt", notCollected: "nicht erhoben" }[row.status]}; ${row.collectedPolicies} Richtlinien; ${row.recognizedPolicies} mit erkanntem Nachweis; ${row.unsupportedPolicies} ohne erkannten Nachweis. `
+        : `${row.family}: collection ${row.status}; ${row.collectedPolicies} policies; ${row.recognizedPolicies} with recognized evidence; ${row.unsupportedPolicies} without recognized evidence. `) +
+        row.errors
+          .map((message) =>
+            locale === "de"
+              ? message.replaceAll("Settings Catalog", "Einstellungskatalog")
+              : message,
+          )
+          .join("; "),
+      { fontSize: 7, lineHeight: 3.3, after: 2 },
+    );
   const fetchErrors = data.fetchErrors ?? [];
   if (fetchErrors.length > 0) {
     const warningLines = [
@@ -1888,6 +2056,12 @@ export async function generateComplianceReportPDF(
         controlId: control.control.id,
       },
     );
+
+    for (const aspect of control.unassessedAspects)
+      drawWrappedText(
+        `${locale === "de" ? "Noch zu bewerten" : "Still to assess"}: ${locale === "de" ? translateAssessmentLimitation(aspect) : aspect}`,
+        { fontSize: 7.5, lineHeight: 3.4, after: 2 },
+      );
 
     for (const result of mappedCapabilities) {
       const resultTextHeight = capabilityTextHeight(result);

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -1544,13 +1544,24 @@ export async function generateComplianceReportPDF(
     [96, 28, 28, 28],
   );
 
-  const assignedDeviations = assessment.capabilities.filter((result) =>
+  const controlIdsByCapability = new Map<string, string[]>();
+  for (const control of controls) {
+    for (const capabilityId of control.capabilityIds) {
+      const ids = controlIdsByCapability.get(capabilityId);
+      if (ids) ids.push(control.control.id);
+      else controlIdsByCapability.set(capabilityId, [control.control.id]);
+    }
+  }
+  const frameworkCapabilities = assessment.capabilities.filter((result) =>
+    controlIdsByCapability.has(result.capability.id),
+  );
+  const assignedDeviations = frameworkCapabilities.filter((result) =>
     result.evidence.some(
       (item) =>
         item.verdict === "disabled" && item.assignment.state === "assigned",
     ),
   );
-  const unassignedCompliant = assessment.capabilities.filter(
+  const unassignedCompliant = frameworkCapabilities.filter(
     (result) => result.status === "configuredNotAssigned",
   );
   drawWrappedText(
@@ -1591,14 +1602,6 @@ export async function generateComplianceReportPDF(
     lineHeight: 4.5,
     after: 1,
   });
-  const controlIdsByCapability = new Map<string, string[]>();
-  for (const control of controls) {
-    for (const capabilityId of control.capabilityIds) {
-      const ids = controlIdsByCapability.get(capabilityId);
-      if (ids) ids.push(control.control.id);
-      else controlIdsByCapability.set(capabilityId, [control.control.id]);
-    }
-  }
   const capabilityName = (result: CapabilityResult) =>
     locale === "de"
       ? (GERMAN_CAPABILITY_NAMES[result.capability.id] ??

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -1342,7 +1342,34 @@ export async function generateComplianceReportPDF(
       };
     };
 
-    const rows = evidenceRegistry.map(buildRow);
+    const maxRowLines = Math.floor(
+      (contentBottom - 18 - 5 - headerHeight - 5) / lineHeight,
+    );
+    const rows = evidenceRegistry.flatMap((entry) => {
+      const row = buildRow(entry);
+      if (row.height <= maxRowLines * lineHeight + 5) return [row];
+      // Large Conditional Access conditions (and long policy values) must flow
+      // across pages rather than extend beyond the printable area.
+      const cells = row.cells.map((lines, index) =>
+        index === 1 ? [...lines, ...row.policyIdLines] : lines,
+      );
+      const lineCount = Math.max(...cells.map((lines) => lines.length));
+      const chunks = [];
+      for (let offset = 0; offset < lineCount; offset += maxRowLines) {
+        const chunkCells = cells.map((lines, index) =>
+          index === 0 ? [entry.ref] : lines.slice(offset, offset + maxRowLines),
+        );
+        chunks.push({
+          ...row,
+          cells: chunkCells,
+          policyIdLines: [],
+          height:
+            Math.max(...chunkCells.map((lines) => lines.length)) * lineHeight +
+            5,
+        });
+      }
+      return chunks;
+    });
     const drawAppendixContinuationCaption = () => {
       doc.setFont("helvetica", "italic");
       doc.setFontSize(7.5);

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -30,7 +30,8 @@ export type ComplianceFrameworkId =
   | "def-stan-05-138-i4"
   | "cyber-essentials-v3"
   | "nist-800-171-r2"
-  | "nist-800-171-r3";
+  | "nist-800-171-r3"
+  | "essential-eight";
 
 type Locale = "en" | "de";
 type RgbColor = [number, number, number];
@@ -217,6 +218,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "soc2-tsc": "SOC-2",
       "def-stan-05-138-i4": "Def-Stan-05-138",
       "cyber-essentials-v3": "Cyber-Essentials",
+      "essential-eight": "Essential-Eight",
       "nist-800-171-r2": "NIST-800-171-R2",
       "nist-800-171-r3": "NIST-800-171-R3",
     },
@@ -358,6 +360,7 @@ const STRINGS: Record<Locale, ReportStrings> = {
       "soc2-tsc": "SOC-2",
       "def-stan-05-138-i4": "Def-Stan-05-138",
       "cyber-essentials-v3": "Cyber-Essentials",
+      "essential-eight": "Essential-Eight",
       "nist-800-171-r2": "NIST-800-171-R2",
       "nist-800-171-r3": "NIST-800-171-R3",
     },
@@ -365,6 +368,14 @@ const STRINGS: Record<Locale, ReportStrings> = {
 };
 
 export const GERMAN_CAPABILITY_NAMES: Readonly<Record<string, string>> = {
+  "windows-office-macro-win32-block":
+    "Win32-Aufrufe durch Office-Makros blockiert",
+  "windows-office-child-process-block": "Unterprozesse von Office blockiert",
+  "windows-office-executable-block": "Ausführbare Office-Inhalte blockiert",
+  "windows-office-injection-block": "Prozessinjektion durch Office blockiert",
+  "windows-adobe-child-process-block":
+    "Unterprozesse von Adobe Reader blockiert",
+
   "windows-antivirus-required": "Antivirenschutz als Konformitätsanforderung",
   "windows-periodic-antimalware-scan": "Regelmäßige Schadsoftwareprüfungen",
   "windows-quality-update-deadline": "Qualitätsupdate-Frist bis 14 Tage",
@@ -533,6 +544,7 @@ const FRAMEWORK_REPORT_CODES: Record<ComplianceFrameworkId, string> = {
   "soc2-tsc": "SOC",
   "def-stan-05-138-i4": "DEF",
   "cyber-essentials-v3": "CE",
+  "essential-eight": "E8",
   "nist-800-171-r2": "N171",
   "nist-800-171-r3": "N171R3",
 };
@@ -660,14 +672,17 @@ function buildOverviewRows(
   const controlsByPrefix = new Map<string, ControlAssessment[]>();
   for (const control of controls) {
     const prefix =
-      frameworkId === "nist-800-53-r5"
-        ? control.control.id.split("-")[0]
-        : frameworkId === "nist-800-171-r2" || frameworkId === "nist-800-171-r3"
-          ? control.control.id.split(".").slice(0, 2).join(".")
-          : frameworkId === "def-stan-05-138-i4"
-            ? (DEF_STAN_FAMILIES[control.control.id.slice(0, 2)] ??
-              control.control.id.slice(0, 2))
-            : control.control.id.split(".")[0];
+      frameworkId === "essential-eight"
+        ? control.control.title
+        : frameworkId === "nist-800-53-r5"
+          ? control.control.id.split("-")[0]
+          : frameworkId === "nist-800-171-r2" ||
+              frameworkId === "nist-800-171-r3"
+            ? control.control.id.split(".").slice(0, 2).join(".")
+            : frameworkId === "def-stan-05-138-i4"
+              ? (DEF_STAN_FAMILIES[control.control.id.slice(0, 2)] ??
+                control.control.id.slice(0, 2))
+              : control.control.id.split(".")[0];
     if (!prefix) continue;
     const existing = controlsByPrefix.get(prefix);
     if (existing) existing.push(control);
@@ -756,9 +771,14 @@ function implementationSignals(results: readonly CapabilityResult[]): string[] {
 export function complianceReportFileName(
   frameworkId: ComplianceFrameworkId,
   tenantLabel?: string,
+  essentialEightMaturityLevel: 1 | 2 | 3 = 1,
 ): string {
   const now = new Date();
-  const frameworkLabel = STRINGS.en.fileFrameworkLabels[frameworkId];
+  const frameworkLabel =
+    STRINGS.en.fileFrameworkLabels[frameworkId] +
+    (frameworkId === "essential-eight"
+      ? `-ML${essentialEightMaturityLevel}`
+      : "");
   const slug = tenantLabel ? tenantSlug(tenantLabel) : "";
   const tenantPart = slug ? `-${slug}` : "";
   return `Compliance-Report-${frameworkLabel}${tenantPart}-${localIsoDate(now)}-${localTime(now)}.pdf`;
@@ -2004,9 +2024,17 @@ export async function generateComplianceReportPDF(
         6
       );
     };
+    const requirementText =
+      options.frameworkId === "essential-eight"
+        ? control.control.summary
+        : undefined;
+    const requirementHeight = requirementText
+      ? wrap(requirementText, contentWidth, 9, "normal").length * 4 + 3
+      : 0;
     const firstCapability = mappedCapabilities[0];
     const minimumControlStartHeight =
       controlHeadingHeight +
+      requirementHeight +
       controlStatusHeight +
       (firstCapability
         ? wrap(capabilityName(firstCapability), contentWidth, 9.5, "bold")
@@ -2021,6 +2049,7 @@ export async function generateComplianceReportPDF(
       );
       const fullControlHeight =
         controlHeadingHeight +
+        requirementHeight +
         controlStatusHeight +
         capabilityHeight +
         gapHeight;
@@ -2056,6 +2085,13 @@ export async function generateComplianceReportPDF(
         controlId: control.control.id,
       },
     );
+
+    if (requirementText)
+      drawWrappedText(requirementText, {
+        fontSize: 9,
+        lineHeight: 4,
+        after: 3,
+      });
 
     for (const aspect of control.unassessedAspects)
       drawWrappedText(

--- a/src/lib/compliance/report-pdf.ts
+++ b/src/lib/compliance/report-pdf.ts
@@ -1989,6 +1989,7 @@ export async function generateComplianceReportPDF(
     });
   }
 
+  const recordedStrategies = new Set<string>();
   for (const control of controls) {
     const tier = control.control.tier ? ` (${control.control.tier})` : "";
     const controlHeading = `${control.control.id} ${control.control.title}${tier}`;
@@ -2060,11 +2061,19 @@ export async function generateComplianceReportPDF(
       ensureSpace(minimumControlStartHeight);
     }
 
-    tocEntries.push({
-      title: `${control.control.id} ${control.control.title}`,
-      page: doc.internal.getCurrentPageInfo().pageNumber,
-      level: 1,
-    });
+    // Essential Eight has up to 149 requirements. Index the eight strategies
+    // at their first requirement so the contents stay readable on one page.
+    const isEssentialEight = options.frameworkId === "essential-eight";
+    if (!isEssentialEight || !recordedStrategies.has(control.control.title)) {
+      tocEntries.push({
+        title: isEssentialEight
+          ? control.control.title
+          : `${control.control.id} ${control.control.title}`,
+        page: doc.internal.getCurrentPageInfo().pageNumber,
+        level: 1,
+      });
+      recordedStrategies.add(control.control.title);
+    }
 
     drawWrappedText(controlHeading, {
       fontSize: 12,

--- a/src/lib/compliance/types.ts
+++ b/src/lib/compliance/types.ts
@@ -1,4 +1,20 @@
-export type CompliancePlatform = "windows" | "macos" | "ios" | "android";
+export type CompliancePlatform =
+  | "windows"
+  | "macos"
+  | "ios"
+  | "android"
+  | "tenant";
+
+export interface AssessmentScope {
+  /** Explicit scope. Omitted means all supported platforms, never inferred from policy absence. */
+  platforms?: CompliancePlatform[];
+  defStanRiskLevel?: 0 | 1 | 2 | 3;
+}
+
+export type EvidenceKind =
+  | "configuration"
+  | "complianceRequirement"
+  | "accessPolicy";
 
 export type ValueExpectation =
   | { kind: "equals"; value: string | number | boolean }
@@ -12,6 +28,7 @@ export interface SettingsCatalogSignal {
   settingDefinitionId: string;
   enforcedWhen: ValueExpectation;
   disabledWhen?: ValueExpectation;
+  requirementGroup?: string;
 }
 
 export interface GraphPropertySignal {
@@ -22,9 +39,33 @@ export interface GraphPropertySignal {
   propertyPath: string;
   enforcedWhen: ValueExpectation;
   disabledWhen?: ValueExpectation;
+  requirementGroup?: string;
 }
 
-export type DetectionSignal = SettingsCatalogSignal | GraphPropertySignal;
+/** Exact identifiers, never display-name or script-content heuristics. */
+export interface LegacySettingSignal {
+  source: "administrativeTemplate" | "securityBaseline" | "omaUri";
+  settingId: string;
+  enforcedWhen: ValueExpectation;
+  disabledWhen?: ValueExpectation;
+  requirementGroup?: string;
+}
+
+export interface PolicyCheckSignal {
+  source: "policyCheck";
+  check:
+    | "scheduledAntivirusScan"
+    | "qualityUpdateDeadline"
+    | "conditionalAccessMfa"
+    | "conditionalAccessCompliantDevice";
+  requirementGroup?: string;
+}
+
+export type DetectionSignal =
+  | SettingsCatalogSignal
+  | GraphPropertySignal
+  | LegacySettingSignal
+  | PolicyCheckSignal;
 
 export interface ComplianceCapability {
   id: string;
@@ -36,11 +77,17 @@ export interface ComplianceCapability {
     de: string;
   };
   signals: readonly DetectionSignal[];
+  /** All groups must be present on the same assigned policy. Signals within a group are alternatives. */
+  requiredGroups?: readonly string[];
+  documentationUrl?: string;
 }
 
 export interface AssignmentSummary {
-  state: "assigned" | "notAssigned";
+  state: "assigned" | "notAssigned" | "unknown";
   targets: string[];
+  exclusions: string[];
+  filters: Array<{ target: string; id: string; mode: string }>;
+  coverage: "unverified";
 }
 
 export interface CapabilityEvidence {
@@ -48,6 +95,7 @@ export interface CapabilityEvidence {
   policyId: string;
   policyName: string;
   policyType: string;
+  familyKey?: string;
   source: DetectionSignal["source"];
   /** The setting definition id or "<odataType>.<propertyPath>" that produced this evidence. */
   settingId: string;
@@ -55,10 +103,20 @@ export interface CapabilityEvidence {
   verdict: "enforced" | "disabled";
   assignment: AssignmentSummary;
   note?: string;
+  kind: EvidenceKind;
+  requirementGroup?: string;
+  policyVersion?: string;
+  policyModifiedAt?: string;
 }
 
 export type CapabilityStatus =
   | "enforced"
+  | "requirementAssigned"
+  | "assignmentUnknown"
+  | "conflictingEvidence"
+  | "partialConfiguration"
+  | "collectionIncomplete"
+  | "notApplicable"
   | "configuredNotAssigned"
   | "disabledByPolicy"
   | "noEvidence";
@@ -67,6 +125,7 @@ export interface CapabilityResult {
   capability: ComplianceCapability;
   status: CapabilityStatus;
   evidence: CapabilityEvidence[];
+  limitations: string[];
 }
 
 export interface FrameworkControl {
@@ -75,37 +134,69 @@ export interface FrameworkControl {
   summary: string;
   /** Requirement tier where the framework defines one (e.g. BSI Basis/Standard). */
   tier?: string;
+  evidenceStrength?: "direct" | "supporting";
+  unassessedAspects?: readonly string[];
+  platforms?: readonly CompliancePlatform[];
+  riskLevels?: readonly number[];
+  granularity?: "requirement" | "buildingBlock" | "theme";
 }
 
 export interface FrameworkDefinition {
   id: string;
   name: string;
   version: string;
+  /** Published requirement count, separate from the selected technical mappings. */
+  totalRequirements?: number;
   /** Explains the granularity of the mapping, shown alongside any report. */
   note?: string;
   controls: Record<string, FrameworkControl>;
   /** capability id -> control ids that the capability provides evidence for */
   mappings: Record<string, readonly string[]>;
+  source?: { url: string; verifiedAt: string };
 }
 
-export type ControlStatus = "evidenceFound" | "partialEvidence" | "noEvidence";
+export type ControlStatus =
+  | "evidenceFound"
+  | "partialEvidence"
+  | "noEvidence"
+  | "notApplicable"
+  | "notAssessed"
+  | "conflictingEvidence";
 
 export interface ControlAssessment {
   control: FrameworkControl;
   capabilityIds: string[];
   enforcedCapabilityIds: string[];
   status: ControlStatus;
+  unassessedAspects: string[];
+  excludedCapabilityIds: string[];
 }
 
 export interface FrameworkAssessment {
-  framework: Pick<FrameworkDefinition, "id" | "name" | "version" | "note">;
+  framework: Pick<
+    FrameworkDefinition,
+    "id" | "name" | "version" | "note" | "source" | "totalRequirements"
+  >;
   controls: ControlAssessment[];
   summary: {
     totalControls: number;
     withEvidence: number;
     partial: number;
     withoutEvidence: number;
+    notApplicable: number;
+    notAssessed: number;
+    conflicting: number;
+    applicableControls: number;
   };
+}
+
+export interface CollectionCoverage {
+  family: string;
+  collectedPolicies: number;
+  recognizedPolicies: number;
+  unsupportedPolicies: number;
+  status: "complete" | "incomplete" | "unknown" | "notCollected";
+  errors: string[];
 }
 
 export interface ComplianceAssessment {
@@ -113,4 +204,13 @@ export interface ComplianceAssessment {
   disclaimer: string;
   capabilities: CapabilityResult[];
   frameworks: FrameworkAssessment[];
+  scope: AssessmentScope;
+  collectionCoverage: CollectionCoverage[];
+  provenance: {
+    rulesetVersion: string;
+    collectedAt?: string;
+    collectionStartedAt?: string;
+    deviceState: "notCollected";
+    effectiveAccess: "unverified";
+  };
 }

--- a/src/lib/compliance/types.ts
+++ b/src/lib/compliance/types.ts
@@ -8,6 +8,7 @@ export type CompliancePlatform =
 export interface AssessmentScope {
   /** Explicit scope. Omitted means all supported platforms, never inferred from policy absence. */
   platforms?: CompliancePlatform[];
+  essentialEightMaturityLevel?: 1 | 2 | 3;
   defStanRiskLevel?: 0 | 1 | 2 | 3;
 }
 

--- a/src/lib/configuration-analyzer.ts
+++ b/src/lib/configuration-analyzer.ts
@@ -1,7 +1,17 @@
+import type { AssessmentScope } from "./compliance/types";
 import type { BrandingOptions } from "~/types/branding";
 import type { ConfigurationSectionData } from "./configuration-sections";
 
 export interface DetailedExportData {
+  collectedAt?: string;
+  collectionStartedAt?: string;
+  collectionSkippedFamilies?: string[];
+  assessmentScope?: AssessmentScope;
+  permissionErrors?: Array<{
+    resource: string;
+    message: string;
+    requiredPermission: string;
+  }>;
   sections?: ConfigurationSectionData[];
   fetchErrors?: Array<{
     policyId: string;

--- a/src/lib/configuration-analyzer.ts
+++ b/src/lib/configuration-analyzer.ts
@@ -1,3 +1,4 @@
+import { INTUNE_POLICY_REGISTRY } from "./intune-policy-registry";
 import { summarizeAssignments } from "./compliance/assignments";
 import type { AssessmentScope } from "./compliance/types";
 import type { BrandingOptions } from "~/types/branding";
@@ -75,11 +76,23 @@ export function analyzeConfigurations(data: DetailedExportData) {
         ...(data.conditionalAccessPolicies || []),
       ];
 
-  // Conditional Access uses conditions rather than an Intune assignment relation.
+  // Registry types without an assignment relationship have no assignment coverage to assess.
+  const nonAssignableKeys = new Set(
+    INTUNE_POLICY_REGISTRY.filter(
+      (entry) =>
+        !entry.childCollections?.some(
+          (child) => child.property === "assignments",
+        ),
+    ).map((entry) => entry.key),
+  );
   const nonAssignable = new Set([
     ...(data.conditionalAccessPolicies ?? []),
     ...(data.sections ?? [])
-      .filter((section) => section.familyKey === "conditionalAccessPolicies")
+      .filter(
+        (section) =>
+          section.familyKey === "conditionalAccessPolicies" ||
+          nonAssignableKeys.has(section.key),
+      )
       .flatMap((section) => section.items),
   ]);
   const uniqueGroups = new Set<string>();
@@ -89,6 +102,7 @@ export function analyzeConfigurations(data: DetailedExportData) {
   let unknownCount = 0;
   const assignmentState = (config: any) =>
     nonAssignable.has(config) ||
+    nonAssignableKeys.has(config.registryKey) ||
     config["@odata.type"] === "#microsoft.graph.conditionalAccessPolicy"
       ? "notApplicable"
       : summarizeAssignments(

--- a/src/lib/configuration-analyzer.ts
+++ b/src/lib/configuration-analyzer.ts
@@ -75,17 +75,27 @@ export function analyzeConfigurations(data: DetailedExportData) {
         ...(data.conditionalAccessPolicies || []),
       ];
 
+  // Conditional Access uses conditions rather than an Intune assignment relation.
+  const nonAssignable = new Set([
+    ...(data.conditionalAccessPolicies ?? []),
+    ...(data.sections ?? [])
+      .filter((section) => section.familyKey === "conditionalAccessPolicies")
+      .flatMap((section) => section.items),
+  ]);
   const uniqueGroups = new Set<string>();
   const groupAssignmentCount: Record<string, number> = {};
   let assignedCount = 0;
   let unassignedCount = 0;
   let unknownCount = 0;
   const assignmentState = (config: any) =>
-    summarizeAssignments(
-      config.assignments,
-      undefined,
-      config.collectionStatus?.assignments === "incomplete",
-    ).state;
+    nonAssignable.has(config) ||
+    config["@odata.type"] === "#microsoft.graph.conditionalAccessPolicy"
+      ? "notApplicable"
+      : summarizeAssignments(
+          config.assignments,
+          undefined,
+          config.collectionStatus?.assignments === "incomplete",
+        ).state;
   const inventoryCounts = (items: any[]) => ({
     total: items.length,
     assigned: items.filter((item) => assignmentState(item) === "assigned")
@@ -93,6 +103,9 @@ export function analyzeConfigurations(data: DetailedExportData) {
     unassigned: items.filter((item) => assignmentState(item) === "notAssigned")
       .length,
     unknown: items.filter((item) => assignmentState(item) === "unknown").length,
+    notApplicable: items.filter(
+      (item) => assignmentState(item) === "notApplicable",
+    ).length,
   });
 
   allConfigs.forEach((config) => {
@@ -126,7 +139,7 @@ export function analyzeConfigurations(data: DetailedExportData) {
       });
     } else if (state === "notAssigned") {
       unassignedCount++;
-    } else {
+    } else if (state === "unknown") {
       unknownCount++;
     }
   });
@@ -267,6 +280,9 @@ export function analyzeConfigurations(data: DetailedExportData) {
 
   return {
     totalConfigs: allConfigs.length,
+    assignmentApplicableConfigs: assignedCount + unassignedCount + unknownCount,
+    assignmentNotApplicableConfigs:
+      allConfigs.length - assignedCount - unassignedCount - unknownCount,
     assignedConfigs: assignedCount,
     unassignedConfigs: unassignedCount,
     unknownAssignmentConfigs: unknownCount,

--- a/src/lib/configuration-analyzer.ts
+++ b/src/lib/configuration-analyzer.ts
@@ -1,3 +1,4 @@
+import { summarizeAssignments } from "./compliance/assignments";
 import type { AssessmentScope } from "./compliance/types";
 import type { BrandingOptions } from "~/types/branding";
 import type { ConfigurationSectionData } from "./configuration-sections";
@@ -78,9 +79,25 @@ export function analyzeConfigurations(data: DetailedExportData) {
   const groupAssignmentCount: Record<string, number> = {};
   let assignedCount = 0;
   let unassignedCount = 0;
+  let unknownCount = 0;
+  const assignmentState = (config: any) =>
+    summarizeAssignments(
+      config.assignments,
+      undefined,
+      config.collectionStatus?.assignments === "incomplete",
+    ).state;
+  const inventoryCounts = (items: any[]) => ({
+    total: items.length,
+    assigned: items.filter((item) => assignmentState(item) === "assigned")
+      .length,
+    unassigned: items.filter((item) => assignmentState(item) === "notAssigned")
+      .length,
+    unknown: items.filter((item) => assignmentState(item) === "unknown").length,
+  });
 
   allConfigs.forEach((config) => {
-    if (config.assignments && config.assignments.length > 0) {
+    const state = assignmentState(config);
+    if (state === "assigned") {
       assignedCount++;
       config.assignments.forEach((assignment: any) => {
         const odataType =
@@ -88,6 +105,7 @@ export function analyzeConfigurations(data: DetailedExportData) {
             ? assignment.target["@odata.type"].toLowerCase()
             : "";
 
+        if (odataType.includes("exclusiongroupassignmenttarget")) return;
         if (assignment.target?.groupId) {
           uniqueGroups.add(assignment.target.groupId);
           const groupId = assignment.target.groupId;
@@ -106,8 +124,10 @@ export function analyzeConfigurations(data: DetailedExportData) {
             (groupAssignmentCount["All Devices"] || 0) + 1;
         }
       });
-    } else {
+    } else if (state === "notAssigned") {
       unassignedCount++;
+    } else {
+      unknownCount++;
     }
   });
 
@@ -176,11 +196,7 @@ export function analyzeConfigurations(data: DetailedExportData) {
     ? data.sections.map((section) => ({
         key: section.key,
         label: section.label,
-        total: section.items.length,
-        assigned: section.items.filter(
-          (item) =>
-            Array.isArray(item.assignments) && item.assignments.length > 0,
-        ).length,
+        ...inventoryCounts(section.items),
       }))
     : [
         {
@@ -223,20 +239,37 @@ export function analyzeConfigurations(data: DetailedExportData) {
           label: "Scripts (macOS)",
           items: data.scripts.macOS,
         },
+        {
+          key: "appConfigurations",
+          label: "App Configurations",
+          items: data.appConfigurations || [],
+        },
+        {
+          key: "windowsUpdatePolicies",
+          label: "Windows Update Policies",
+          items: data.windowsUpdatePolicies || [],
+        },
+        {
+          key: "enrollmentConfigurations",
+          label: "Enrollment Configurations",
+          items: data.enrollmentConfigurations || [],
+        },
+        {
+          key: "conditionalAccessPolicies",
+          label: "Conditional Access Policies",
+          items: data.conditionalAccessPolicies || [],
+        },
       ].map(({ key, label, items }) => ({
         key,
         label,
-        total: items.length,
-        assigned: items.filter(
-          (item) =>
-            Array.isArray(item.assignments) && item.assignments.length > 0,
-        ).length,
+        ...inventoryCounts(items),
       }));
 
   return {
     totalConfigs: allConfigs.length,
     assignedConfigs: assignedCount,
     unassignedConfigs: unassignedCount,
+    unknownAssignmentConfigs: unknownCount,
     uniqueGroupsCount: uniqueGroups.size,
     topGroups,
     platformCounts,

--- a/src/lib/configuration-parser.ts
+++ b/src/lib/configuration-parser.ts
@@ -325,46 +325,28 @@ export function formatValue(value: any): string {
     return value.toString();
   }
 
-  if (typeof value === "string") {
-    // Clean up technical values
-    if (value.startsWith("device_vendor_msft_")) {
-      return value.replace(/device_vendor_msft_/g, "").replace(/_/g, " ");
-    }
-    return value;
-  }
+  if (typeof value === "string") return value;
 
   if (Array.isArray(value)) {
-    // Handle empty arrays
-    if (value.length === 0) {
-      return "Not configured";
-    }
-
-    // Handle arrays of objects - extract displayName or other meaningful fields
-    if (value.length > 0 && typeof value[0] === "object" && value[0] !== null) {
-      const formattedItems = value.map((item: any) => {
-        // Try to find a meaningful string representation
-        if (item.displayName) return item.displayName;
-        if (item.name) return item.name;
-        if (item.value) return String(item.value);
-        if (item.packageId) return item.packageId;
-        if (item.bundleId) return item.bundleId;
-        // If object has only a few keys, try to create a readable string
-        const keys = Object.keys(item);
-        if (keys.length === 1 && keys[0]) return String(item[keys[0]]);
-        return JSON.stringify(item);
-      });
-      return formattedItems.join("\n");
-    }
-
-    // Handle arrays of primitives (strings, numbers, booleans)
-    // Use newlines for better readability if more than 3 items
-    const formattedItems = value.map((item: any) =>
-      typeof item === "string" ? formatValue(item) : String(item),
-    );
-    return formattedItems.join(value.length > 3 ? "\n" : ", ");
+    if (value.length === 0) return "Not configured";
+    return value
+      .map(formatValue)
+      .join(
+        value.length > 3 ||
+          value.some((item) => item !== null && typeof item === "object")
+          ? "\n"
+          : ", ",
+      );
   }
 
   if (typeof value === "object") {
+    // Preserve name/value pairs and falsy values instead of discarding payloads.
+    if (Object.hasOwn(value, "value")) {
+      const label = value.displayName ?? value.name;
+      return label !== undefined && label !== null
+        ? `${String(label)}: ${formatValue(value.value)}`
+        : formatValue(value.value);
+    }
     return JSON.stringify(value, null, 2);
   }
 
@@ -385,6 +367,8 @@ const DOCUMENT_METADATA_KEYS = new Set([
   "configType",
   "registryKey",
   "sourceEndpoint",
+  "collectionStatus",
+  "presentationFetchError",
 ]);
 
 function humanizePropertyName(value: string) {
@@ -504,6 +488,7 @@ export function parseDeviceConfiguration(config: any): Array<{
   Object.keys(config).forEach((key) => {
     if (
       !ignoredKeys.includes(key) &&
+      !DOCUMENT_METADATA_KEYS.has(key) &&
       config[key] !== null &&
       config[key] !== undefined
     ) {
@@ -547,12 +532,20 @@ export function parseAdministrativeTemplate(definitionValues: any[]): Array<{
     let value = dv.presentationFetchError
       ? "Unavailable (Microsoft Graph did not return presentation values)"
       : "Not configured";
-    const state = dv.enabled ? "Enabled" : "Disabled";
+    const state =
+      dv.enabled === true
+        ? "Enabled"
+        : dv.enabled === false
+          ? "Disabled"
+          : "Unknown";
 
     // Extract values from presentation values
     if (presentationValues.length > 0) {
       const values = presentationValues
         .map((pv: any) => {
+          if (Array.isArray(pv.values)) {
+            return `${pv.presentation?.label || "Values"}: ${formatValue(pv.values)}`;
+          }
           if (pv.value !== undefined && pv.value !== null) {
             return `${pv.presentation?.label || "Value"}: ${formatValue(pv.value)}`;
           }
@@ -602,6 +595,7 @@ export function parseComplianceRules(policy: any): Array<{
   Object.keys(policy).forEach((key) => {
     if (
       !ignoredKeys.includes(key) &&
+      !DOCUMENT_METADATA_KEYS.has(key) &&
       policy[key] !== undefined &&
       policy[key] !== null
     ) {
@@ -616,7 +610,10 @@ export function parseComplianceRules(policy: any): Array<{
         category: getCategoryFromKey(key),
         rule: formatKeyName(key),
         value: formattedValue,
-        action: getComplianceAction(policy.scheduledActionsForRule),
+        action: getComplianceAction(
+          policy.scheduledActionsForRule,
+          policy.collectionStatus?.scheduledActionsForRule,
+        ),
       });
     }
   });
@@ -665,7 +662,10 @@ function parseSecurityBaselineSettingName(
 }
 
 // Parse security baseline categories and settings
-export function parseSecurityBaseline(categories: any[]): Array<{
+export function parseSecurityBaseline(
+  categories: any[],
+  flatSettings?: any[],
+): Array<{
   category: string;
   settings: Array<{
     name: string;
@@ -673,14 +673,26 @@ export function parseSecurityBaseline(categories: any[]): Array<{
     description?: string;
   }>;
 }> {
-  return categories.map((category) => {
+  const sourceCategories = Array.isArray(flatSettings)
+    ? [{ displayName: "Baseline settings", settings: flatSettings }]
+    : categories;
+  return sourceCategories.map((category) => {
     const settings = (category.settings || [])
       .map((setting: any) => {
         let value = "Not configured";
 
         if (setting.value !== undefined && setting.value !== null) {
           value = formatValue(setting.value);
-        } else if (setting.stringValue) {
+        } else if (typeof setting.valueJson === "string") {
+          try {
+            value = formatValue(JSON.parse(setting.valueJson));
+          } catch {
+            value = setting.valueJson;
+          }
+        } else if (
+          setting.stringValue !== undefined &&
+          setting.stringValue !== null
+        ) {
           value = setting.stringValue;
         } else if (setting.intValue !== undefined) {
           value = setting.intValue.toString();
@@ -707,9 +719,11 @@ export function parseSecurityBaseline(categories: any[]): Array<{
 }
 
 // Parse assignment information
-export function parseAssignments(assignments: any[]): string {
+export function parseAssignments(assignments: any[], status?: string): string {
   if (!assignments || assignments.length === 0) {
-    return "Not assigned";
+    return status === "incomplete"
+      ? "Assignments unavailable (collection incomplete)"
+      : "Not assigned";
   }
 
   const labels: string[] = [];
@@ -719,39 +733,21 @@ export function parseAssignments(assignments: any[]): string {
     const typeRaw = target["@odata.type"] || "";
     const type = typeof typeRaw === "string" ? typeRaw.toLowerCase() : "";
 
-    // Common group-based assignments
+    let label: string | undefined;
     if (target.groupId) {
-      if (type.includes("exclusiongroup")) {
-        labels.push(`Excluded: ${target.groupId}`);
-      } else {
-        labels.push(`Group: ${target.groupId}`);
-      }
-      continue;
+      label = `${type.includes("exclusiongroup") ? "Excluded" : "Group"}: ${target.groupId}`;
+    } else if (type.includes("alldevices")) {
+      label = "All Devices";
+    } else if (type.includes("alllicensedusers") || type.includes("allusers")) {
+      label = "All Users";
     }
-
-    // All Devices / All Users / All Licensed Users
-    if (type.includes("alldevices")) {
-      labels.push("All Devices");
-      continue;
-    }
-    if (type.includes("alllicensedusers") || type.includes("allusers")) {
-      labels.push("All Users");
-      continue;
-    }
-
-    // Intune assignment filter
     if (target.deviceAndAppManagementAssignmentFilterId) {
-      const fType = String(
-        target.deviceAndAppManagementAssignmentFilterType || "",
-      ).toLowerCase();
-      const prefix = fType.includes("include")
-        ? "Filter (Include)"
-        : fType.includes("exclude")
-          ? "Filter (Exclude)"
-          : "Filter";
-      labels.push(
-        `${prefix}: ${target.deviceAndAppManagementAssignmentFilterId}`,
-      );
+      const filterType = target.deviceAndAppManagementAssignmentFilterType;
+      const filter = `Filter (${filterType === "include" ? "Include" : filterType === "exclude" ? "Exclude" : "Unknown"}): ${target.deviceAndAppManagementAssignmentFilterId}`;
+      label = label ? `${label} [${filter}]` : filter;
+    }
+    if (label) {
+      labels.push(label);
       continue;
     }
 
@@ -768,7 +764,10 @@ export function parseAssignments(assignments: any[]): string {
     labels.push("Custom Assignment");
   }
 
-  return labels.join(", ");
+  return (
+    labels.join(", ") +
+    (status === "incomplete" ? " (collection incomplete)" : "")
+  );
 }
 
 // Helper functions
@@ -820,28 +819,33 @@ function getPropertyDescription(key: string): string | undefined {
   return descriptions[key];
 }
 
-function getComplianceAction(scheduledActions: any[]): string {
-  if (!scheduledActions || scheduledActions.length === 0) {
-    return "No action configured";
-  }
-
-  const actions = scheduledActions
-    .flatMap((sa) => sa.scheduledActionConfigurations || [])
+function getComplianceAction(scheduledActions: any[], status?: string): string {
+  const incomplete = status === "incomplete";
+  const actions = (scheduledActions || [])
+    .flatMap((rule) => rule?.scheduledActionConfigurations || [])
     .map((config: any) => {
-      const hours = config.gracePeriodHours || 0;
-      const days = Math.floor(hours / 24);
-      const actionType = config.actionType || "notification";
-
-      if (actionType === "block") {
-        return `Block access after ${days} days`;
-      } else if (actionType === "retire") {
-        return `Retire device after ${days} days`;
-      } else if (actionType === "removeResourceAccessProfiles") {
-        return `Remove profiles after ${days} days`;
-      }
-
-      return `Notify after ${days} days`;
+      const hours = config.gracePeriodHours;
+      const timing =
+        typeof hours !== "number" || !Number.isFinite(hours) || hours < 0
+          ? " (timing unavailable)"
+          : hours === 0
+            ? " immediately"
+            : hours % 24 === 0
+              ? ` after ${hours / 24} day${hours === 24 ? "" : "s"}`
+              : ` after ${hours} hour${hours === 1 ? "" : "s"}`;
+      const labels: Record<string, string> = {
+        block: "Mark device noncompliant",
+        retire: "Retire device",
+        removeResourceAccessProfiles: "Remove profiles",
+        notification: "Notify",
+        pushNotification: "Send push notification",
+        remoteLock: "Remotely lock device",
+      };
+      return `${labels[config.actionType] ?? `Action ${config.actionType ?? "unknown"}`}${timing}`;
     });
-
-  return actions.join(", ");
+  if (actions.length === 0)
+    return incomplete
+      ? "Actions unavailable (collection incomplete)"
+      : "No action configured";
+  return actions.join(", ") + (incomplete ? " (collection incomplete)" : "");
 }

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -1089,7 +1089,10 @@ export async function generateDetailedDOCX(
     }
 
     // Assignments
-    const rawAssignment = parseAssignments(policy.assignments);
+    const rawAssignment = parseAssignments(
+      policy.assignments,
+      policy.collectionStatus?.assignments,
+    );
     const assignmentText = enhanceAssignmentText(
       rawAssignment,
       data.groupNames,
@@ -1496,7 +1499,15 @@ export async function generateDetailedDOCX(
         );
         sectionChildren.push(...policyMeta(baseline));
 
-        const cats = parseSecurityBaseline(baseline.categories || []);
+        if (baseline.collectionStatus?.settings === "incomplete") {
+          sectionChildren.push(
+            bodyText("Baseline settings collection incomplete"),
+          );
+        }
+        const cats = parseSecurityBaseline(
+          baseline.categories || [],
+          baseline.settings,
+        );
         for (const cat of cats) {
           if (cat.settings.length === 0) continue;
           sectionChildren.push(heading3(cat.category));

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -964,7 +964,7 @@ export async function generateDetailedDOCX(
     complianceChildren.push(heading1("Compliance Evidence Preview"));
     complianceChildren.push(
       bodyText(
-        "This preview maps the exported configuration to technical evidence for NIST SP 800-53 (Rev. 5), NIST CSF 2.0, and BSI IT-Grundschutz. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
+        "This preview maps the exported configuration to technical evidence for each supported compliance framework. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
       ),
     );
     complianceChildren.push(spacer());

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -1,4 +1,9 @@
 import {
+  CONTROL_STATUS_LABELS,
+  CONTROL_STATUS_ORDER,
+  frameworkCoverageLabel,
+} from "./compliance/presentation";
+import {
   AlignmentType,
   BorderStyle,
   Document,
@@ -40,11 +45,7 @@ import {
 } from "./configuration-parser";
 import type { BrandingOptions } from "~/types/branding";
 import { REDACTED_VALUE } from "./intune-policy-registry";
-import {
-  assessCompliance,
-  compareControlIds,
-  type ControlStatus,
-} from "./compliance";
+import { assessCompliance, compareControlIds } from "./compliance";
 import {
   buildConditionalAccessReportRows,
   conditionalAccessStateLabel,
@@ -950,32 +951,28 @@ export async function generateDetailedDOCX(
   try {
     const complianceAssessment = assessCompliance(data);
     const complianceChildren: (Paragraph | Table)[] = [];
-    const statusLabels: Record<ControlStatus, string> = {
-      evidenceFound: "Configuration evidence",
-      partialEvidence: "Partial configuration evidence",
-      noEvidence: "No recognized configuration evidence",
-    };
-    const statusRank: Record<ControlStatus, number> = {
-      evidenceFound: 0,
-      partialEvidence: 1,
-      noEvidence: 2,
-    };
+    const statusLabels = CONTROL_STATUS_LABELS;
+    const statusRank = CONTROL_STATUS_ORDER;
 
     complianceChildren.push(heading1("Compliance Evidence Preview"));
     complianceChildren.push(
       bodyText(
-        "This preview maps the exported configuration to technical evidence for each supported compliance framework. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
+        "This preview maps the exported configuration to technical evidence for each supported compliance framework. Supporting evidence may describe configuration or a compliance requirement. Device state, effective access and the remaining control requirements are assessed separately.",
       ),
     );
     complianceChildren.push(spacer());
 
     for (const framework of complianceAssessment.frameworks) {
       complianceChildren.push(
-        heading2(`${framework.framework.name} (${framework.framework.version})`),
+        heading2(
+          `${framework.framework.name} (${framework.framework.version})`,
+        ),
       );
+      const coverageLabel = frameworkCoverageLabel(framework);
+      if (coverageLabel) complianceChildren.push(bodyText(coverageLabel));
       complianceChildren.push(
         bodyText(
-          `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.totalControls} technically assessable controls)`,
+          `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} mapped entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
         ),
       );
 

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -840,7 +840,7 @@ export async function generateDetailedDOCX(
       if (analytics.assignmentNotApplicableConfigs)
         summaryChildren.push(
           bodyText(
-            `Assignment not applicable: ${analytics.assignmentNotApplicableConfigs} configurations use another targeting model. Assignment coverage excludes these configurations.`,
+            `Assignment not applicable: ${analytics.assignmentNotApplicableConfigs} configurations; excluded from assignment coverage.`,
           ),
         );
       // Assignment coverage

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -808,9 +808,11 @@ export async function generateDetailedDOCX(
 
       // Key metrics table (3 columns)
       const coveragePercent =
-        analytics.totalConfigs > 0
+        analytics.assignmentApplicableConfigs > 0
           ? Math.round(
-              (analytics.assignedConfigs / analytics.totalConfigs) * 100,
+              (analytics.assignedConfigs /
+                analytics.assignmentApplicableConfigs) *
+                100,
             )
           : 0;
 
@@ -835,6 +837,12 @@ export async function generateDetailedDOCX(
       );
       summaryChildren.push(spacer());
 
+      if (analytics.assignmentNotApplicableConfigs)
+        summaryChildren.push(
+          bodyText(
+            `Assignment not applicable: ${analytics.assignmentNotApplicableConfigs} configurations use another targeting model. Assignment coverage excludes these configurations.`,
+          ),
+        );
       // Assignment coverage
       let coverageColor = "00A652"; // green
       if (coveragePercent < 50) coverageColor = "CC0000";
@@ -901,14 +909,14 @@ export async function generateDetailedDOCX(
       summaryChildren.push(heading2("Configuration Inventory"));
       const inventoryRows: string[][] = [];
       analytics.inventory.forEach(
-        ({ label, total, assigned, unassigned, unknown }) => {
+        ({ label, total, assigned, unassigned, unknown, notApplicable }) => {
           if (total > 0) {
             inventoryRows.push([
               label,
               String(total),
-              String(assigned),
-              String(unassigned),
-              String(unknown),
+              notApplicable === total ? "N/A" : String(assigned),
+              notApplicable === total ? "N/A" : String(unassigned),
+              notApplicable === total ? "N/A" : String(unknown),
             ]);
           }
         },
@@ -2286,9 +2294,6 @@ export async function generateDetailedDOCX(
       );
   }
   const doc = new Document({
-    features: {
-      updateFields: true,
-    },
     title: branding?.metadata?.title || "Intune Configuration Documentation",
     creator: branding?.metadata?.author || "IntuneDocumentation",
     subject:

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -972,7 +972,7 @@ export async function generateDetailedDOCX(
       if (coverageLabel) complianceChildren.push(bodyText(coverageLabel));
       complianceChildren.push(
         bodyText(
-          `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} mapped entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
+          `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
         ),
       );
 
@@ -989,9 +989,11 @@ export async function generateDetailedDOCX(
             .slice(0, maxRows)
             .map((assessed) => [
               assessed.control.id,
-              assessed.control.tier
-                ? `${assessed.control.title} (${assessed.control.tier})`
-                : assessed.control.title,
+              framework.framework.id === "essential-eight"
+                ? `${assessed.control.title}: ${assessed.control.summary}`
+                : assessed.control.tier
+                  ? `${assessed.control.title} (${assessed.control.tier})`
+                  : assessed.control.title,
               statusLabels[assessed.status],
             ]),
           branding,

--- a/src/lib/docx-generator-detailed.ts
+++ b/src/lib/docx-generator-detailed.ts
@@ -20,7 +20,8 @@ import {
   TabStopType,
   Table,
   TableCell,
-  TableOfContents,
+  Bookmark,
+  InternalHyperlink,
   TableRow,
   TextRun,
   WidthType,
@@ -673,8 +674,17 @@ export async function generateDetailedDOCX(
   const defaultHeader = buildHeader();
   const defaultFooter = buildFooter();
 
+  const spacers = new WeakSet<Paragraph>();
+  const contentsEntries: { title: string; anchor: string }[] = [];
+  let contentsChildren: Paragraph[] | undefined;
+
   // Helper: wrap children in a content section (with page break, header, footer)
   const pushContentSection = (children: (Paragraph | Table)[]) => {
+    while (
+      children.length &&
+      spacers.has(children[children.length - 1] as Paragraph)
+    )
+      children.pop();
     const sectionProps: any = {
       type: SectionType.NEXT_PAGE,
     };
@@ -688,20 +698,30 @@ export async function generateDetailedDOCX(
   };
 
   // Helper: create a Heading 1 paragraph
-  const heading1 = (text: string): Paragraph =>
-    new Paragraph({
+  const heading1 = (text: string): Paragraph => {
+    const anchor = `section_${contentsEntries.length + 1}`;
+    if (text !== "Table of Contents")
+      contentsEntries.push({ title: text, anchor });
+    return new Paragraph({
       children: [
-        new TextRun({
-          text,
-          bold: true,
-          color: primaryHex,
-          font: fontName,
-          size: headerSizeHp + 8,
+        new Bookmark({
+          id: anchor,
+          children: [
+            new TextRun({
+              text,
+              bold: true,
+              color: primaryHex,
+              font: fontName,
+              size: headerSizeHp + 8,
+            }),
+          ],
         }),
       ],
       heading: HeadingLevel.HEADING_1,
+      keepNext: true,
       spacing: { before: 240, after: 120 },
     });
+  };
 
   // Helper: create a Heading 2 paragraph
   const heading2 = (text: string): Paragraph =>
@@ -759,34 +779,22 @@ export async function generateDetailedDOCX(
     });
 
   // Helper: blank spacer
-  const spacer = (): Paragraph => new Paragraph({ spacing: { after: 120 } });
+  const spacer = (): Paragraph => {
+    const paragraph = new Paragraph({ spacing: { after: 120 } });
+    spacers.add(paragraph);
+    return paragraph;
+  };
 
   // ===== 2. TABLE OF CONTENTS =====
   if (branding?.documentSettings?.includeTableOfContents !== false) {
-    const tocChildren: (Paragraph | Table | TableOfContents)[] = [];
-    tocChildren.push(heading1("Table of Contents"));
-    tocChildren.push(
-      new TableOfContents("TOC", {
-        hyperlink: true,
-        headingStyleRange: "1-3",
-      }),
-    );
-    tocChildren.push(spacer());
-    tocChildren.push(
+    contentsChildren = [
       new Paragraph({
-        children: [
-          new TextRun({
-            text: "Right-click and select 'Update Field' to populate page numbers.",
-            font: fontName,
-            size: bodySizeHp - 2,
-            color: "888888",
-            italics: true,
-          }),
-        ],
-        spacing: { before: 200 },
+        text: "Table of Contents",
+        heading: HeadingLevel.HEADING_1,
+        spacing: { before: 240, after: 120 },
       }),
-    );
-    pushContentSection(tocChildren);
+    ];
+    pushContentSection(contentsChildren);
   }
 
   // ===== 3. EXECUTIVE SUMMARY =====
@@ -808,12 +816,18 @@ export async function generateDetailedDOCX(
 
       summaryChildren.push(
         createSettingsTable(
-          ["Total Configurations", "Assigned Policies", "Unassigned"],
+          [
+            "Total Configurations",
+            "Assigned Policies",
+            "Unassigned",
+            "Unknown",
+          ],
           [
             [
               String(analytics.totalConfigs),
               String(analytics.assignedConfigs),
               String(analytics.unassignedConfigs),
+              String(analytics.unknownAssignmentConfigs),
             ],
           ],
           branding,
@@ -886,21 +900,24 @@ export async function generateDetailedDOCX(
       // Configuration inventory by type
       summaryChildren.push(heading2("Configuration Inventory"));
       const inventoryRows: string[][] = [];
-      analytics.inventory.forEach(({ label, total, assigned }) => {
-        if (total > 0) {
-          inventoryRows.push([
-            label,
-            String(total),
-            String(assigned),
-            String(total - assigned),
-          ]);
-        }
-      });
+      analytics.inventory.forEach(
+        ({ label, total, assigned, unassigned, unknown }) => {
+          if (total > 0) {
+            inventoryRows.push([
+              label,
+              String(total),
+              String(assigned),
+              String(unassigned),
+              String(unknown),
+            ]);
+          }
+        },
+      );
 
       if (inventoryRows.length > 0) {
         summaryChildren.push(
           createSettingsTable(
-            ["Policy Type", "Total", "Assigned", "Unassigned"],
+            ["Policy Type", "Total", "Assigned", "Unassigned", "Unknown"],
             inventoryRows,
             branding,
           ),
@@ -2245,6 +2262,29 @@ export async function generateDetailedDOCX(
   // -----------------------------------------------------------------------
   // Build the Document
   // -----------------------------------------------------------------------
+  // A populated section index works immediately in Word and previewers,
+  // without relying on the reader to recalculate a TOC field.
+  if (contentsChildren) {
+    for (const entry of contentsEntries)
+      contentsChildren.push(
+        new Paragraph({
+          children: [
+            new InternalHyperlink({
+              anchor: entry.anchor,
+              children: [
+                new TextRun({
+                  text: entry.title,
+                  font: fontName,
+                  size: bodySizeHp,
+                  color: primaryHex,
+                }),
+              ],
+            }),
+          ],
+          spacing: { after: 120 },
+        }),
+      );
+  }
   const doc = new Document({
     features: {
       updateFields: true,

--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -1,13 +1,56 @@
-import { Client } from "@microsoft/microsoft-graph-client";
+import { createGraphLimiter, retryGraphRequest } from "./graph-request";
+import { Client, RetryHandlerOptions } from "@microsoft/microsoft-graph-client";
 import "isomorphic-fetch";
-import { collectAllPages } from "./graph-paging";
+import {
+  collectAllPages,
+  collectAllPagesWithStatus,
+  GraphPaginationError,
+} from "./graph-paging";
 
-export function createGraphClient(accessToken: string) {
-  return Client.init({
-    authProvider: (done) => {
-      done(null, accessToken);
-    },
+export function createGraphClient(
+  accessToken: string,
+  options: { signal?: AbortSignal; budgetMs?: number } = {},
+) {
+  const signals = [
+    options.signal,
+    options.budgetMs ? AbortSignal.timeout(options.budgetMs) : undefined,
+  ].filter((signal): signal is AbortSignal => !!signal);
+  const signal = signals.length ? AbortSignal.any(signals) : undefined;
+  const client = Client.init({
+    defaultVersion: "beta",
+    authProvider: (done) => done(null, accessToken),
   });
+  const run = createGraphLimiter(6);
+  const api = client.api.bind(client);
+  client.api = (path: string) => {
+    const request = api(path);
+    request.middlewareOptions([new RetryHandlerOptions(0, 0)]);
+    if (signal) request.option("signal", signal);
+    const get = request.get.bind(request);
+    request.get = ((...args: Parameters<typeof get>) =>
+      run(
+        () => retryGraphRequest(() => get(...args), { signal }),
+        signal,
+      )) as typeof request.get;
+    const post = request.post.bind(request);
+    request.post = ((...args: Parameters<typeof post>) => {
+      const body = args[0];
+      const readOnlyBatch =
+        path === "/$batch" &&
+        Array.isArray(body?.requests) &&
+        body.requests.length > 0 &&
+        body.requests.every((item: any) => item?.method === "GET");
+      return run(
+        () =>
+          readOnlyBatch
+            ? retryGraphRequest(() => post(...args), { signal })
+            : post(...args),
+        signal,
+      );
+    }) as typeof request.post;
+    return request;
+  };
+  return client;
 }
 
 export interface DeviceConfiguration {
@@ -67,6 +110,22 @@ export interface EnrollmentRestriction {
 }
 
 export class IntuneService {
+  private collectionErrors: Array<{
+    source: string;
+    message: string;
+    statusCode?: number;
+  }> = [];
+  getFetchErrors() {
+    return [...this.collectionErrors];
+  }
+  private captureError(error: any) {
+    this.collectionErrors.push({
+      source: "Legacy Graph collection",
+      message: error?.message ?? "Graph read failed",
+      statusCode: error?.statusCode ?? error?.cause?.statusCode,
+    });
+  }
+
   private client: ReturnType<typeof createGraphClient>;
 
   constructor(accessToken: string) {
@@ -77,23 +136,32 @@ export class IntuneService {
     try {
       const response = await this.client
         .api("/deviceManagement/deviceConfigurations")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      return await collectAllPages<DeviceConfiguration>(this.client as unknown as Client, response);
+      return await collectAllPages<DeviceConfiguration>(
+        this.client as unknown as Client,
+        response,
+      );
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching device configurations:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
-  async getDeviceConfigurationDetails(id: string): Promise<DeviceConfiguration | null> {
+  async getDeviceConfigurationDetails(
+    id: string,
+  ): Promise<DeviceConfiguration | null> {
     try {
       const config = await this.client
         .api(`/deviceManagement/deviceConfigurations/${id}`)
         .get();
       return config;
     } catch (error) {
+      this.captureError(error);
       console.error(`Error fetching configuration ${id}:`, error);
       return null;
     }
@@ -103,23 +171,32 @@ export class IntuneService {
     try {
       const response = await this.client
         .api("/deviceManagement/deviceCompliancePolicies")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      return await collectAllPages<CompliancePolicy>(this.client as unknown as Client, response);
+      return await collectAllPages<CompliancePolicy>(
+        this.client as unknown as Client,
+        response,
+      );
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching compliance policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
-  async getCompliancePolicyDetails(id: string): Promise<CompliancePolicy | null> {
+  async getCompliancePolicyDetails(
+    id: string,
+  ): Promise<CompliancePolicy | null> {
     try {
       const policy = await this.client
         .api(`/deviceManagement/deviceCompliancePolicies/${id}`)
         .get();
       return policy;
     } catch (error) {
+      this.captureError(error);
       console.error(`Error fetching compliance policy ${id}:`, error);
       return null;
     }
@@ -130,25 +207,45 @@ export class IntuneService {
       const [iosFirst, androidFirst] = await Promise.all([
         this.client
           .api("/deviceAppManagement/iosManagedAppProtections")
-          .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+          .select(
+            "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+          )
           .top(999)
           .get()
-          .catch(() => ({ value: [] })),
+          .catch((error) => {
+            this.captureError(error);
+            return { value: [] };
+          }),
         this.client
           .api("/deviceAppManagement/androidManagedAppProtections")
-          .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+          .select(
+            "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+          )
           .top(999)
           .get()
-          .catch(() => ({ value: [] })),
+          .catch((error) => {
+            this.captureError(error);
+            return { value: [] };
+          }),
       ]);
-      const [iosPolicies, androidPolicies] = await Promise.all([
-        collectAllPages<AppProtectionPolicy>(this.client as unknown as Client, iosFirst),
-        collectAllPages<AppProtectionPolicy>(this.client as unknown as Client, androidFirst),
-      ]);
-      return [...iosPolicies, ...androidPolicies];
+      const platforms = await Promise.all(
+        [iosFirst, androidFirst].map(async (response) => {
+          const pages = await collectAllPagesWithStatus<AppProtectionPolicy>(
+            this.client as unknown as Client,
+            response,
+          );
+          if (!pages.complete)
+            this.captureError(
+              new GraphPaginationError(pages.items, pages.error),
+            );
+          return pages.items;
+        }),
+      );
+      return platforms.flat();
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching app protection policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -158,15 +255,21 @@ export class IntuneService {
         .api("/identity/conditionalAccess/policies")
         .top(999)
         .get();
-      return await collectAllPages<ConditionalAccessPolicy>(this.client as unknown as Client, response);
+      return await collectAllPages<ConditionalAccessPolicy>(
+        this.client as unknown as Client,
+        response,
+      );
     } catch (error: any) {
+      this.captureError(error);
       // Conditional Access requires additional permissions that may not be granted
       if (error?.statusCode === 403) {
-        console.log("Conditional Access policies skipped - insufficient permissions");
+        console.log(
+          "Conditional Access policies skipped - insufficient permissions",
+        );
       } else {
         console.error("Error fetching conditional access policies:", error);
       }
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -174,13 +277,19 @@ export class IntuneService {
     try {
       const response = await this.client
         .api("/deviceManagement/deviceEnrollmentConfigurations")
-        .select("id,displayName,description,priority,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,priority,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      return await collectAllPages<EnrollmentRestriction>(this.client as unknown as Client, response);
+      return await collectAllPages<EnrollmentRestriction>(
+        this.client as unknown as Client,
+        response,
+      );
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching enrollment restrictions:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -201,14 +310,22 @@ export class IntuneService {
 
     // Fetch detailed information for each configuration
     const deviceConfigDetails = await Promise.all(
-      deviceConfigurations.map((config) => this.getDeviceConfigurationDetails(config.id))
+      deviceConfigurations.map((config) =>
+        this.getDeviceConfigurationDetails(config.id),
+      ),
     );
 
     const compliancePolicyDetails = await Promise.all(
-      compliancePolicies.map((policy) => this.getCompliancePolicyDetails(policy.id))
+      compliancePolicies.map((policy) =>
+        this.getCompliancePolicyDetails(policy.id),
+      ),
     );
 
     return {
+      fetchErrors: this.getFetchErrors(),
+      collectionStatus: this.collectionErrors.length
+        ? "incomplete"
+        : "complete",
       deviceConfigurations: deviceConfigDetails.filter(Boolean),
       compliancePolicies: compliancePolicyDetails.filter(Boolean),
       appProtectionPolicies,

--- a/src/lib/graph-paging.ts
+++ b/src/lib/graph-paging.ts
@@ -1,60 +1,6 @@
 import type { Client } from "@microsoft/microsoft-graph-client";
 
-// Helper function for retrying with exponential backoff
-async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
-  maxRetries: number = 5,
-  initialDelay: number = 1000,
-): Promise<T> {
-  let lastError: any;
-
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error: any) {
-      lastError = error;
-      const statusCode = error?.statusCode || error?.response?.status;
-      const errorMessage = error?.message || "";
-
-      // Don't retry on permanent failures
-      // 404 or 403 - resource doesn't exist or forbidden
-      // "No OData route exists" - API endpoint not supported for this resource
-      if (
-        statusCode === 404 ||
-        statusCode === 403 ||
-        errorMessage.includes("No OData route exists")
-      ) {
-        throw error;
-      }
-
-      // Check if it's a rate limit error (429)
-      if (error?.statusCode === 429 || error?.code === "TooManyRequests") {
-        // Try to get Retry-After header
-        const retryAfter = error?.headers?.["retry-after"] || error?.retryAfter;
-        const retryDelay = retryAfter ? parseInt(retryAfter) * 1000 : 30000; // Default to 30s
-        console.log(
-          `Rate limited. Waiting ${retryDelay}ms before retry ${attempt + 1}/${maxRetries}`,
-        );
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
-        continue;
-      }
-
-      // For other errors, use exponential backoff with jitter
-      if (attempt < maxRetries - 1) {
-        const exponentialDelay = initialDelay * Math.pow(2, attempt);
-        const jitter = Math.random() * 500;
-        const delayMs = exponentialDelay + jitter;
-
-        console.log(
-          `Retry ${attempt + 1}/${maxRetries} after ${delayMs.toFixed(0)}ms. Error: ${error?.message || "Unknown error"}`,
-        );
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
-    }
-  }
-
-  throw lastError;
-}
+import { retryGraphRequest } from "./graph-request";
 
 // Collects all pages given a first Graph response with potential @odata.nextLink
 export class GraphPaginationError<T = unknown> extends Error {
@@ -105,26 +51,40 @@ export async function collectAllPagesWithStatus<T = any>(
   firstResponse: any,
   options: GraphPagingOptions = {},
 ): Promise<GraphPagingResult<T>> {
-  const items: T[] = Array.isArray(firstResponse?.value)
-    ? [...firstResponse.value]
-    : [];
+  if (!Array.isArray(firstResponse?.value)) {
+    return {
+      items: [],
+      complete: false,
+      error: new Error("Graph omitted the collection value array"),
+    };
+  }
+  const items: T[] = [...firstResponse.value];
+  const visited = new Set<string>();
   let nextLink: string | undefined = firstResponse?.["@odata.nextLink"];
   let pageNumber = 2;
 
-  while (nextLink) {
+  while (nextLink !== undefined && nextLink !== null) {
     try {
+      if (typeof nextLink !== "string" || !nextLink || visited.has(nextLink)) {
+        throw new Error(
+          "Graph returned an invalid or repeated continuation link",
+        );
+      }
+      visited.add(nextLink);
       // The Graph SDK supports passing the absolute nextLink URL
       // Avoid adding .version() or other modifiers when following nextLink
-      const page: any = await retryWithBackoff(
+      const page: any = await retryGraphRequest(
         () => (client as any).api(nextLink).get(),
-        options.maxRetries ?? 5,
-        options.initialDelay ?? 1000,
+        {
+          maxAttempts: options.maxRetries ?? 5,
+          initialDelay: options.initialDelay ?? 1000,
+        },
       );
 
-      if (Array.isArray(page?.value)) {
-        items.push(...page.value);
-        pageNumber++;
-      }
+      if (!Array.isArray(page?.value))
+        throw new Error("Graph omitted the collection value array");
+      items.push(...page.value);
+      pageNumber++;
 
       nextLink = page?.["@odata.nextLink"];
     } catch (error: any) {

--- a/src/lib/graph-request.ts
+++ b/src/lib/graph-request.ts
@@ -1,0 +1,125 @@
+function abortReason(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new DOMException("Graph collection cancelled", "AbortError");
+}
+
+const exhausted = new WeakSet<object>();
+
+export function graphStatus(error: any): number | undefined {
+  const status = error?.statusCode ?? error?.status ?? error?.response?.status;
+  return typeof status === "number" && status >= 100 ? status : undefined;
+}
+
+export function isTransientGraphError(error: any): boolean {
+  if (
+    [error?.name, error?.code].some(
+      (value) => value === "AbortError" || value === "TimeoutError",
+    )
+  )
+    return false;
+  if (error && typeof error === "object" && exhausted.has(error)) return false;
+  const status = graphStatus(error);
+  return status === undefined
+    ? error instanceof TypeError ||
+        [
+          "TypeError",
+          "FetchError",
+          "ECONNRESET",
+          "ETIMEDOUT",
+          "EAI_AGAIN",
+        ].includes(error?.code)
+    : [408, 429, 500, 502, 503, 504].includes(status);
+}
+
+export function retryAfterMs(error: any, now = Date.now()): number | undefined {
+  const headers = error?.headers ?? error?.response?.headers;
+  const raw =
+    headers?.get?.("retry-after") ??
+    Object.entries(headers ?? {}).find(
+      ([key]) => key.toLowerCase() === "retry-after",
+    )?.[1] ??
+    error?.retryAfter;
+  if (raw === undefined || raw === null) return undefined;
+  const value = String(raw).trim();
+  if (/^\d+(?:\.\d+)?$/.test(value)) return Number(value) * 1000;
+  const date = Date.parse(value);
+  return Number.isFinite(date) ? Math.max(0, date - now) : undefined;
+}
+
+export function waitForGraph(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(abortReason(signal));
+    const abort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+export async function retryGraphRequest<T>(
+  action: () => Promise<T>,
+  options: {
+    maxAttempts?: number;
+    initialDelay?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<T> {
+  const attempts = Math.max(1, options.maxAttempts ?? 3);
+  for (let attempt = 0; ; attempt++) {
+    options.signal?.throwIfAborted();
+    try {
+      return await action();
+    } catch (error) {
+      if (attempt + 1 >= attempts || !isTransientGraphError(error)) {
+        if (error && typeof error === "object") exhausted.add(error);
+        throw error;
+      }
+      await waitForGraph(
+        retryAfterMs(error) ??
+          (options.initialDelay ?? 1000) * 2 ** attempt + Math.random() * 250,
+        options.signal,
+      );
+    }
+  }
+}
+
+// Shared by all families using a client, including requests queued by Promise.all.
+export function createGraphLimiter(limit = 6) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  return async function run<T>(
+    action: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    signal?.throwIfAborted();
+    if (active >= limit)
+      await new Promise<void>((resolve, reject) => {
+        const ready = () => {
+          signal?.removeEventListener("abort", abort);
+          resolve();
+        };
+        const abort = () => {
+          const index = queue.indexOf(ready);
+          if (index >= 0) queue.splice(index, 1);
+          reject(abortReason(signal));
+        };
+        queue.push(ready);
+        signal?.addEventListener("abort", abort, { once: true });
+      });
+    else active++;
+    try {
+      signal?.throwIfAborted();
+      return await action();
+    } finally {
+      const next = queue.shift();
+      if (next) next();
+      else active--;
+    }
+  };
+}

--- a/src/lib/group-resolver.ts
+++ b/src/lib/group-resolver.ts
@@ -1,15 +1,22 @@
-import { Client } from "@microsoft/microsoft-graph-client";
+import { createGraphClient } from "./graph-client";
+import {
+  graphStatus,
+  isTransientGraphError,
+  retryAfterMs,
+  waitForGraph,
+} from "./graph-request";
+import type { Client } from "@microsoft/microsoft-graph-client";
 
 export class GroupResolver {
   private client: Client;
+  private warnings: string[] = [];
+  getWarnings() {
+    return [...this.warnings];
+  }
   private groupCache = new Map<string, string>();
 
   constructor(accessToken: string) {
-    this.client = Client.init({
-      authProvider: (done) => {
-        done(null, accessToken);
-      },
-    });
+    this.client = createGraphClient(accessToken);
   }
 
   // Fetch a single group name by ID
@@ -26,68 +33,86 @@ export class GroupResolver {
         .select("id,displayName")
         .get();
 
-      const displayName = group.displayName || `Group ${groupId}`;
+      const displayName = group.displayName || groupId;
       this.groupCache.set(groupId, displayName);
       return displayName;
     } catch (error) {
+      this.warnings.push(
+        `Could not resolve group ${groupId}; retaining its identifier.`,
+      );
       console.error(`Error fetching group ${groupId}:`, error);
-      return `Group ${groupId}`;
+      return groupId;
     }
   }
 
   // Batch fetch multiple group names
   async getGroupNames(groupIds: string[]): Promise<Map<string, string>> {
     const result = new Map<string, string>();
-    const uncachedIds: string[] = [];
-
-    // Check cache first
-    for (const id of groupIds) {
-      if (this.groupCache.has(id)) {
-        result.set(id, this.groupCache.get(id)!);
-      } else {
-        uncachedIds.push(id);
+    const uncached = [...new Set(groupIds)].filter((id) => {
+      const cached = this.groupCache.get(id);
+      if (cached) {
+        result.set(id, cached);
+        return false;
       }
-    }
-
-    // Batch fetch uncached groups
-    if (uncachedIds.length > 0) {
-      try {
-        // Use $batch endpoint for efficient fetching
-        const batchRequests = uncachedIds.map((id, index) => ({
-          id: index.toString(),
-          method: "GET",
-          url: `/groups/${id}?$select=id,displayName`,
-        }));
-
-        // Process in batches of 20 (Graph API limit)
-        const batchSize = 20;
-        for (let i = 0; i < batchRequests.length; i += batchSize) {
-          const batch = batchRequests.slice(i, i + batchSize);
-
-          const batchResponse = await this.client
+      return true;
+    });
+    const unresolved = (id: string, status: unknown) => {
+      result.set(id, id);
+      this.warnings.push(
+        `Could not resolve group ${id} (HTTP ${typeof status === "number" ? status : "unknown"}); retaining its identifier.`,
+      );
+    };
+    for (let offset = 0; offset < uncached.length; offset += 20) {
+      let pending = uncached
+        .slice(offset, offset + 20)
+        .map((groupId, index) => ({ id: String(index), groupId }));
+      for (let attempt = 0; pending.length > 0; attempt++) {
+        let response;
+        try {
+          response = await this.client
             .api("/$batch")
             .version("beta")
-            .post({ requests: batch });
-
-          for (const response of batchResponse.responses) {
-            if (response.status === 200 && response.body) {
-              const group = response.body;
-              const displayName = group.displayName || `Group ${group.id}`;
-              this.groupCache.set(group.id, displayName);
-              result.set(group.id, displayName);
-            }
+            .post({
+              requests: pending.map(({ id, groupId }) => ({
+                id,
+                method: "GET",
+                url: `/groups/${groupId}?$select=id,displayName`,
+              })),
+            });
+        } catch (error: any) {
+          pending.forEach(({ groupId }) =>
+            unresolved(groupId, graphStatus(error)),
+          );
+          break;
+        }
+        const responses = new Map<string, any>(
+          (Array.isArray(response?.responses) ? response.responses : []).map(
+            (item: any) => [item.id, item],
+          ),
+        );
+        const retry: typeof pending = [];
+        let delay = 0;
+        for (const item of pending) {
+          const entry = responses.get(item.id);
+          if (entry?.status === 200 && entry.body?.id === item.groupId) {
+            const name = entry.body.displayName || item.groupId;
+            this.groupCache.set(item.groupId, name);
+            result.set(item.groupId, name);
+            continue;
           }
+          const error = {
+            statusCode: entry?.status === 200 ? 502 : (entry?.status ?? 502),
+            headers: entry?.headers,
+          };
+          if (attempt < 2 && isTransientGraphError(error)) {
+            retry.push(item);
+            delay = Math.max(delay, retryAfterMs(error) ?? 1000 * 2 ** attempt);
+          } else unresolved(item.groupId, entry?.status);
         }
-      } catch (error) {
-        console.error("Error batch fetching groups:", error);
-        // Fallback to individual fetching
-        for (const id of uncachedIds) {
-          const name = await this.getGroupName(id);
-          result.set(id, name);
-        }
+        pending = retry;
+        if (pending.length) await waitForGraph(delay);
       }
     }
-
     return result;
   }
 
@@ -129,12 +154,10 @@ export class GroupResolver {
       } else if (type?.includes("allLicensedUsersAssignmentTarget")) {
         resolvedTargets.push("All Users");
       } else if (type?.includes("exclusionGroupAssignmentTarget")) {
-        const groupName =
-          groupNames.get(target.groupId) || `Group ${target.groupId}`;
+        const groupName = groupNames.get(target.groupId) || target.groupId;
         resolvedTargets.push(`Excluded: ${groupName}`);
       } else if (type?.includes("groupAssignmentTarget")) {
-        const groupName =
-          groupNames.get(target.groupId) || `Group ${target.groupId}`;
+        const groupName = groupNames.get(target.groupId) || target.groupId;
         resolvedTargets.push(groupName);
       } else {
         resolvedTargets.push("Custom Assignment");

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -187,6 +187,67 @@ export class DetailedIntuneService {
   private client: ReturnType<typeof createGraphClient>;
   private permissionErrors: PermissionError[] = [];
   private fetchErrors: FetchError[] = [];
+  private async readPolicyDetails(
+    policy: any,
+    familyKey: string,
+    endpoint: string,
+    select?: string,
+  ) {
+    try {
+      const item = await this.retryWithBackoff(() => {
+        const request = this.client.api(endpoint).version("beta");
+        return (select ? request.select(select) : request).get();
+      });
+      return { item: { ...policy, ...item }, complete: true };
+    } catch (error) {
+      const details = this.graphError(error);
+      this.fetchErrors.push({
+        policyId: policy.id,
+        policyName: policy.displayName ?? policy.name ?? policy.id,
+        policyType: familyKey,
+        familyKey,
+        endpoint,
+        error: details.message,
+        statusCode: details.statusCode,
+        partial: true,
+      });
+      return { item: policy, complete: false };
+    }
+  }
+  private async readPolicyRelation(
+    policy: any,
+    familyKey: string,
+    endpoint: string,
+    expand?: string,
+  ) {
+    let items: any[] = [];
+    try {
+      const response = await this.retryWithBackoff(() => {
+        const request = this.client.api(endpoint).version("beta");
+        return (expand ? request.expand(expand) : request).get();
+      });
+      const pages = await collectAllPagesWithStatus<any>(
+        this.client as unknown as Client,
+        response,
+      );
+      items = pages.items;
+      if (!pages.complete) throw pages.error;
+      return { items, complete: true };
+    } catch (error) {
+      const details = this.graphError(error);
+      this.fetchErrors.push({
+        policyId: policy.id,
+        policyName: policy.displayName ?? policy.name ?? policy.id,
+        policyType: familyKey,
+        familyKey,
+        endpoint,
+        error: details.message,
+        statusCode: details.statusCode,
+        partial: true,
+      });
+      return { items, complete: false };
+    }
+  }
   private progressCallback?: ProgressCallback;
   private configurationSettingDefinitionCache = new Map<
     string,
@@ -831,6 +892,18 @@ export class DetailedIntuneService {
                 configType: "Settings Catalog",
                 settings: settings || [],
                 assignments: assignments || [],
+                collectionStatus: {
+                  assignments: policyWarnings.some((warning) =>
+                    warning.startsWith("Assignments:"),
+                  )
+                    ? "incomplete"
+                    : "complete",
+                  settings: policyWarnings.some((warning) =>
+                    warning.startsWith("Settings:"),
+                  )
+                    ? "incomplete"
+                    : "complete",
+                },
                 hasFetchError: policyWarnings.length > 0,
                 fetchErrorMessage:
                   policyWarnings.length > 0
@@ -870,6 +943,10 @@ export class DetailedIntuneService {
                 configType: "Settings Catalog",
                 settings: [],
                 assignments: [],
+                collectionStatus: {
+                  assignments: "incomplete",
+                  settings: "incomplete",
+                },
                 hasFetchError: true,
                 fetchErrorMessage: errorMessage,
               };
@@ -926,34 +1003,23 @@ export class DetailedIntuneService {
       const detailedConfigs = await Promise.all(
         nonUpdateRingConfigs.map(async (config: any) => {
           try {
-            // Fetch assignments with retry
-            let assignmentsResponse;
-            try {
-              assignmentsResponse = await this.retryWithBackoff(() =>
-                this.client
-                  .api(
-                    `/deviceManagement/deviceConfigurations('${config.id}')/assignments`,
-                  )
-                  .version("beta")
-                  .get(),
-              );
-            } catch (assignmentError: any) {
-              console.warn(
-                `Failed to fetch assignments for ${config.displayName}:`,
-                assignmentError?.message,
-              );
-              assignmentsResponse = { value: [] };
-            }
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
+            const assignmentResult = await this.readPolicyRelation(
+              config,
+              "deviceConfigurations",
+              `/deviceManagement/deviceConfigurations('${config.id}')/assignments`,
             );
+            const assignments = assignmentResult.items;
 
             // The config object already contains all settings as properties
             return {
               ...config,
               configType: this.getConfigurationType(config["@odata.type"]),
               assignments: assignments || [],
+              collectionStatus: {
+                assignments: assignmentResult.complete
+                  ? "complete"
+                  : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1144,6 +1210,18 @@ export class DetailedIntuneService {
               ...config,
               configType: "Administrative Template",
               definitionValues: definitionValuesWithPresentations,
+              collectionStatus: {
+                assignments: policyWarnings.some((warning) =>
+                  warning.startsWith("Assignments:"),
+                )
+                  ? "incomplete"
+                  : "complete",
+                settings: policyWarnings.some(
+                  (warning) => !warning.startsWith("Assignments:"),
+                )
+                  ? "incomplete"
+                  : "complete",
+              },
               assignments: assignments || [],
               version: 1,
               hasFetchError: policyWarnings.length > 0,
@@ -1211,63 +1289,31 @@ export class DetailedIntuneService {
       const detailedPolicies = await Promise.all(
         (allPolicies || []).map(async (policy: any) => {
           try {
-            // Fetch assignments with retry
-            let assignmentsResponse;
-            try {
-              assignmentsResponse = await this.retryWithBackoff(() =>
-                this.client
-                  .api(
-                    `/deviceManagement/deviceCompliancePolicies('${policy.id}')/assignments`,
-                  )
-                  .version("beta")
-                  .get(),
-              );
-            } catch (assignmentError: any) {
-              console.warn(
-                `Failed to fetch assignments for ${policy.displayName}:`,
-                assignmentError?.message,
-              );
-              assignmentsResponse = { value: [] };
-            }
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
+            const assignmentResult = await this.readPolicyRelation(
+              policy,
+              "compliancePolicies",
+              `/deviceManagement/deviceCompliancePolicies('${policy.id}')/assignments`,
             );
+            const assignments = assignmentResult.items;
 
-            // Fetch scheduled actions for rules with retry
-            // Note: Not all compliance policies support the scheduledActionsForRule endpoint
-            let scheduledActions;
-            try {
-              scheduledActions = await this.retryWithBackoff(() =>
-                this.client
-                  .api(
-                    `/deviceManagement/deviceCompliancePolicies('${policy.id}')/scheduledActionsForRule`,
-                  )
-                  .version("beta")
-                  .expand("scheduledActionConfigurations")
-                  .get(),
-              );
-            } catch (scheduledError: any) {
-              const errorMessage = scheduledError?.message || "";
-              // Don't log warnings for known API limitations (OData route not exists)
-              if (!errorMessage.includes("No OData route exists")) {
-                console.warn(
-                  `Failed to fetch scheduled actions for ${policy.displayName}:`,
-                  scheduledError?.message,
-                );
-              }
-              scheduledActions = { value: [] };
-            }
-            const scheduledActionsAll = await collectAllPages<any>(
-              this.client as unknown as Client,
-              scheduledActions,
+            const actionsResult = await this.readPolicyRelation(
+              policy,
+              "compliancePolicies",
+              `/deviceManagement/deviceCompliancePolicies('${policy.id}')/scheduledActionsForRule`,
+              "scheduledActionConfigurations",
             );
+            const scheduledActionsAll = actionsResult.items;
 
             return {
               ...policy,
               configType: "Compliance Policy",
               scheduledActionsForRule: scheduledActionsAll || [],
               assignments: assignments || [],
+              collectionStatus: {
+                assignments: assignmentResult.complete
+                  ? "complete"
+                  : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1385,28 +1431,20 @@ export class DetailedIntuneService {
               endpoint = `/deviceAppManagement/windowsManagedAppProtections('${policy.id}')/assignments`;
             }
 
-            // Fetch assignments and targeted apps
-            const assignmentsResponse = await this.client
-              .api(endpoint)
-              .version("beta")
-              .get()
-              .catch(() => ({ value: [] }));
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
-            );
-
-            const appsEndpoint = endpoint.replace(/\/assignments$/, "/apps");
-            const appsResponse = await this.client
-              .api(appsEndpoint)
-              .version("beta")
-              .top(999)
-              .get()
-              .catch(() => ({ value: [] }));
-            const apps = await collectAllPages<any>(
-              this.client as unknown as Client,
-              appsResponse,
-            );
+            const [assignmentResult, appsResult] = await Promise.all([
+              this.readPolicyRelation(
+                policy,
+                "appProtectionPolicies",
+                endpoint,
+              ),
+              this.readPolicyRelation(
+                policy,
+                "appProtectionPolicies",
+                endpoint.replace(/\/assignments$/, "/apps"),
+              ),
+            ]);
+            const assignments = assignmentResult.items;
+            const apps = appsResult.items;
 
             return {
               ...policy,
@@ -1414,6 +1452,12 @@ export class DetailedIntuneService {
               platformType: policy.platform,
               assignments: assignments || [],
               apps: apps || [],
+              collectionStatus: {
+                assignments: assignmentResult.complete
+                  ? "complete"
+                  : "incomplete",
+                apps: appsResult.complete ? "complete" : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1463,33 +1507,38 @@ export class DetailedIntuneService {
       const detailedIntents = await Promise.all(
         (allIntents || []).map(async (intent: any) => {
           try {
-            // Fetch categories with settings
-            const categories = await this.client
-              .api(`/deviceManagement/intents('${intent.id}')/categories`)
-              .version("beta")
-              .expand("settings")
-              .get()
-              .catch(() => ({ value: [] }));
-            const categoriesAll = await collectAllPages<any>(
-              this.client as unknown as Client,
-              categories,
-            );
-
-            // Fetch assignments
-            const assignmentsResponse = await this.client
-              .api(`/deviceManagement/intents('${intent.id}')/assignments`)
-              .version("beta")
-              .get()
-              .catch(() => ({ value: [] }));
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
-            );
+            const [categoriesResult, settingsResult, assignmentResult] =
+              await Promise.all([
+                this.readPolicyRelation(
+                  intent,
+                  "securityBaselines",
+                  `/deviceManagement/intents('${intent.id}')/categories`,
+                ),
+                this.readPolicyRelation(
+                  intent,
+                  "securityBaselines",
+                  `/deviceManagement/intents('${intent.id}')/settings`,
+                ),
+                this.readPolicyRelation(
+                  intent,
+                  "securityBaselines",
+                  `/deviceManagement/intents('${intent.id}')/assignments`,
+                ),
+              ]);
+            const categoriesAll = categoriesResult.items;
+            const assignments = assignmentResult.items;
 
             return {
               ...intent,
               configType: "Security Baseline",
               categories: categoriesAll || [],
+              settings: settingsResult.items,
+              collectionStatus: {
+                assignments: assignmentResult.complete
+                  ? "complete"
+                  : "incomplete",
+                settings: settingsResult.complete ? "complete" : "incomplete",
+              },
               assignments: assignments || [],
             };
           } catch (error) {
@@ -1553,26 +1602,21 @@ export class DetailedIntuneService {
       const detailedScripts = await Promise.all(
         (allScripts || []).map(async (script: any) => {
           try {
-            // Fetch script content
-            const scriptContent = await this.client
-              .api(`/deviceManagement/deviceManagementScripts('${script.id}')`)
-              .version("beta")
-              .select("scriptContent")
-              .get()
-              .catch(() => ({ scriptContent: null }));
-
-            // Fetch assignments
-            const assignmentsResponse = await this.client
-              .api(
-                `/deviceManagement/deviceManagementScripts('${script.id}')/assignments`,
-              )
-              .version("beta")
-              .get()
-              .catch(() => ({ value: [] }));
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
-            );
+            const endpoint = `/deviceManagement/deviceManagementScripts('${script.id}')`;
+            const [details, assignments] = await Promise.all([
+              this.readPolicyDetails(
+                script,
+                "scripts",
+                endpoint,
+                "scriptContent",
+              ),
+              this.readPolicyRelation(
+                script,
+                "scripts",
+                `${endpoint}/assignments`,
+              ),
+            ]);
+            const scriptContent = details.item;
 
             return {
               ...script,
@@ -1583,7 +1627,11 @@ export class DetailedIntuneService {
                 : null,
               configType: "PowerShell Script",
               platformType: "Windows",
-              assignments: assignments || [],
+              assignments: assignments.items,
+              collectionStatus: {
+                details: details.complete ? "complete" : "incomplete",
+                assignments: assignments.complete ? "complete" : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1615,12 +1663,12 @@ export class DetailedIntuneService {
         });
       } else {
         console.error("Error fetching Windows scripts:", error);
-        this.recordCollectionError(
-          "Windows PowerShell Scripts",
-          error,
-          "DeviceManagementScripts.Read.All",
-        );
       }
+      this.recordCollectionError(
+        "Windows PowerShell Scripts",
+        error,
+        "DeviceManagementScripts.Read.All",
+      );
       return this.partialCollectionItems(error, "PowerShell Script");
     }
   }
@@ -1645,26 +1693,21 @@ export class DetailedIntuneService {
       const detailedScripts = await Promise.all(
         (allScripts || []).map(async (script: any) => {
           try {
-            // Fetch script content
-            const scriptContent = await this.client
-              .api(`/deviceManagement/deviceShellScripts('${script.id}')`)
-              .version("beta")
-              .select("scriptContent")
-              .get()
-              .catch(() => ({ scriptContent: null }));
-
-            // Fetch assignments
-            const assignmentsResponse = await this.client
-              .api(
-                `/deviceManagement/deviceShellScripts('${script.id}')/assignments`,
-              )
-              .version("beta")
-              .get()
-              .catch(() => ({ value: [] }));
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
-            );
+            const endpoint = `/deviceManagement/deviceShellScripts('${script.id}')`;
+            const [details, assignments] = await Promise.all([
+              this.readPolicyDetails(
+                script,
+                "scripts",
+                endpoint,
+                "scriptContent",
+              ),
+              this.readPolicyRelation(
+                script,
+                "scripts",
+                `${endpoint}/assignments`,
+              ),
+            ]);
+            const scriptContent = details.item;
 
             return {
               ...script,
@@ -1675,7 +1718,11 @@ export class DetailedIntuneService {
                 : null,
               configType: "Shell Script",
               platformType: "macOS",
-              assignments: assignments || [],
+              assignments: assignments.items,
+              collectionStatus: {
+                details: details.complete ? "complete" : "incomplete",
+                assignments: assignments.complete ? "complete" : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1705,12 +1752,12 @@ export class DetailedIntuneService {
         });
       } else {
         console.error("Error fetching macOS scripts:", error);
-        this.recordCollectionError(
-          "macOS Shell Scripts",
-          error,
-          "DeviceManagementScripts.Read.All",
-        );
       }
+      this.recordCollectionError(
+        "macOS Shell Scripts",
+        error,
+        "DeviceManagementScripts.Read.All",
+      );
       return this.partialCollectionItems(error, "Shell Script");
     }
   }
@@ -1826,52 +1873,23 @@ export class DetailedIntuneService {
       const detailedConfigs = await Promise.all(
         (allConfigs || []).map(async (config: any) => {
           try {
-            // Fetch full configuration details including all settings
-            let fullConfig;
-            try {
-              fullConfig = await this.retryWithBackoff(() =>
-                this.client
-                  .api(
-                    `/deviceAppManagement/mobileAppConfigurations('${config.id}')`,
-                  )
-                  .version("beta")
-                  .get(),
-              );
-            } catch (detailsError: any) {
-              console.warn(
-                `Failed to fetch full details for ${config.displayName}:`,
-                detailsError?.message,
-              );
-              fullConfig = config; // Fallback to basic config
-            }
-
-            // Fetch assignments with retry
-            let assignmentsResponse;
-            try {
-              assignmentsResponse = await this.retryWithBackoff(() =>
-                this.client
-                  .api(
-                    `/deviceAppManagement/mobileAppConfigurations('${config.id}')/assignments`,
-                  )
-                  .version("beta")
-                  .get(),
-              );
-            } catch (assignmentError: any) {
-              console.warn(
-                `Failed to fetch assignments for ${config.displayName}:`,
-                assignmentError?.message,
-              );
-              assignmentsResponse = { value: [] };
-            }
-            const assignments = await collectAllPages<any>(
-              this.client as unknown as Client,
-              assignmentsResponse,
-            );
-
+            const endpoint = `/deviceAppManagement/mobileAppConfigurations('${config.id}')`;
+            const [details, assignments] = await Promise.all([
+              this.readPolicyDetails(config, "appConfigurations", endpoint),
+              this.readPolicyRelation(
+                config,
+                "appConfigurations",
+                `${endpoint}/assignments`,
+              ),
+            ]);
             return {
-              ...fullConfig, // Use full config with all settings
+              ...details.item,
               configType: "App Configuration",
-              assignments: assignments || [],
+              assignments: assignments.items,
+              collectionStatus: {
+                details: details.complete ? "complete" : "incomplete",
+                assignments: assignments.complete ? "complete" : "incomplete",
+              },
             };
           } catch (error) {
             console.error(
@@ -1921,6 +1939,11 @@ export class DetailedIntuneService {
       const detailedPolicies = await Promise.all(
         list.map(async (policy: any) => {
           try {
+            const assignmentResult = await this.readPolicyRelation(
+              policy,
+              "windowsUpdatePolicies",
+              `/deviceManagement/deviceConfigurations('${policy.id}')/assignments`,
+            );
             const detailResponse = await this.client
               .api(`/deviceManagement/deviceConfigurations/${policy.id}`)
               .version("beta")
@@ -1930,10 +1953,23 @@ export class DetailedIntuneService {
               ...policy,
               ...detailResponse,
               configType: "Windows Update Ring",
-              assignments:
-                policy.assignments || detailResponse.assignments || [],
+              assignments: assignmentResult.items,
+              collectionStatus: {
+                assignments: assignmentResult.complete
+                  ? "complete"
+                  : "incomplete",
+              },
             };
           } catch (error) {
+            this.fetchErrors.push({
+              policyId: policy.id,
+              policyName: policy.displayName ?? policy.id,
+              policyType: "Windows Update Policies",
+              familyKey: "windowsUpdatePolicies",
+              endpoint: `/deviceManagement/deviceConfigurations/${policy.id}`,
+              error: this.graphError(error).message,
+              partial: true,
+            });
             console.error(
               `Error fetching details for Windows Update policy ${policy.id}:`,
               error,
@@ -2148,6 +2184,7 @@ export class DetailedIntuneService {
   }
 
   async getAllDetailedConfigurations(includeConditionalAccess = true) {
+    const collectionStartedAt = new Date().toISOString();
     console.log("Fetching all detailed Intune configurations...");
     this.permissionErrors = []; // Reset permission errors
     this.fetchErrors = []; // Reset fetch errors
@@ -2422,6 +2459,11 @@ export class DetailedIntuneService {
     );
 
     return {
+      collectedAt: new Date().toISOString(),
+      collectionStartedAt,
+      collectionSkippedFamilies: includeConditionalAccess
+        ? []
+        : ["conditionalAccessPolicies"],
       settingsCatalog: safeSettingsCatalog,
       deviceConfigurations: safeDeviceConfigurations,
       administrativeTemplates: safeAdministrativeTemplates,

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -187,6 +187,71 @@ export class DetailedIntuneService {
   private client: ReturnType<typeof createGraphClient>;
   private permissionErrors: PermissionError[] = [];
   private fetchErrors: FetchError[] = [];
+  private async readComplianceScheduledActions(policy: any) {
+    // Some Intune backends reject GET on the scheduledActionsForRule relation.
+    // Read the parent policy with both navigation collections expanded instead.
+    const endpoint = `/deviceManagement/deviceCompliancePolicies/${encodeURIComponent(policy.id)}`;
+    const expand =
+      "scheduledActionsForRule($expand=scheduledActionConfigurations)";
+    const errors: unknown[] = [];
+    let items: any[] = [];
+    try {
+      const response = await this.retryWithBackoff(() =>
+        this.client.api(endpoint).version("beta").expand(expand).get(),
+      );
+      if (!Array.isArray(response?.scheduledActionsForRule))
+        throw new Error(
+          "Graph omitted the expanded scheduledActionsForRule collection",
+        );
+      const rules = await collectAllPagesWithStatus<any>(
+        this.client as unknown as Client,
+        {
+          value: response.scheduledActionsForRule,
+          "@odata.nextLink": response["scheduledActionsForRule@odata.nextLink"],
+        },
+      );
+      if (!rules.complete) errors.push(rules.error);
+      items = await Promise.all(
+        rules.items.map(async (rule: any) => {
+          if (!Array.isArray(rule?.scheduledActionConfigurations)) {
+            errors.push(
+              new Error(
+                "Graph omitted an expanded scheduledActionConfigurations collection",
+              ),
+            );
+            return rule;
+          }
+          const actions = await collectAllPagesWithStatus<any>(
+            this.client as unknown as Client,
+            {
+              value: rule.scheduledActionConfigurations,
+              "@odata.nextLink":
+                rule["scheduledActionConfigurations@odata.nextLink"],
+            },
+          );
+          if (!actions.complete) errors.push(actions.error);
+          return { ...rule, scheduledActionConfigurations: actions.items };
+        }),
+      );
+    } catch (error) {
+      errors.push(error);
+    }
+    for (const error of errors) {
+      const details = this.graphError(error);
+      this.fetchErrors.push({
+        policyId: policy.id,
+        policyName: policy.displayName ?? policy.id,
+        policyType: "Compliance Policies",
+        familyKey: "compliancePolicies",
+        endpoint: `${endpoint}?$expand=${expand}`,
+        error: `Scheduled noncompliance actions could not be fully collected: ${details.message}`,
+        statusCode: details.statusCode,
+        errorCode: details.errorCode,
+        partial: true,
+      });
+    }
+    return { items, complete: errors.length === 0 };
+  }
   private async readPolicyDetails(
     policy: any,
     familyKey: string,
@@ -1296,12 +1361,8 @@ export class DetailedIntuneService {
             );
             const assignments = assignmentResult.items;
 
-            const actionsResult = await this.readPolicyRelation(
-              policy,
-              "compliancePolicies",
-              `/deviceManagement/deviceCompliancePolicies('${policy.id}')/scheduledActionsForRule`,
-              "scheduledActionConfigurations",
-            );
+            const actionsResult =
+              await this.readComplianceScheduledActions(policy);
             const scheduledActionsAll = actionsResult.items;
 
             return {
@@ -1310,6 +1371,9 @@ export class DetailedIntuneService {
               scheduledActionsForRule: scheduledActionsAll || [],
               assignments: assignments || [],
               collectionStatus: {
+                scheduledActionsForRule: actionsResult.complete
+                  ? "complete"
+                  : "incomplete",
                 assignments: assignmentResult.complete
                   ? "complete"
                   : "incomplete",

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -1,4 +1,5 @@
-import { Client } from "@microsoft/microsoft-graph-client";
+import { retryGraphRequest } from "./graph-request";
+import type { Client } from "@microsoft/microsoft-graph-client";
 import "isomorphic-fetch";
 import {
   collectAllPages,
@@ -19,13 +20,8 @@ import {
   collectConfiguredSettingDefinitionIds,
 } from "./configuration-parser";
 
-export function createGraphClient(accessToken: string) {
-  return Client.init({
-    authProvider: (done) => {
-      done(null, accessToken);
-    },
-  });
-}
+import { createGraphClient } from "./graph-client";
+export { createGraphClient } from "./graph-client";
 
 // Enhanced configuration types with settings
 export interface ConfigurationSettingInstance {
@@ -263,7 +259,11 @@ export class DetailedIntuneService {
         const request = this.client.api(endpoint).version("beta");
         return (select ? request.select(select) : request).get();
       });
-      return { item: { ...policy, ...item }, complete: true };
+      return {
+        item: { ...policy, ...item },
+        complete: true,
+        errorMessage: undefined,
+      };
     } catch (error) {
       const details = this.graphError(error);
       this.fetchErrors.push({
@@ -276,7 +276,7 @@ export class DetailedIntuneService {
         statusCode: details.statusCode,
         partial: true,
       });
-      return { item: policy, complete: false };
+      return { item: policy, complete: false, errorMessage: details.message };
     }
   }
   private async readPolicyRelation(
@@ -362,8 +362,12 @@ export class DetailedIntuneService {
   ];
   private nextConfigurationSettingDefinitionRequestLane = 0;
 
-  constructor(accessToken: string, progressCallback?: ProgressCallback) {
-    this.client = createGraphClient(accessToken);
+  constructor(
+    accessToken: string,
+    progressCallback?: ProgressCallback,
+    signal?: AbortSignal,
+  ) {
+    this.client = createGraphClient(accessToken, { signal, budgetMs: 105_000 });
     this.progressCallback = progressCallback;
   }
 
@@ -660,7 +664,10 @@ export class DetailedIntuneService {
       if (entry.childCollections?.length && rawItems.length > 0) {
         rawItems = await mapWithConcurrency(rawItems, 4, async (item: any) => {
           if (!item?.id) return item;
-          const enriched = { ...item };
+          const enriched = {
+            ...item,
+            collectionStatus: { ...item.collectionStatus },
+          };
           const enrichmentWarnings: string[] = [];
           for (const child of entry.childCollections || []) {
             try {
@@ -671,19 +678,49 @@ export class DetailedIntuneService {
                 childRequest = childRequest.expand(child.expand);
               if (child.shape !== "singleton")
                 childRequest = childRequest.top(getRegistryPageSize(child));
-              const childResponse = await this.retryWithBackoff(
-                () => childRequest.get(),
-                2,
-                300,
-              );
+              let childResponse;
+              try {
+                childResponse = await this.retryWithBackoff(
+                  () => childRequest.get(),
+                  2,
+                  300,
+                );
+              } catch (error) {
+                const details = this.graphError(error);
+                if (
+                  child.shape === "singleton" ||
+                  details.statusCode !== 400 ||
+                  !/No OData route exists/i.test(details.message)
+                )
+                  throw error;
+                const parent = await this.retryWithBackoff(() =>
+                  this.client
+                    .api(`${entry.path}/${encodeURIComponent(item.id)}`)
+                    .version("beta")
+                    .expand(child.path)
+                    .get(),
+                );
+                if (!Array.isArray(parent?.[child.property]))
+                  throw new Error(
+                    `Graph omitted the expanded ${child.property} collection`,
+                  );
+                childResponse = {
+                  value: parent[child.property],
+                  "@odata.nextLink": parent[`${child.property}@odata.nextLink`],
+                };
+              }
               if (child.shape === "singleton") {
                 enriched[child.property] = childResponse;
+                enriched.collectionStatus[child.property] = "complete";
               } else {
                 const childPages = await collectAllPagesWithStatus<any>(
                   this.client as unknown as Client,
                   childResponse,
                 );
                 enriched[child.property] = childPages.items;
+                enriched.collectionStatus[child.property] = childPages.complete
+                  ? "complete"
+                  : "incomplete";
                 if (!childPages.complete) {
                   enrichmentWarnings.push(
                     `${child.property}: ${this.graphError(childPages.error).message}`,
@@ -691,6 +728,7 @@ export class DetailedIntuneService {
                 }
               }
             } catch (error: any) {
+              enriched.collectionStatus[child.property] = "incomplete";
               enrichmentWarnings.push(
                 `${child.property}: ${this.graphError(error).message}`,
               );
@@ -762,67 +800,13 @@ export class DetailedIntuneService {
     );
   }
 
-  // Helper function to add delay between requests
-  private delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
   // Helper function to retry an API call with exponential backoff and jitter
   private async retryWithBackoff<T>(
     fn: () => Promise<T>,
     maxRetries: number = 5,
     initialDelay: number = 1000,
   ): Promise<T> {
-    let lastError: any;
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        return await fn();
-      } catch (error: any) {
-        lastError = error;
-        const statusCode = error?.statusCode || error?.response?.status;
-        const errorMessage = error?.message || "";
-
-        // Don't retry on permanent failures
-        // 404 or 403 - resource doesn't exist or forbidden
-        // "No OData route exists" - API endpoint not supported for this resource
-        if (
-          statusCode === 404 ||
-          statusCode === 403 ||
-          errorMessage.includes("No OData route exists")
-        ) {
-          throw error;
-        }
-
-        // If this is the last attempt, throw the error
-        if (attempt === maxRetries - 1) {
-          throw error;
-        }
-
-        // Check if it's a rate limit error (429)
-        if (statusCode === 429 || error?.code === "TooManyRequests") {
-          // Try to get Retry-After header
-          const retryAfter =
-            error?.headers?.["retry-after"] || error?.retryAfter;
-          const retryDelay = retryAfter ? parseInt(retryAfter) * 1000 : 30000; // Default to 30s
-          console.log(
-            `Rate limited (429). Waiting ${retryDelay}ms before retry ${attempt + 1}/${maxRetries}`,
-          );
-          await this.delay(retryDelay);
-          continue;
-        }
-
-        // Wait with exponential backoff plus jitter to avoid thundering herd
-        const exponentialDelay = initialDelay * Math.pow(2, attempt);
-        const jitter = Math.random() * 500; // Random jitter up to 500ms
-        const delayMs = exponentialDelay + jitter;
-
-        console.log(
-          `Retry attempt ${attempt + 1}/${maxRetries} after ${Math.round(delayMs)}ms (error: ${error?.message || "Unknown"})`,
-        );
-        await this.delay(delayMs);
-      }
-    }
-    throw lastError;
+    return retryGraphRequest(fn, { maxAttempts: maxRetries, initialDelay });
   }
 
   // 1. Settings Catalog with full settings
@@ -1051,12 +1035,6 @@ export class DetailedIntuneService {
         );
 
         detailedPolicies.push(...batchResults);
-
-        // Add a small delay between batches to avoid rate limiting
-        // Reduced from 500ms to 200ms for faster processing
-        if (i + batchSize < (allPolicies || []).length) {
-          await this.delay(200);
-        }
       }
 
       console.log(
@@ -1487,31 +1465,27 @@ export class DetailedIntuneService {
         ],
       );
 
-      const allIosPolicies = await collectAllPages<any>(
-        this.client as unknown as Client,
-        iosPolicies,
+      const platformResults = await Promise.all(
+        [
+          { platform: "iOS", response: iosPolicies },
+          { platform: "Android", response: androidPolicies },
+          { platform: "Windows", response: windowsPolicies },
+        ].map(async ({ platform, response }) => {
+          const pages = await collectAllPagesWithStatus<any>(
+            this.client as unknown as Client,
+            response,
+          );
+          if (!pages.complete) {
+            this.recordCollectionError(
+              `${platform} App Protection Policies`,
+              new GraphPaginationError(pages.items, pages.error),
+              "DeviceManagementApps.Read.All",
+            );
+          }
+          return pages.items.map((policy: any) => ({ ...policy, platform }));
+        }),
       );
-      const allAndroidPolicies = await collectAllPages<any>(
-        this.client as unknown as Client,
-        androidPolicies,
-      );
-      const allWindowsPolicies = await collectAllPages<any>(
-        this.client as unknown as Client,
-        windowsPolicies,
-      );
-
-      // Combine all policies and fetch their assignments
-      const allPolicies = [
-        ...(allIosPolicies || []).map((p: any) => ({ ...p, platform: "iOS" })),
-        ...(allAndroidPolicies || []).map((p: any) => ({
-          ...p,
-          platform: "Android",
-        })),
-        ...(allWindowsPolicies || []).map((p: any) => ({
-          ...p,
-          platform: "Windows",
-        })),
-      ];
+      const allPolicies = platformResults.flat();
 
       const detailedPolicies = await Promise.all(
         allPolicies.map(async (policy: any) => {
@@ -1608,6 +1582,11 @@ export class DetailedIntuneService {
                   intent,
                   "securityBaselines",
                   `/deviceManagement/intents('${intent.id}')/categories`,
+                  undefined,
+                  {
+                    endpoint: `/deviceManagement/intents/${encodeURIComponent(intent.id)}`,
+                    relation: "categories",
+                  },
                 ),
                 this.readPolicyRelation(
                   intent,
@@ -1629,6 +1608,9 @@ export class DetailedIntuneService {
               categories: categoriesAll || [],
               settings: settingsResult.items,
               collectionStatus: {
+                categories: categoriesResult.complete
+                  ? "complete"
+                  : "incomplete",
                 assignments: assignmentResult.complete
                   ? "complete"
                   : "incomplete",
@@ -2037,47 +2019,26 @@ export class DetailedIntuneService {
       // Fetch detailed settings for each policy
       const detailedPolicies = await Promise.all(
         list.map(async (policy: any) => {
-          try {
-            const assignmentResult = await this.readPolicyRelation(
+          const endpoint = `/deviceManagement/deviceConfigurations/${encodeURIComponent(policy.id)}`;
+          const [assignments, details] = await Promise.all([
+            this.readPolicyRelation(
               policy,
               "windowsUpdatePolicies",
               `/deviceManagement/deviceConfigurations('${policy.id}')/assignments`,
-            );
-            const detailResponse = await this.client
-              .api(`/deviceManagement/deviceConfigurations/${policy.id}`)
-              .version("beta")
-              .get();
-
-            return {
-              ...policy,
-              ...detailResponse,
-              configType: "Windows Update Ring",
-              assignments: assignmentResult.items,
-              collectionStatus: {
-                assignments: assignmentResult.complete
-                  ? "complete"
-                  : "incomplete",
-              },
-            };
-          } catch (error) {
-            this.fetchErrors.push({
-              policyId: policy.id,
-              policyName: policy.displayName ?? policy.id,
-              policyType: "Windows Update Policies",
-              familyKey: "windowsUpdatePolicies",
-              endpoint: `/deviceManagement/deviceConfigurations/${policy.id}`,
-              error: this.graphError(error).message,
-              partial: true,
-            });
-            console.error(
-              `Error fetching details for Windows Update policy ${policy.id}:`,
-              error,
-            );
-            return {
-              ...policy,
-              configType: "Windows Update Ring",
-            };
-          }
+            ),
+            this.readPolicyDetails(policy, "windowsUpdatePolicies", endpoint),
+          ]);
+          return {
+            ...details.item,
+            configType: "Windows Update Ring",
+            assignments: assignments.items,
+            hasFetchError: !details.complete,
+            fetchErrorMessage: details.errorMessage,
+            collectionStatus: {
+              details: details.complete ? "complete" : "incomplete",
+              assignments: assignments.complete ? "complete" : "incomplete",
+            },
+          };
         }),
       );
 
@@ -2265,10 +2226,24 @@ export class DetailedIntuneService {
   ): Promise<T> {
     return promise.then(
       (value) => {
-        this.progressSectionsFor(step, value).forEach((section) =>
+        const sections = this.progressSectionsFor(step, value);
+        sections.forEach((section) =>
           this.progressCallback?.({ step, type: "section", section }),
         );
-        this.progressCallback?.({ step, type: "completed" });
+        const incomplete =
+          this.fetchErrors.some(
+            (error) =>
+              error.policyType === step ||
+              sections.some((section) => section.familyKey === error.familyKey),
+          ) ||
+          (Array.isArray(value) && value.some((section) => section?.error));
+        this.progressCallback?.({
+          step,
+          type: incomplete ? "error" : "completed",
+          message: incomplete
+            ? "Collection finished with incomplete results"
+            : undefined,
+        });
         return value;
       },
       (error: any) => {

--- a/src/lib/intune-detailed-client.ts
+++ b/src/lib/intune-detailed-client.ts
@@ -284,13 +284,44 @@ export class DetailedIntuneService {
     familyKey: string,
     endpoint: string,
     expand?: string,
+    expandedParent?: { endpoint: string; relation: string },
   ) {
     let items: any[] = [];
     try {
-      const response = await this.retryWithBackoff(() => {
-        const request = this.client.api(endpoint).version("beta");
-        return (expand ? request.expand(expand) : request).get();
-      });
+      let response;
+      try {
+        response = await this.retryWithBackoff(() => {
+          const request = this.client.api(endpoint).version("beta");
+          return (expand ? request.expand(expand) : request).get();
+        });
+      } catch (error) {
+        const details = this.graphError(error);
+        if (
+          !expandedParent ||
+          details.statusCode !== 400 ||
+          !/No OData route exists/i.test(details.message)
+        )
+          throw error;
+        // Compatibility fallback for backends rejecting navigation GET requests.
+        endpoint = `${expandedParent.endpoint}?$expand=${expandedParent.relation}`;
+        const parent = await this.retryWithBackoff(() =>
+          this.client
+            .api(expandedParent.endpoint)
+            .version("beta")
+            .expand(expandedParent.relation)
+            .get(),
+        );
+        if (!Array.isArray(parent?.[expandedParent.relation])) {
+          throw new Error(
+            `Graph omitted the expanded ${expandedParent.relation} collection`,
+          );
+        }
+        response = {
+          value: parent[expandedParent.relation],
+          "@odata.nextLink":
+            parent[`${expandedParent.relation}@odata.nextLink`],
+        };
+      }
       const pages = await collectAllPagesWithStatus<any>(
         this.client as unknown as Client,
         response,
@@ -1666,7 +1697,7 @@ export class DetailedIntuneService {
       const detailedScripts = await Promise.all(
         (allScripts || []).map(async (script: any) => {
           try {
-            const endpoint = `/deviceManagement/deviceManagementScripts('${script.id}')`;
+            const endpoint = `/deviceManagement/deviceManagementScripts/${encodeURIComponent(script.id)}`;
             const [details, assignments] = await Promise.all([
               this.readPolicyDetails(
                 script,
@@ -1678,6 +1709,8 @@ export class DetailedIntuneService {
                 script,
                 "scripts",
                 `${endpoint}/assignments`,
+                undefined,
+                { endpoint, relation: "assignments" },
               ),
             ]);
             const scriptContent = details.item;
@@ -1757,7 +1790,7 @@ export class DetailedIntuneService {
       const detailedScripts = await Promise.all(
         (allScripts || []).map(async (script: any) => {
           try {
-            const endpoint = `/deviceManagement/deviceShellScripts('${script.id}')`;
+            const endpoint = `/deviceManagement/deviceShellScripts/${encodeURIComponent(script.id)}`;
             const [details, assignments] = await Promise.all([
               this.readPolicyDetails(
                 script,
@@ -1769,6 +1802,8 @@ export class DetailedIntuneService {
                 script,
                 "scripts",
                 `${endpoint}/assignments`,
+                undefined,
+                { endpoint, relation: "assignments" },
               ),
             ]);
             const scriptContent = details.item;

--- a/src/lib/intune-graph-client.ts
+++ b/src/lib/intune-graph-client.ts
@@ -1,14 +1,9 @@
-import { Client } from "@microsoft/microsoft-graph-client";
+import type { Client } from "@microsoft/microsoft-graph-client";
 import "isomorphic-fetch";
-import { collectAllPages } from "./graph-paging";
+import { collectAllPages, GraphPaginationError } from "./graph-paging";
 
-export function createGraphClient(accessToken: string) {
-  return Client.init({
-    authProvider: (done) => {
-      done(null, accessToken);
-    },
-  });
-}
+import { createGraphClient } from "./graph-client";
+export { createGraphClient } from "./graph-client";
 
 // Generic configuration type
 export interface BaseConfiguration {
@@ -26,6 +21,22 @@ export interface BaseConfiguration {
 }
 
 export class IntuneConfigurationService {
+  private collectionErrors: Array<{
+    source: string;
+    message: string;
+    statusCode?: number;
+  }> = [];
+  getFetchErrors() {
+    return [...this.collectionErrors];
+  }
+  private captureError(error: any) {
+    this.collectionErrors.push({
+      source: "Legacy Graph collection",
+      message: error?.message ?? "Graph read failed",
+      statusCode: error?.statusCode ?? error?.cause?.statusCode,
+    });
+  }
+
   private client: ReturnType<typeof createGraphClient>;
 
   constructor(accessToken: string) {
@@ -38,22 +49,28 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/configurationPolicies")
         .version("beta")
-        .select("id,name,description,platforms,technologies,createdDateTime,lastModifiedDateTime,settingCount,roleScopeTagIds")
+        .select(
+          "id,name,description,platforms,technologies,createdDateTime,lastModifiedDateTime,settingCount,roleScopeTagIds",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       // Map the response to our standard format
       return items.map((policy: any) => ({
         ...policy,
         displayName: policy.name || policy.displayName,
         "@odata.type": "#microsoft.graph.deviceManagementConfigurationPolicy",
         platformType: policy.platforms,
-        configType: "Settings Catalog"
+        configType: "Settings Catalog",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching configuration policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -61,11 +78,14 @@ export class IntuneConfigurationService {
   async getConfigurationPolicySettings(policyId: string): Promise<any> {
     try {
       const response = await this.client
-        .api(`/deviceManagement/configurationPolicies('${policyId}')?$expand=settings`)
+        .api(
+          `/deviceManagement/configurationPolicies('${policyId}')?$expand=settings`,
+        )
         .version("beta")
         .get();
       return response;
     } catch (error) {
+      this.captureError(error);
       console.error(`Error fetching settings for policy ${policyId}:`, error);
       return null;
     }
@@ -77,18 +97,24 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/deviceConfigurations")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((config: any) => ({
         ...config,
-        configType: "Device Configuration (Template)"
+        configType: "Device Configuration (Template)",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching device configurations:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -98,20 +124,26 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/groupPolicyConfigurations")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,roleScopeTagIds")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,roleScopeTagIds",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((config: any) => ({
         ...config,
         "@odata.type": "#microsoft.graph.groupPolicyConfiguration",
         configType: "Administrative Template",
-        version: 1 // Group Policy configs don't have version field
+        version: 1, // Group Policy configs don't have version field
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching group policy configurations:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -121,19 +153,25 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/intents")
         .version("beta")
-        .select("id,displayName,description,lastModifiedDateTime,isAssigned,templateId,roleScopeTagIds")
+        .select(
+          "id,displayName,description,lastModifiedDateTime,isAssigned,templateId,roleScopeTagIds",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((intent: any) => ({
         ...intent,
         "@odata.type": "#microsoft.graph.deviceManagementIntent",
-        configType: "Security Baseline/Endpoint Security"
+        configType: "Security Baseline/Endpoint Security",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching device management intents:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -141,13 +179,16 @@ export class IntuneConfigurationService {
   async getIntentSettings(intentId: string): Promise<any> {
     try {
       const response = await this.client
-        .api(`/deviceManagement/intents/${intentId}/categories?$expand=settings`)
+        .api(
+          `/deviceManagement/intents/${intentId}/categories?$expand=settings`,
+        )
         .version("beta")
         .get();
       return response.value || [];
     } catch (error) {
+      this.captureError(error);
       console.error(`Error fetching intent settings for ${intentId}:`, error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -157,18 +198,24 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/deviceCompliancePolicies")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((policy: any) => ({
         ...policy,
-        configType: "Compliance Policy"
+        configType: "Compliance Policy",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching compliance policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -178,20 +225,26 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/deviceShellScripts")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,fileName,scriptContent,runAsAccount")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,fileName,scriptContent,runAsAccount",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((script: any) => ({
         ...script,
         "@odata.type": "#microsoft.graph.deviceShellScript",
         configType: "Shell Script (macOS)",
-        platformType: "macOS"
+        platformType: "macOS",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching shell scripts:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -201,20 +254,26 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/deviceManagementScripts")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,fileName,runAsAccount,enforceSignatureCheck,runAs32Bit")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,fileName,runAsAccount,enforceSignatureCheck,runAs32Bit",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((script: any) => ({
         ...script,
         "@odata.type": "#microsoft.graph.deviceManagementScript",
         configType: "PowerShell Script (Windows)",
-        platformType: "Windows"
+        platformType: "Windows",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching PowerShell scripts:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -225,18 +284,24 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceAppManagement/targetedManagedAppConfigurations")
         .version("beta")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((config: any) => ({
         ...config,
-        configType: "App Configuration Policy"
+        configType: "App Configuration Policy",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching app configuration policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -247,19 +312,25 @@ export class IntuneConfigurationService {
         .api("/deviceManagement/deviceConfigurations")
         .version("beta")
         .filter("isof('microsoft.graph.windowsUpdateForBusinessConfiguration')")
-        .select("id,displayName,description,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((policy: any) => ({
         ...policy,
         configType: "Windows Update Policy",
-        platformType: "Windows"
+        platformType: "Windows",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching Windows Update policies:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -269,18 +340,24 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/deviceEnrollmentConfigurations")
         .version("beta")
-        .select("id,displayName,description,priority,createdDateTime,lastModifiedDateTime,version")
+        .select(
+          "id,displayName,description,priority,createdDateTime,lastModifiedDateTime,version",
+        )
         .top(999)
         .get();
-      
-      const items = await collectAllPages<any>(this.client as unknown as Client, response);
+
+      const items = await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
       return items.map((config: any) => ({
         ...config,
-        configType: "Enrollment Configuration"
+        configType: "Enrollment Configuration",
       }));
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching enrollment configurations:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
@@ -290,31 +367,37 @@ export class IntuneConfigurationService {
       const response = await this.client
         .api("/deviceManagement/templates")
         .version("beta")
-        .select("id,displayName,description,publishedDateTime,platformType,templateType")
+        .select(
+          "id,displayName,description,publishedDateTime,platformType,templateType",
+        )
         .top(999)
         .get();
-      return await collectAllPages<any>(this.client as unknown as Client, response);
+      return await collectAllPages<any>(
+        this.client as unknown as Client,
+        response,
+      );
     } catch (error) {
+      this.captureError(error);
       console.error("Error fetching templates:", error);
-      return [];
+      return error instanceof GraphPaginationError ? error.items : [];
     }
   }
 
   // Main method to get ALL configurations
   async getAllDeviceConfigurations() {
     console.log("Fetching all Intune device configurations...");
-    
+
     const [
-      configurationPolicies,     // Settings Catalog
-      deviceConfigurations,       // Traditional templates
-      groupPolicyConfigs,         // Administrative templates
-      intents,                    // Security baselines & endpoint security
-      compliancePolicies,        // Compliance
-      shellScripts,              // macOS scripts
-      powerShellScripts,         // Windows scripts
-      appConfigs,                // App configuration
-      windowsUpdatePolicies,     // Windows Update
-      enrollmentConfigs          // Enrollment
+      configurationPolicies, // Settings Catalog
+      deviceConfigurations, // Traditional templates
+      groupPolicyConfigs, // Administrative templates
+      intents, // Security baselines & endpoint security
+      compliancePolicies, // Compliance
+      shellScripts, // macOS scripts
+      powerShellScripts, // Windows scripts
+      appConfigs, // App configuration
+      windowsUpdatePolicies, // Windows Update
+      enrollmentConfigs, // Enrollment
     ] = await Promise.all([
       this.getConfigurationPolicies(),
       this.getDeviceConfigurations(),
@@ -325,7 +408,7 @@ export class IntuneConfigurationService {
       this.getDeviceManagementScripts(),
       this.getManagedAppPolicies(),
       this.getWindowsUpdatePolicies(),
-      this.getEnrollmentConfigurations()
+      this.getEnrollmentConfigurations(),
     ]);
 
     // Optionally fetch detailed settings for Settings Catalog policies (currently disabled)
@@ -337,6 +420,10 @@ export class IntuneConfigurationService {
     // );
 
     return {
+      fetchErrors: this.getFetchErrors(),
+      collectionStatus: this.collectionErrors.length
+        ? "incomplete"
+        : "complete",
       settingsCatalog: configurationPolicies,
       deviceConfigurations,
       administrativeTemplates: groupPolicyConfigs,
@@ -344,19 +431,19 @@ export class IntuneConfigurationService {
       compliancePolicies,
       scripts: {
         macOS: shellScripts,
-        windows: powerShellScripts
+        windows: powerShellScripts,
       },
       appConfigurations: appConfigs,
       windowsUpdatePolicies,
       enrollmentConfigurations: enrollmentConfigs,
-      
+
       // Summary
       summary: {
-        totalConfigurations: 
-          configurationPolicies.length + 
-          deviceConfigurations.length + 
-          groupPolicyConfigs.length + 
-          intents.length + 
+        totalConfigurations:
+          configurationPolicies.length +
+          deviceConfigurations.length +
+          groupPolicyConfigs.length +
+          intents.length +
           compliancePolicies.length +
           shellScripts.length +
           powerShellScripts.length +
@@ -372,22 +459,28 @@ export class IntuneConfigurationService {
           scripts: shellScripts.length + powerShellScripts.length,
           appConfigurations: appConfigs.length,
           windowsUpdatePolicies: windowsUpdatePolicies.length,
-          enrollmentConfigurations: enrollmentConfigs.length
-        }
-      }
+          enrollmentConfigurations: enrollmentConfigs.length,
+        },
+      },
     };
   }
 
   // Get configurations by platform
-  async getConfigurationsByPlatform(platform: 'Windows' | 'macOS' | 'iOS' | 'Android') {
+  async getConfigurationsByPlatform(
+    platform: "Windows" | "macOS" | "iOS" | "Android",
+  ) {
     const allConfigs = await this.getAllDeviceConfigurations();
-    
+
     // Filter configurations by platform
     const filteredConfigs = {
-      settingsCatalog: allConfigs.settingsCatalog.filter(c => 
-        c.platformType?.includes(platform) || c.platforms?.includes(platform.toLowerCase())
+      fetchErrors: allConfigs.fetchErrors,
+      collectionStatus: allConfigs.collectionStatus,
+      settingsCatalog: allConfigs.settingsCatalog.filter(
+        (c) =>
+          c.platformType?.includes(platform) ||
+          c.platforms?.includes(platform.toLowerCase()),
       ),
-      deviceConfigurations: allConfigs.deviceConfigurations.filter(c => {
+      deviceConfigurations: allConfigs.deviceConfigurations.filter((c) => {
         const type = c["@odata.type"]?.toLowerCase() || "";
         return type.includes(platform.toLowerCase());
       }),

--- a/src/lib/intune-policy-registry.ts
+++ b/src/lib/intune-policy-registry.ts
@@ -58,6 +58,7 @@ export const ADDITIONAL_FAMILY_LABELS: Record<
 export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   {
     key: "windowsFeatureUpdateProfiles",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Feature update profiles",
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsFeatureUpdateProfiles",
@@ -66,6 +67,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "windowsQualityUpdateProfiles",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Quality update profiles",
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsQualityUpdateProfiles",
@@ -74,6 +76,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "windowsQualityUpdatePolicies",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Expedite quality update policies",
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsQualityUpdatePolicies",
@@ -82,6 +85,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "windowsDriverUpdateProfiles",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Driver update profiles",
     family: "windowsUpdateProfiles",
     path: "/deviceManagement/windowsDriverUpdateProfiles",
@@ -98,6 +102,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "deviceComplianceScripts",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Compliance scripts",
     family: "scriptsAndRemediations",
     path: "/deviceManagement/deviceComplianceScripts",
@@ -105,6 +110,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "deviceCustomAttributeShellScripts",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "macOS custom attributes",
     family: "scriptsAndRemediations",
     path: "/deviceManagement/deviceCustomAttributeShellScripts",
@@ -127,6 +133,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "appleUserInitiatedEnrollmentProfiles",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Apple user-initiated profiles",
     family: "enrollmentAndProvisioning",
     path: "/deviceManagement/appleUserInitiatedEnrollmentProfiles",
@@ -141,6 +148,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "mobileApps",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Mobile apps",
     family: "applications",
     path: "/deviceAppManagement/mobileApps",
@@ -183,6 +191,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "mdmWindowsInformationProtectionPolicies",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "MDM Windows Information Protection (legacy)",
     family: "applications",
     path: "/deviceAppManagement/mdmWindowsInformationProtectionPolicies",
@@ -192,6 +201,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "windowsInformationProtectionPolicies",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Windows Information Protection (legacy)",
     family: "applications",
     path: "/deviceAppManagement/windowsInformationProtectionPolicies",
@@ -201,6 +211,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "iosLobAppProvisioningConfigurations",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "iOS LOB provisioning profiles",
     family: "applications",
     path: "/deviceAppManagement/iosLobAppProvisioningConfigurations",
@@ -222,6 +233,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "roleScopeTags",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Scope tags",
     family: "assignmentAndRbac",
     path: "/deviceManagement/roleScopeTags",
@@ -300,7 +312,10 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
     family: "specialistPolicies",
     path: "/deviceAppManagement/policySets",
     permissionHint: "DeviceManagementApps.Read.All",
-    childCollections: [{ property: "items", path: "items" }],
+    childCollections: [
+      { property: "items", path: "items" },
+      { property: "assignments", path: "assignments" },
+    ],
   },
   {
     key: "notificationMessageTemplates",
@@ -317,6 +332,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "termsAndConditions",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Terms and conditions",
     family: "specialistPolicies",
     path: "/deviceManagement/termsAndConditions",
@@ -338,6 +354,7 @@ export const INTUNE_POLICY_REGISTRY: IntuneRegistryEntry[] = [
   },
   {
     key: "hardwareConfigurations",
+    childCollections: [{ property: "assignments", path: "assignments" }],
     label: "Hardware configurations",
     family: "specialistPolicies",
     path: "/deviceManagement/hardwareConfigurations",

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1,3 +1,10 @@
+import { compareControlIds } from "./compliance/engine";
+import {
+  CONTROL_STATUS_LABELS,
+  CONTROL_STATUS_ORDER,
+  CONTROL_STATUS_COLORS,
+  frameworkCoverageLabel,
+} from "./compliance/presentation";
 import jsPDF from "jspdf";
 import {
   extractSettingValue,
@@ -17,7 +24,7 @@ import {
   type ExportGenerationResult,
 } from "./configuration-analyzer";
 import { REDACTED_VALUE } from "./intune-policy-registry";
-import { assessCompliance, type ControlStatus } from "./compliance";
+import { assessCompliance } from "./compliance";
 import {
   buildConditionalAccessReportRows,
   conditionalAccessStateLabel,
@@ -1229,28 +1236,16 @@ export async function generateDetailedPDF(
     addSectionHeader("Compliance Evidence Preview");
 
     addText(
-      "This preview maps the exported configuration to technical evidence for each supported compliance framework. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
+      "This preview maps the exported configuration to technical evidence for each supported compliance framework. Supporting evidence may describe configuration or a compliance requirement. Device state, effective access and the remaining control requirements are assessed separately.",
       9,
       "normal",
       [80, 80, 80],
     );
     yPosition += 5;
 
-    const statusLabels: Record<ControlStatus, string> = {
-      evidenceFound: "Configuration evidence",
-      partialEvidence: "Partial configuration evidence",
-      noEvidence: "No recognized configuration evidence",
-    };
-    const statusColors: Record<ControlStatus, [number, number, number]> = {
-      evidenceFound: [39, 174, 96],
-      partialEvidence: [230, 126, 34],
-      noEvidence: [140, 140, 140],
-    };
-    const statusRank: Record<ControlStatus, number> = {
-      evidenceFound: 0,
-      partialEvidence: 1,
-      noEvidence: 2,
-    };
+    const statusLabels = CONTROL_STATUS_LABELS;
+    const statusColors = CONTROL_STATUS_COLORS;
+    const statusRank = CONTROL_STATUS_ORDER;
 
     for (const framework of assessment.frameworks) {
       checkPageBreak(45);
@@ -1260,8 +1255,10 @@ export async function generateDetailedPDF(
         "bold",
       );
       yPosition += 1;
+      const coverageLabel = frameworkCoverageLabel(framework);
+      if (coverageLabel) addText(coverageLabel, 9, "normal", [80, 80, 80]);
       addText(
-        `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.totalControls} technically assessable controls)`,
+        `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} mapped entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
         9,
         "normal",
         [80, 80, 80],
@@ -1272,7 +1269,7 @@ export async function generateDetailedPDF(
       const ranked = [...framework.controls].sort(
         (a, b) =>
           statusRank[a.status] - statusRank[b.status] ||
-          a.control.id.localeCompare(b.control.id),
+          compareControlIds(a.control.id, b.control.id),
       );
       for (const assessed of ranked.slice(0, maxRows)) {
         checkPageBreak(10);

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1229,7 +1229,7 @@ export async function generateDetailedPDF(
     addSectionHeader("Compliance Evidence Preview");
 
     addText(
-      "This preview maps the exported configuration to technical evidence for NIST SP 800-53 (Rev. 5), NIST CSF 2.0, and BSI IT-Grundschutz. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
+      "This preview maps the exported configuration to technical evidence for each supported compliance framework. Evidence is only claimed when a recognized Intune setting is configured with an enforcing value on an assigned policy.",
       9,
       "normal",
       [80, 80, 80],

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1753,7 +1753,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           policy.displayName || policy.name,
-          enhanceAssignmentText(parseAssignments(policy.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              policy.assignments,
+              policy.collectionStatus?.assignments,
+            ),
+          ),
           policy.createdDateTime,
           policy.lastModifiedDateTime,
         );
@@ -1838,7 +1843,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           config.displayName,
-          enhanceAssignmentText(parseAssignments(config.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              config.assignments,
+              config.collectionStatus?.assignments,
+            ),
+          ),
           config.createdDateTime,
           config.lastModifiedDateTime,
         );
@@ -1889,7 +1899,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           template.displayName,
-          enhanceAssignmentText(parseAssignments(template.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              template.assignments,
+              template.collectionStatus?.assignments,
+            ),
+          ),
           template.createdDateTime,
           template.lastModifiedDateTime,
         );
@@ -1956,7 +1971,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           policy.displayName,
-          enhanceAssignmentText(parseAssignments(policy.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              policy.assignments,
+              policy.collectionStatus?.assignments,
+            ),
+          ),
           policy.createdDateTime,
           policy.lastModifiedDateTime,
         );
@@ -2015,7 +2035,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           policy.displayName,
-          enhanceAssignmentText(parseAssignments(policy.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              policy.assignments,
+              policy.collectionStatus?.assignments,
+            ),
+          ),
           policy.createdDateTime,
           policy.lastModifiedDateTime,
         );
@@ -2218,7 +2243,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           baseline.displayName,
-          enhanceAssignmentText(parseAssignments(baseline.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              baseline.assignments,
+              baseline.collectionStatus?.assignments,
+            ),
+          ),
           baseline.createdDateTime,
           baseline.lastModifiedDateTime,
         );
@@ -2228,9 +2258,21 @@ export async function generateDetailedPDF(
           yPosition += 2;
         }
 
+        if (baseline.collectionStatus?.settings === "incomplete") {
+          addText(
+            "Baseline settings collection incomplete",
+            9,
+            "normal",
+            [150, 150, 150],
+          );
+          yPosition += 5;
+        }
         // Parse and display baseline settings
-        if (baseline.categories && baseline.categories.length > 0) {
-          const categories = parseSecurityBaseline(baseline.categories);
+        if (baseline.settings?.length || baseline.categories?.length) {
+          const categories = parseSecurityBaseline(
+            baseline.categories || [],
+            baseline.settings,
+          );
           categories.forEach((category) => {
             if (category.settings.length > 0) {
               addText(category.category, 10, "bold");
@@ -2239,7 +2281,14 @@ export async function generateDetailedPDF(
             }
           });
         } else {
-          addText("No settings configured", 9, "normal", [150, 150, 150]);
+          addText(
+            baseline.collectionStatus?.settings === "incomplete"
+              ? "Settings unavailable"
+              : "No settings configured",
+            9,
+            "normal",
+            [150, 150, 150],
+          );
           yPosition += 5;
         }
 
@@ -2279,7 +2328,12 @@ export async function generateDetailedPDF(
         try {
           addConfigHeader(
             script.displayName,
-            enhanceAssignmentText(parseAssignments(script.assignments)),
+            enhanceAssignmentText(
+              parseAssignments(
+                script.assignments,
+                script.collectionStatus?.assignments,
+              ),
+            ),
             script.createdDateTime,
             script.lastModifiedDateTime,
           );
@@ -2381,7 +2435,12 @@ export async function generateDetailedPDF(
         try {
           addConfigHeader(
             script.displayName,
-            enhanceAssignmentText(parseAssignments(script.assignments)),
+            enhanceAssignmentText(
+              parseAssignments(
+                script.assignments,
+                script.collectionStatus?.assignments,
+              ),
+            ),
             script.createdDateTime,
             script.lastModifiedDateTime,
           );
@@ -2488,7 +2547,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           config.displayName || config.name,
-          enhanceAssignmentText(parseAssignments(config.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              config.assignments,
+              config.collectionStatus?.assignments,
+            ),
+          ),
           config.createdDateTime,
           config.lastModifiedDateTime,
         );
@@ -2642,7 +2706,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           policy.displayName || policy.name,
-          enhanceAssignmentText(parseAssignments(policy.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              policy.assignments,
+              policy.collectionStatus?.assignments,
+            ),
+          ),
           policy.createdDateTime,
           policy.lastModifiedDateTime,
         );
@@ -2817,7 +2886,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           config.displayName || config.name,
-          enhanceAssignmentText(parseAssignments(config.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              config.assignments,
+              config.collectionStatus?.assignments,
+            ),
+          ),
           config.createdDateTime,
           config.lastModifiedDateTime,
         );
@@ -3001,7 +3075,12 @@ export async function generateDetailedPDF(
       try {
         addConfigHeader(
           item.displayName || item.name || section.label,
-          enhanceAssignmentText(parseAssignments(item.assignments)),
+          enhanceAssignmentText(
+            parseAssignments(
+              item.assignments,
+              item.collectionStatus?.assignments,
+            ),
+          ),
           item.createdDateTime,
           item.lastModifiedDateTime || item.modifiedDateTime,
         );

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1083,7 +1083,15 @@ export async function generateDetailedPDF(
       cardX += cardWidth + cardSpacing;
     });
 
-    yPosition += cardHeight + 15;
+    yPosition += cardHeight + 6;
+    doc.setFontSize(9);
+    doc.setTextColor(100, 100, 100);
+    doc.text(
+      `Unknown assignments: ${analytics.unknownAssignmentConfigs}`,
+      margin,
+      yPosition,
+    );
+    yPosition += 9;
 
     // === ASSIGNMENT RATE VISUALIZATION ===
     doc.setFontSize(12);
@@ -1361,6 +1369,8 @@ export async function generateDetailedPDF(
     type: item.label,
     count: item.total,
     assigned: item.assigned,
+    unassigned: item.unassigned,
+    unknown: item.unknown,
   }));
 
   // Check if we need to start a new page for Configuration Inventory
@@ -1388,7 +1398,7 @@ export async function generateDetailedPDF(
   yPosition += 10;
 
   // Enhanced table header with color
-  const tableWidth = 165;
+  const tableWidth = 180;
   const [thr, thg, thb] = hexToRgb(primaryColor);
   doc.setFillColor(thr, thg, thb);
   doc.rect(margin, yPosition, tableWidth, 10, "F");
@@ -1397,9 +1407,10 @@ export async function generateDetailedPDF(
   doc.setFont(fontFamily, "bold");
   doc.setTextColor(255, 255, 255);
   doc.text("Policy Type", margin + 3, yPosition + 7);
-  doc.text("Total", margin + 85, yPosition + 7);
-  doc.text("Assigned", margin + 110, yPosition + 7);
-  doc.text("Unassigned", margin + 140, yPosition + 7);
+  doc.text("Total", margin + 80, yPosition + 7);
+  doc.text("Assigned", margin + 100, yPosition + 7);
+  doc.text("Unassigned", margin + 125, yPosition + 7);
+  doc.text("Unknown", margin + 155, yPosition + 7);
   yPosition += 10;
 
   doc.setFont(fontFamily, "normal");
@@ -1426,10 +1437,12 @@ export async function generateDetailedPDF(
       doc.setFont(fontFamily, "bold");
       doc.setTextColor(255, 255, 255);
       doc.text("Policy Type", margin + 3, yPosition + 7);
-      doc.text("Total", margin + 85, yPosition + 7);
-      doc.text("Assigned", margin + 110, yPosition + 7);
-      doc.text("Unassigned", margin + 140, yPosition + 7);
+      doc.text("Total", margin + 80, yPosition + 7);
+      doc.text("Assigned", margin + 100, yPosition + 7);
+      doc.text("Unassigned", margin + 125, yPosition + 7);
       yPosition += 10;
+
+      doc.text("Unknown", margin + 155, yPosition - 3);
 
       // Reset text settings
       doc.setFont(fontFamily, "normal");
@@ -1461,20 +1474,22 @@ export async function generateDetailedPDF(
     // Total count
     doc.setFont(fontFamily, "bold");
     doc.setTextColor(52, 152, 219); // Blue
-    doc.text(item.count.toString(), margin + 90, yPosition + 6);
+    doc.text(item.count.toString(), margin + 85, yPosition + 6);
 
     // Assigned count
     doc.setTextColor(39, 174, 96); // Green
-    doc.text(item.assigned.toString(), margin + 120, yPosition + 6);
+    doc.text(item.assigned.toString(), margin + 110, yPosition + 6);
 
     // Unassigned count (red if > 0, gray if 0)
-    const unassigned = item.count - item.assigned;
+    const unassigned = item.unassigned;
     doc.setTextColor(
       unassigned > 0 ? 231 : 149,
       unassigned > 0 ? 76 : 165,
       unassigned > 0 ? 60 : 166,
     );
-    doc.text(unassigned.toString(), margin + 150, yPosition + 6);
+    doc.text(unassigned.toString(), margin + 135, yPosition + 6);
+    doc.setTextColor(100, 100, 100);
+    doc.text(item.unknown.toString(), margin + 165, yPosition + 6);
 
     doc.setTextColor(0, 0, 0);
     doc.setFont(fontFamily, "normal");

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1016,8 +1016,9 @@ export async function generateDetailedPDF(
 
     // Calculate assignment rate
     const assignmentRate =
-      analytics.totalConfigs > 0
-        ? (analytics.assignedConfigs / analytics.totalConfigs) * 100
+      analytics.assignmentApplicableConfigs > 0
+        ? (analytics.assignedConfigs / analytics.assignmentApplicableConfigs) *
+          100
         : 0;
 
     // Create metrics cards without emoji icons
@@ -1093,6 +1094,13 @@ export async function generateDetailedPDF(
     );
     yPosition += 9;
 
+    if (analytics.assignmentNotApplicableConfigs) {
+      addText(
+        `Assignment not applicable: ${analytics.assignmentNotApplicableConfigs} configurations; excluded from assignment coverage.`,
+        9,
+      );
+      yPosition += 4;
+    }
     // === ASSIGNMENT RATE VISUALIZATION ===
     doc.setFontSize(12);
     doc.setFont(fontFamily, "bold");
@@ -1371,6 +1379,7 @@ export async function generateDetailedPDF(
     assigned: item.assigned,
     unassigned: item.unassigned,
     unknown: item.unknown,
+    notApplicable: item.notApplicable,
   }));
 
   // Check if we need to start a new page for Configuration Inventory
@@ -1478,7 +1487,11 @@ export async function generateDetailedPDF(
 
     // Assigned count
     doc.setTextColor(39, 174, 96); // Green
-    doc.text(item.assigned.toString(), margin + 110, yPosition + 6);
+    doc.text(
+      item.notApplicable === item.count ? "N/A" : item.assigned.toString(),
+      margin + 110,
+      yPosition + 6,
+    );
 
     // Unassigned count (red if > 0, gray if 0)
     const unassigned = item.unassigned;
@@ -1487,9 +1500,17 @@ export async function generateDetailedPDF(
       unassigned > 0 ? 76 : 165,
       unassigned > 0 ? 60 : 166,
     );
-    doc.text(unassigned.toString(), margin + 135, yPosition + 6);
+    doc.text(
+      item.notApplicable === item.count ? "N/A" : unassigned.toString(),
+      margin + 135,
+      yPosition + 6,
+    );
     doc.setTextColor(100, 100, 100);
-    doc.text(item.unknown.toString(), margin + 165, yPosition + 6);
+    doc.text(
+      item.notApplicable === item.count ? "N/A" : item.unknown.toString(),
+      margin + 165,
+      yPosition + 6,
+    );
 
     doc.setTextColor(0, 0, 0);
     doc.setFont(fontFamily, "normal");

--- a/src/lib/pdf-generator-detailed.ts
+++ b/src/lib/pdf-generator-detailed.ts
@@ -1258,7 +1258,7 @@ export async function generateDetailedPDF(
       const coverageLabel = frameworkCoverageLabel(framework);
       if (coverageLabel) addText(coverageLabel, 9, "normal", [80, 80, 80]);
       addText(
-        `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} mapped entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
+        `${framework.summary.withEvidence} with evidence, ${framework.summary.partial} partial, ${framework.summary.withoutEvidence} without evidence (${framework.summary.applicableControls} entries in scope; ${framework.summary.notApplicable} outside scope; ${framework.summary.notAssessed} not assessed; ${framework.summary.conflicting} mixed evidence)`,
         9,
         "normal",
         [80, 80, 80],
@@ -1280,6 +1280,8 @@ export async function generateDetailedPDF(
           "normal",
           statusColors[assessed.status],
         );
+        if (framework.framework.id === "essential-eight")
+          addText(assessed.control.summary, 9, "normal", [80, 80, 80]);
         yPosition += 1;
       }
       if (ranked.length > maxRows) {


### PR DESCRIPTION
The evidence engine could hide contradictory settings, treat failed assignment reads as unassigned policies, and overstate what compliance requirements prove. This change preserves those distinctions and adds explicit assessment scope, collection coverage and reproducible evidence records.

For example, a Windows policy with an enabled domain firewall and a disabled public firewall now shows mixed policy evidence. An unreadable assignment remains unknown, and a configured compliance requirement never establishes actual device enforcement or blocked access.

## Framework support

- Adds ASD Essential Eight with a target Maturity Level 1/2/3 selector. Includes all 48/107/149 appendix requirement entries across all eight strategies, with 3/8/10 supporting evidence mappings. Unmapped requirements remain unassessed; no achieved maturity score is calculated.
- Carries the target into the JSON manifest, report content and filename, and full-documentation previews. Adds five exact Office/Adobe ASR detectors; audit and warning modes are not blocking evidence.
- Uses ASD’s published November 2023 model with CC BY 4.0 attribution. Local appendix row identifiers are explicitly distinguished from official ISM IDs; the proposed 2026 Essentials series is not substituted for the published model.

- Adds UK MOD Def Stan 05-138 Issue 4, NCSC Cyber Essentials v3.3 (April 2026), and separate NIST SP 800-171 Revision 2 and Revision 3 assessments alongside the existing frameworks.
- Retains Revision 2 for CMMC Level 2. Revision 2 maps 12 of 110 published requirements; Revision 3 maps 11 of 97. The dashboard, PDF, Word previews and JSON distinguish mapping coverage from assessed compliance.
- Maps Revision 3 independently, omitting withdrawn requirements and retaining gaps for organization-defined parameters, transmission encryption, software authorization and operational evidence.
- Uses official publisher references. Def Stan titles and summaries use original wording. CIS content remains excluded.

## Evidence and collection changes

- Expands the catalog to 44 capabilities, including scheduled malware scans, update timing, application control, integrity protections, Conditional Access requirements and managed-app data transfer restrictions.
- Corrects real-time protection and Android integrity detection; requires complete firewall profiles on the same policy and preserves contradictory values.
- Preserves assignment filters, exclusions, failed relation reads and partial results. Collects actual security-baseline settings separately from category metadata.
- Reads compliance scheduled actions through parent-policy expansion to avoid the reported HTTP 400 route failure. Follows rule/action pagination and preserves partial results with explicit collection status.
- Adds exact-identifier legacy adapters. Unrecognized definitions remain unassessed, and script contents are not evaluated as deployment evidence.
- Adds platform scope and Def Stan risk-level selection. Supporting mappings stay partial, while missing collection data is distinguished from absent evidence.
- Adds collection/detection coverage, policy provenance, source-snapshot and ruleset SHA-256 fingerprints, and a downloadable JSON evidence record. Updates the ruleset to 2026.09.5.
- Updates dashboard and report labels, counters, source references and PDF pagination.

- Fixes full PDF/Word value rendering: includes collected baseline settings and Administrative Template lists, preserves structured values and literal strings, retains assignment filters and incomplete collection status, keeps precise action timing, and excludes collection metadata from settings. Adds parser and generated-document regression coverage.

- Uses canonical assignment routes for macOS shell scripts and Windows PowerShell scripts, with parent expansion as a fallback for HTTP 400 OData route errors. Preserves script content, assignment filters, paginated results and explicit incomplete status on failed reads.

## Validation

- 256 tests across 24 files pass, including mapping semantics, assignment/collection failures, both NIST revisions, dashboard selection, JSON provenance, and PDF/Word output.
- `npm run check` and `npm run build` pass. Existing hook and image warnings remain.
- Verified desktop and mobile layouts, revision switching and a Revision 3 PDF download in an isolated browser. Generated sample PDFs for all nine framework/version options and inspected representative pages.
- Validation combines synthetic exports, injected Graph faults and sampled read-only lab collection through Greybeard. The latest collector validation passed 26 calls covering baseline settings, compliance scheduled actions, macOS and Windows scripts, and registry assignment relations. Empty lab families, all subtypes and large-tenant load remain outside live coverage. Configuration evidence does not verify device state or constitute certification, a complete assessment, or an SPRS score.
- Generated 18 export files covering all frameworks and Essential Eight Levels 1, 2 and 3. Verified all 304 Essential Eight requirement texts and parsed baseline/list values. Rendered all three Word exports with bundled LibreOffice and checked their layout; each is 14 pages with no blank pages in the validation fixture.
- Fixed the Essential Eight PDF contents overflow by indexing the eight strategies. Word now has a populated, clickable section index without a manual field refresh, and trailing section spacers no longer create blank pages.
- Full PDF/Word summaries and inventories distinguish unknown assignment collection from confirmed unassigned policies; excluded groups are omitted from assignment rankings.
- Local tests on Node 26 use `NODE_OPTIONS=--no-experimental-webstorage`; CI uses Node 22.

## Independent review and follow-up

Claude Code Fable reviewed the complete 49-file PR and performed a follow-up review of the fixes. All six verified findings were addressed: framework-neutral update timing verdicts, separation of ancillary collection warnings from capability evidence failures, Conditional Access assignment applicability, firewall compliance-requirement semantics, NIST Revision 2 MFA mappings, and Word field-refresh settings. The follow-up independently confirmed 223 passing tests and found no new blocking code defect.

A reproduced oversized Conditional Access appendix row now splits across PDF pages without losing values or crossing the footer. Fresh synthetic PDF and Word exports were checked after the fixes, including a large conditions payload and all three Essential Eight levels.

Remaining refinements are low priority: retaining an explicit partial-profile limitation alongside a firewall requirement, consistent styling across split appendix rows, and reviewing the pre-existing Potential Gaps denominator. Nested scheduled-action expansion has now been verified against the lab tenant.

## Graph reliability review

The full Graph review identified nine collection and reporting gaps. Fixes preserve per-platform app-protection partials, validate pagination, collect registry assignment relations with completeness markers, and fall back to parent expansion for baseline categories. Legacy routes expose partial-result diagnostics. Permission probes distinguish denial from temporary unavailability, and streaming results preserve failed steps.

A shared six-request limit and transient retry policy handle Retry-After, SDK-wrapped network failures and cancellation. Detailed collection has a 105-second budget. GET-only batch envelopes are retried; failed inner group reads are rebatched after one shared wait. Unresolved names retain identifiers and appear as warnings in PDF and Word. Nonassignable registry resources are not applicable in assignment coverage, and update-ring detail failures retain assignments with explicit incomplete markers.

Claude Code Fable reviewed the complete PR again and confirmed the original nine findings were addressed. Its six residual findings were also fixed and covered by regression tests. Fable’s focused follow-up confirmed all six fixes and found no blocking regression. Its three remaining wording nits were also corrected. Fresh full-documentation PDF and Word exports include the new group-resolution warning. No tenant configuration was changed during validation.
