### PR TITLE
Add a spam-protected contact support form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,10 @@ NEXT_PUBLIC_ENABLE_ANALYTICS="false"
 
 # Optional Crisp support chat. Leave unset for Docker/self-hosted deployments.
 # NEXT_PUBLIC_CRISP_WEBSITE_ID="your_crisp_website_id"
+
+# Hosted support form at /support (public origin only). All four are required.
+# Resend sender must belong to a verified domain. Never use the visitor as From.
+# RESEND_API_KEY="re_..."
+# SUPPORT_FROM_EMAIL="Intune Documentation <support@ugurlabs.com>"
+# SUPPORT_TURNSTILE_SITE_KEY="your_turnstile_site_key"
+# SUPPORT_TURNSTILE_SECRET_KEY="your_turnstile_secret_key"

--- a/README.md
+++ b/README.md
@@ -118,3 +118,33 @@ Map both domains to the deployment and add `https://app.intunedocumentation.com`
 Only the exact configured public origin loads Crisp and Plausible. Public pages clear legacy session storage before loading those scripts and cannot collect Intune data. The app uses a per-response script nonce and runs no analytics or chat SDK in its own origin. A support button on app pages opens an isolated iframe at the public origin’s `/support-chat` route. Only the configured app origin may embed that page. The frame receives no account, token, policy, or URL data from the app, loads only when opened, and stays mounted when closed to preserve the conversation. Nonced HTML is dynamically rendered and must not be cached by a CDN. Unknown preview origins and self-hosted installations default to app mode with no third-party scripts. Leave both variables unset for a single-origin private app, or supply two distinct origins.
 
 The one-hour limit applies to dashboard snapshots, not Microsoft authentication token lifetimes or a report already visible in memory. Browser session restore can retain sessionStorage after restarting the browser, so the app also validates expiry before restoration. Cross-tab logout requires BroadcastChannel support; the originating tab always clears its own snapshot. No snapshot or logout payload is persisted on the server, in localStorage, or in IndexedDB.
+
+### Contact support form
+
+The public site's `/support` page runs alongside Crisp and sends requests to
+`support@ugurlabs.com` using Resend. Configure `RESEND_API_KEY`,
+`SUPPORT_FROM_EMAIL` (an address on a Resend-verified domain),
+`SUPPORT_TURNSTILE_SITE_KEY`, and `SUPPORT_TURNSTILE_SECRET_KEY` on the server.
+Configure the existing `PUBLIC_SITE_ORIGIN` and `APP_SITE_ORIGIN` pair too.
+Restrict the Turnstile widget to the public site's hostname. The site key is
+passed to the public form at runtime; API keys and secrets stay on the server.
+
+App-origin visits to `/support` redirect to the public site. Unconfigured and
+self-hosted installations show an email link without loading Turnstile. The
+endpoint rejects non-public origins, cross-origin submissions, invalid fields,
+oversized bodies, honeypot submissions, and failed or replayed Turnstile tokens.
+Cloudflare verification must match the public hostname and `support` action.
+Consider an edge rate limit on `POST /api/support` for additional volume control.
+
+The visitor's email is used only as `Reply-To`; the recipient is fixed. Success
+requires a successful Resend response containing an email ID. Acceptance does
+not guarantee inbox delivery. Timeouts show an uncertainty message and keep the
+form contents, so check Resend logs before retrying an uncertain submission.
+The app does not persist or log form contents. Resend processes the email and
+Cloudflare processes the spam verification.
+
+Before going live, configure the four variables, verify the sender domain, and
+submit a real request to confirm inbox delivery and Reply-To. API tests mock
+both services and do not send email. Provider references:
+[Resend send email](https://resend.com/docs/api-reference/emails/send-email) and
+[Turnstile server validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/).

--- a/src/app/api/support/__tests__/route.test.ts
+++ b/src/app/api/support/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../route";
+const origin = "https://intunedocumentation.com";
+const payload = {
+  name: "Visitor",
+  email: "visitor@example.com",
+  subject: "Help",
+  message: "My export failed",
+  website: "",
+  token: "challenge-token",
+};
+const request = (data: unknown = payload, source = origin, host = origin) =>
+  new Request(`${host}/api/support`, {
+    method: "POST",
+    headers: { origin: source, "content-type": "application/json" },
+    body: JSON.stringify(data),
+  });
+const fetchMock = vi.fn();
+const verified = () =>
+  Response.json({
+    success: true,
+    hostname: "intunedocumentation.com",
+    action: "support",
+  });
+beforeEach(() => {
+  vi.stubEnv("PUBLIC_SITE_ORIGIN", origin);
+  vi.stubEnv("APP_SITE_ORIGIN", "https://app.intunedocumentation.com");
+  vi.stubEnv("RESEND_API_KEY", "test-key");
+  vi.stubEnv("SUPPORT_FROM_EMAIL", "Support <support@ugurlabs.com>");
+  vi.stubEnv("SUPPORT_TURNSTILE_SECRET_KEY", "test-secret");
+  vi.stubEnv("SUPPORT_TURNSTILE_SITE_KEY", "test-site");
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+describe("support submissions", () => {
+  it("sends only after verification with a fixed recipient and visitor Reply-To", async () => {
+    fetchMock
+      .mockResolvedValueOnce(verified())
+      .mockResolvedValueOnce(Response.json({ id: "email-id" }));
+    const response = await POST(request());
+    expect(await response.json()).toEqual({ success: true });
+    const options = fetchMock.mock.calls[1]![1] as RequestInit;
+    expect(JSON.parse(options.body as string)).toMatchObject({
+      to: ["support@ugurlabs.com"],
+      reply_to: payload.email,
+      from: "Support <support@ugurlabs.com>",
+    });
+  });
+  it.each([
+    { website: "spam" },
+    { email: "invalid" },
+    { subject: "Hi\r\nBcc: bad@example.com" },
+    { message: " " },
+    { token: "" },
+  ])(
+    "rejects invalid input %j without contacting providers",
+    async (invalid) => {
+      expect((await POST(request({ ...payload, ...invalid }))).status).toBe(
+        400,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+  it("rejects cross-origin and app-origin requests", async () => {
+    expect((await POST(request(payload, "https://evil.example"))).status).toBe(
+      403,
+    );
+    expect(
+      (
+        await POST(
+          request(
+            payload,
+            "https://app.intunedocumentation.com",
+            "https://app.intunedocumentation.com",
+          ),
+        )
+      ).status,
+    ).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("fails closed when configuration is missing", async () => {
+    vi.stubEnv("RESEND_API_KEY", "");
+    expect((await POST(request())).status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it("bounds request bodies even without Content-Length", async () => {
+    expect(
+      (await POST(request({ ...payload, message: "x".repeat(66000) }))).status,
+    ).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it.each([
+    { success: false },
+    { success: true, hostname: "evil.example", action: "support" },
+    { success: true, hostname: "intunedocumentation.com", action: "login" },
+  ])(
+    "rejects failed, replayed, or mismatched verification %j",
+    async (verdict) => {
+      fetchMock.mockResolvedValueOnce(Response.json(verdict));
+      expect((await POST(request())).status).toBe(400);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+  it.each([
+    Response.json({ error: "rejected" }, { status: 429 }),
+    Response.json({}),
+  ])("does not claim success without Resend acceptance", async (result) => {
+    fetchMock.mockResolvedValueOnce(verified()).mockResolvedValueOnce(result);
+    const response = await POST(request());
+    expect(response.status).toBe(502);
+    expect(await response.json()).not.toHaveProperty("success");
+  });
+  it("handles provider timeouts without exposing internals", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("secret provider details"));
+    const response = await POST(request());
+    expect(response.status).toBe(502);
+    expect(await response.text()).not.toContain("secret provider details");
+  });
+});

--- a/src/app/api/support/route.ts
+++ b/src/app/api/support/route.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { siteBoundary } from "~/lib/site-boundary";
+
+export const runtime = "nodejs";
+const singleLine = (max: number) =>
+  z
+    .string()
+    .trim()
+    .min(1)
+    .max(max)
+    .refine((value) => !/[\r\n\x00]/.test(value));
+const submission = z.object({
+  name: singleLine(100),
+  email: z
+    .string()
+    .trim()
+    .max(254)
+    .email()
+    .refine((value) => !/[\r\n\x00]/.test(value)),
+  subject: singleLine(160),
+  message: z.string().trim().min(1).max(10000),
+  website: z.string().max(0),
+  token: z.string().min(1).max(2048),
+});
+const reply = (body: object, status = 200) =>
+  Response.json(body, { status, headers: { "Cache-Control": "no-store" } });
+
+export async function POST(request: Request) {
+  const origin = new URL(request.url);
+  origin.host = request.headers.get("host") ?? origin.host;
+  if (siteBoundary(origin.origin).mode !== "public")
+    return reply({ error: "Not found" }, 404);
+  if (request.headers.get("origin") !== origin.origin)
+    return reply({ error: "Please submit the form from this site." }, 403);
+  const key = process.env.RESEND_API_KEY;
+  const from = process.env.SUPPORT_FROM_EMAIL;
+  const secret = process.env.SUPPORT_TURNSTILE_SECRET_KEY;
+  if (!key || !from || !secret || !process.env.SUPPORT_TURNSTILE_SITE_KEY)
+    return reply(
+      {
+        error:
+          "The support form is unavailable. Please email support@ugurlabs.com.",
+      },
+      503,
+    );
+  if (!request.headers.get("content-type")?.startsWith("application/json"))
+    return reply({ error: "Expected a JSON request." }, 415);
+
+  // Bound the streamed body too, rather than trusting Content-Length.
+  const reader = request.body?.getReader();
+  if (!reader) return reply({ error: "Please complete all fields." }, 400);
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  let input: unknown;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > 65536) {
+        await reader.cancel();
+        return reply({ error: "Your request is too large." }, 413);
+      }
+      chunks.push(value);
+    }
+    input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return reply({ error: "Invalid request." }, 400);
+  }
+  const parsed = submission.safeParse(input);
+  if (!parsed.success)
+    return reply(
+      { error: "Please check all fields and complete the spam verification." },
+      400,
+    );
+  const data = parsed.data;
+  try {
+    const verification = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secret, response: data.token }),
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+    const verdict = z
+      .object({
+        success: z.literal(true),
+        hostname: z.literal(origin.hostname),
+        action: z.literal("support"),
+      })
+      .safeParse(await verification.json());
+    if (!verification.ok || !verdict.success)
+      return reply(
+        { error: "Spam verification failed or expired. Please try again." },
+        400,
+      );
+    const email = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": `support-${createHash("sha256").update(data.token).digest("hex")}`,
+      },
+      body: JSON.stringify({
+        from,
+        to: ["support@ugurlabs.com"],
+        reply_to: data.email,
+        subject: `[Intune Documentation support] ${data.subject}`,
+        text: `Name: ${data.name}\nEmail: ${data.email}\n\n${data.message}`,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+    const accepted = z
+      .object({ id: z.string().min(1) })
+      .safeParse(await email.json());
+    if (!email.ok || !accepted.success)
+      return reply(
+        {
+          error:
+            "Your request could not be sent. Please try again or email support@ugurlabs.com.",
+        },
+        502,
+      );
+    return reply({ success: true });
+  } catch {
+    return reply(
+      {
+        error:
+          "We could not confirm your request was sent. Try again or email support@ugurlabs.com.",
+      },
+      502,
+    );
+  }
+}

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -239,6 +239,24 @@ export default function PrivacyPolicyPage() {
               </li>
             </ul>
 
+            <h2 className="text-xl font-semibold text-slate-900">
+              Support form
+            </h2>
+            <p>
+              When you use the contact support form, we send your name, email
+              address, subject, and message to our support mailbox through
+              Resend. Your email address is included as Reply-To so we can
+              respond directly. The application does not store or log form
+              submissions. The email is processed by Resend and our mailbox
+              provider.
+            </p>
+            <p>
+              The form uses Cloudflare Turnstile to prevent automated spam.
+              Cloudflare processes browser and network information for this
+              verification. The form does not attach Microsoft account details,
+              access tokens, or tenant configurations to your message.
+            </p>
+
             <h2
               id="data-sharing"
               className="scroll-mt-24 text-xl font-semibold text-slate-900"

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { NavigationHeader } from "~/components/navigation-header";
+import { SiteFooter } from "~/components/site-footer";
+import { SupportForm } from "~/components/support-form";
+
+export const metadata: Metadata = {
+  title: "Contact support",
+  description:
+    "Get help with Intune Documentation. Send a support request to the Ugurlabs team.",
+  alternates: { canonical: "/support" },
+};
+
+export default async function SupportPage() {
+  const requestHeaders = await headers();
+  const publicSite = requestHeaders.get("x-site-mode") === "public";
+  if (!publicSite && process.env.PUBLIC_SITE_ORIGIN)
+    redirect(new URL("/support", process.env.PUBLIC_SITE_ORIGIN).href);
+  const configured =
+    publicSite &&
+    process.env.RESEND_API_KEY &&
+    process.env.SUPPORT_FROM_EMAIL &&
+    process.env.SUPPORT_TURNSTILE_SITE_KEY &&
+    process.env.SUPPORT_TURNSTILE_SECRET_KEY;
+  return (
+    <div className="min-h-screen bg-white pt-16">
+      <NavigationHeader />
+      <main className="mx-auto max-w-3xl px-5 py-16 sm:px-8 sm:py-24">
+        <p className="mb-4 text-sm font-semibold tracking-widest text-teal-800 uppercase">
+          Here to help
+        </p>
+        <h1 className="text-petrol-950 text-4xl font-bold tracking-tight sm:text-5xl">
+          Contact support
+        </h1>
+        <p className="mt-5 mb-10 max-w-xl text-lg leading-8 text-slate-600">
+          Need a hand with Intune Documentation? Tell us what you’re working on
+          and where you got stuck.
+        </p>
+        {configured ? (
+          <SupportForm
+            siteKey={process.env.SUPPORT_TURNSTILE_SITE_KEY!}
+            nonce={requestHeaders.get("x-nonce") ?? undefined}
+          />
+        ) : (
+          <p className="rounded-xl border border-slate-200 bg-slate-50 p-6 text-slate-700">
+            The support form is currently unavailable. Please email us directly.
+          </p>
+        )}
+        <p className="mt-8 text-sm text-slate-600">
+          You can also email{" "}
+          <a
+            href="mailto:support@ugurlabs.com"
+            className="text-teal-800 underline"
+          >
+            support@ugurlabs.com
+          </a>
+          .
+        </p>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -192,10 +192,10 @@ export function SiteFooter() {
               </li>
               <li>
                 <a
-                  href="mailto:support@ugurlabs.com"
+                  href="/support"
                   className="transition-colors hover:text-teal-700"
                 >
-                  Contact
+                  Contact support
                 </a>
               </li>
             </ul>

--- a/src/components/support-form.tsx
+++ b/src/components/support-form.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Script from "next/script";
+import Link from "next/link";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+type Turnstile = {
+  render: (element: HTMLElement, options: Record<string, unknown>) => string;
+  reset: (id: string) => void;
+  remove: (id: string) => void;
+};
+
+export function SupportForm({
+  siteKey,
+  nonce,
+}: {
+  siteKey: string;
+  nonce?: string;
+}) {
+  const container = useRef<HTMLDivElement>(null);
+  const widget = useRef<string | null>(null);
+  const submitting = useRef(false);
+  const [ready, setReady] = useState(false);
+  const [token, setToken] = useState("");
+  const [pending, setPending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState("");
+  const api = () => (window as Window & { turnstile?: Turnstile }).turnstile;
+
+  useEffect(() => {
+    const turnstile = api();
+    if (!ready || !container.current || !turnstile || sent) return;
+    widget.current = turnstile.render(container.current, {
+      sitekey: siteKey,
+      action: "support",
+      callback: (value: string) => {
+        setToken(value);
+      },
+      "expired-callback": () => setToken(""),
+      "error-callback": () => {
+        setToken("");
+        setError(
+          "Verification could not load. Try again or email support@ugurlabs.com.",
+        );
+      },
+    });
+    return () => {
+      if (widget.current !== null) turnstile.remove(widget.current);
+      widget.current = null;
+    };
+  }, [ready, siteKey, sent]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting.current || !token) return;
+    submitting.current = true;
+    setPending(true);
+    setError("");
+    const data = new FormData(event.currentTarget);
+    try {
+      const response = await fetch("/api/support", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: data.get("name"),
+          email: data.get("email"),
+          subject: data.get("subject"),
+          message: data.get("message"),
+          website: data.get("website"),
+          token,
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+      const result = (await response.json()) as {
+        success?: boolean;
+        error?: string;
+      };
+      if (!response.ok || result.success !== true)
+        throw new Error(
+          result.error ?? "Your request could not be sent. Please try again.",
+        );
+      setSent(true);
+    } catch (cause) {
+      setError(
+        cause instanceof Error && cause.name === "Error"
+          ? cause.message
+          : "We could not confirm your request was sent. Try again or email support@ugurlabs.com.",
+      );
+      setToken("");
+      if (widget.current !== null) api()?.reset(widget.current);
+    } finally {
+      submitting.current = false;
+      setPending(false);
+    }
+  }
+
+  if (sent)
+    return (
+      <div
+        role="status"
+        className="rounded-2xl border border-teal-200 bg-teal-50 p-8"
+      >
+        <h2 className="text-petrol-950 text-xl font-semibold">
+          Support request sent
+        </h2>
+        <p className="mt-3 text-slate-700">
+          Thank you for getting in touch. We’ll reply to the email address you
+          provided.
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex min-h-11 items-center font-semibold text-teal-800 underline"
+        >
+          Back to home
+        </Link>
+      </div>
+    );
+
+  const inputClass =
+    "mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-3 text-base text-slate-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700";
+  return (
+    <>
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        nonce={nonce}
+        onReady={() => setReady(true)}
+        onError={() =>
+          setError(
+            "Verification could not load. Please email support@ugurlabs.com.",
+          )
+        }
+      />
+      <form onSubmit={submit} className="space-y-6" aria-busy={pending}>
+        <fieldset disabled={pending} className="space-y-6">
+          <div className="grid gap-6 sm:grid-cols-2">
+            <label
+              className="block text-sm font-semibold text-slate-800"
+              htmlFor="support-name"
+            >
+              Name
+              <input
+                id="support-name"
+                name="name"
+                autoComplete="name"
+                required
+                maxLength={100}
+                className={inputClass}
+              />
+            </label>
+            <label
+              className="block text-sm font-semibold text-slate-800"
+              htmlFor="support-email"
+            >
+              Email address
+              <input
+                id="support-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                maxLength={254}
+                className={inputClass}
+              />
+            </label>
+          </div>
+          <label
+            className="block text-sm font-semibold text-slate-800"
+            htmlFor="support-subject"
+          >
+            Subject
+            <input
+              id="support-subject"
+              name="subject"
+              required
+              maxLength={160}
+              className={inputClass}
+            />
+          </label>
+          <label
+            className="block text-sm font-semibold text-slate-800"
+            htmlFor="support-message"
+          >
+            Message
+            <textarea
+              id="support-message"
+              name="message"
+              required
+              maxLength={10000}
+              rows={7}
+              aria-describedby="support-message-hint"
+              className={inputClass}
+            />
+          </label>
+          <p
+            id="support-message-hint"
+            className="text-sm leading-6 text-slate-600"
+          >
+            Describe what happened and what you expected. Please leave out
+            passwords, access tokens, and tenant data.
+          </p>
+          <div hidden aria-hidden="true">
+            <label htmlFor="support-website">Website</label>
+            <input
+              id="support-website"
+              name="website"
+              tabIndex={-1}
+              autoComplete="off"
+            />
+          </div>
+        </fieldset>
+        <div ref={container} />
+        {error && (
+          <p role="alert" className="text-sm text-red-700">
+            {error}
+          </p>
+        )}
+        <p className="text-sm leading-6 text-slate-600">
+          We use your details to respond to your request. Read our{" "}
+          <Link href="/privacy-policy" className="text-teal-800 underline">
+            privacy policy
+          </Link>
+          .
+        </p>
+        <button
+          type="submit"
+          disabled={pending || !token}
+          className="min-h-12 rounded-lg bg-teal-800 px-6 py-3 font-semibold text-white transition-colors hover:bg-teal-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {pending ? "Sending…" : "Send support request"}
+        </button>
+      </form>
+    </>
+  );
+}

--- a/src/env.js
+++ b/src/env.js
@@ -7,6 +7,10 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
+    RESEND_API_KEY: z.string().optional(),
+    SUPPORT_FROM_EMAIL: z.string().optional(),
+    SUPPORT_TURNSTILE_SITE_KEY: z.string().optional(),
+    SUPPORT_TURNSTILE_SECRET_KEY: z.string().optional(),
     NODE_ENV: z.enum(["development", "test", "production"]),
   },
 
@@ -29,6 +33,10 @@ export const env = createEnv({
    */
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
+    RESEND_API_KEY: process.env.RESEND_API_KEY,
+    SUPPORT_FROM_EMAIL: process.env.SUPPORT_FROM_EMAIL,
+    SUPPORT_TURNSTILE_SITE_KEY: process.env.SUPPORT_TURNSTILE_SITE_KEY,
+    SUPPORT_TURNSTILE_SECRET_KEY: process.env.SUPPORT_TURNSTILE_SECRET_KEY,
     NEXT_PUBLIC_AZURE_AD_CLIENT_ID: process.env.NEXT_PUBLIC_AZURE_AD_CLIENT_ID,
     NEXT_PUBLIC_AZURE_AD_TENANT_ID: process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/src/lib/__tests__/site-boundary.test.ts
+++ b/src/lib/__tests__/site-boundary.test.ts
@@ -106,3 +106,18 @@ describe("public/app security boundary", () => {
     );
   });
 });
+
+it("allows Turnstile only on the public support form", () => {
+  configure();
+  for (const [url, allowed] of [
+    ["https://intunedocumentation.com/support", true],
+    ["https://intunedocumentation.com/", false],
+    ["https://app.intunedocumentation.com/support", false],
+    ["https://preview.vercel.app/support", false],
+  ] as const) {
+    const policy = middleware(new NextRequest(url)).headers.get(
+      "content-security-policy",
+    )!;
+    expect(policy.includes("https://challenges.cloudflare.com")).toBe(allowed);
+  }
+});

--- a/src/lib/site-boundary.ts
+++ b/src/lib/site-boundary.ts
@@ -24,6 +24,7 @@ export function contentSecurityPolicy(
   development = false,
   supportOrigin = "",
   frameAncestor = "",
+  supportForm = false,
 ) {
   const crisp = publicSite
     ? " https://*.crisp.chat wss://*.relay.crisp.chat wss://*.relay.rescue.crisp.chat"
@@ -40,8 +41,8 @@ export function contentSecurityPolicy(
     "img-src 'self' data: blob: https:",
     `font-src 'self' data:${publicSite ? " https://client.crisp.chat" : ""}`,
     `media-src 'self' blob:${publicSite ? " https://*.crisp.chat" : ""}`,
-    `connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://changelog.ugurlabs.com${publicSite ? " https://plausible.io" : ""}${crisp}`,
-    `frame-src 'self' https://login.microsoftonline.com${supportOrigin ? ` ${supportOrigin}` : ""}${publicSite ? " https://*.crisp.chat" : ""}`,
+    `connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://changelog.ugurlabs.com${publicSite ? " https://plausible.io" : ""}${crisp}${supportForm ? " https://challenges.cloudflare.com" : ""}`,
+    `frame-src 'self'${supportForm ? " https://challenges.cloudflare.com" : ""} https://login.microsoftonline.com${supportOrigin ? ` ${supportOrigin}` : ""}${publicSite ? " https://*.crisp.chat" : ""}`,
     `worker-src 'self' blob:${publicSite ? " https://*.crisp.chat" : ""}`,
     "manifest-src 'self'",
     ...(development ? [] : ["upgrade-insecure-requests"]),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,7 @@ export function middleware(request: NextRequest) {
     process.env.NODE_ENV === "development",
     supportOrigin,
     supportFrame ? boundary.appOrigin : "",
+    path === "/support" && boundary.mode === "public",
   );
   const headers = new Headers(request.headers);
   // Replace client-supplied values, including on RSC and prefetch requests.


### PR DESCRIPTION
Visitors can contact the Ugurlabs team at `/support` with their name, email address, subject, and message. Requests are emailed to support@ugurlabs.com through Resend, with the visitor as Reply-To, and success appears only after Resend accepts the email. Crisp remains available alongside the form.

The endpoint validates input and body size, enforces the public-site origin, rejects honeypot submissions, and verifies single-use Turnstile tokens against the hostname and support action. Failed sends retain entered text. Unconfigured installations show a direct email link. App-origin visits redirect to the public support page, and Turnstile CSP permissions apply only to that public page.

Includes a footer link, privacy disclosure, environment examples, and setup documentation. The four support variables have been confirmed present in Vercel Production. Live inbox delivery still needs verification after deployment.

Validation: clean `npm ci`, `npm run check`, 381 passing tests, and a successful production build. Browser checks cover mobile layout and simulated submission failure/success. Existing image lint warnings remain.
